### PR TITLE
Looping in support for new Elko distribution and source JARs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 .settings
 dependency-reduced-pom.xml
 neohabitat.iml
+usersDB.json

--- a/build
+++ b/build
@@ -1,18 +1,23 @@
 #!/bin/bash
 # Builds the Neoclassical Habitat Elko server.
 
-export ELKO_VERSION="${NEOHABITAT_ELKO_VERSION-2.0.3}"
+set -eo pipefail
 
+ELKO_VERSION="2.0.4-SNAPSHOT"
+
+# Downloads the latest version of Elkoserver if we have not yet done so.
 if [ ! -e ./lib/elkoserver-${ELKO_VERSION}.jar ]; then
-  # Downloads the latest version of Elkoserver.
   mkdir -p lib
   wget -O ./lib/elkoserver-${ELKO_VERSION}.jar \
-    https://github.com/FUDCo/Elko/releases/download/v${ELKO_VERSION}/elkoserver-${ELKO_VERSION}.jar
+    https://s3.amazonaws.com/ssalevan/Elko/elkoserver-${ELKO_VERSION}.jar
+  wget -O ./lib/elkoserver-${ELKO_VERSION}-sources.jar \
+    https://s3.amazonaws.com/ssalevan/Elko/elkoserver-${ELKO_VERSION}-sources.jar
 fi
 
 # Installs the Elkoserver JAR into the local Maven repository.
 mvn install:install-file \
   -Dfile=./lib/elkoserver-${ELKO_VERSION}.jar \
+  -Dsources=./lib/elkoserver-${ELKO_VERSION}-sources.jar \
   -DgroupId=org.elko \
   -DartifactId=elkoserver \
   -Dversion="${ELKO_VERSION}" \

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,14 @@
         <dependency>
             <groupId>org.elko</groupId>
             <artifactId>elkoserver</artifactId>
-            <version>${env.ELKO_VERSION}</version>
+            <version>2.0.4-SNAPSHOT</version>
+        </dependency>
+        <dependency>  
+            <groupId>org.elko</groupId>  
+            <artifactId>elkoserver</artifactId>  
+            <version>2.0.4-SNAPSHOT</version>
+            <type>jar</type>  
+            <classifier>sources</classifier>  
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This PR covers the following changes:

- Scripting enhancements to support the downloading of Elko source JARs from an S3 bucket of mine; this will allow IDEs to index Elko code alongside Neohabitat code
- Maven pom.xml changes to build using the latest version

Let me know what you think, and thanks!