### PR TITLE
Adds robustness to Vagrantfile and additional documentation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,12 @@ Vagrant.configure("2") do |config|
 
   $run_docker_compose = "cd /vagrant && docker-compose up"
 
+  # Explicitly enforces syncing of the local folder to /vagrant on the VM.
   config.vm.synced_folder ".", "/vagrant"
+
+  # Updates VBox guest additions to the latest version of VirtualBox then reboots the VM.
+  config.vm.provision :shell, binary: true, path: "./script/update_vbox_additions.sh"
+  config.vm.provision :reload
 
   if Gem.win_platform?
     # Handles Windows-style line endings.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,12 +16,9 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 27017, host: 27017
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
     vb.customize ["modifyvm", :id, "--memory", "1024"]
     vb.customize ["modifyvm", :id, "--cpus", "2"]
   end
-
-  $run_docker_compose = "cd /vagrant && docker-compose up"
 
   # Explicitly enforces syncing of the local folder to /vagrant on the VM.
   config.vm.synced_folder ".", "/vagrant"
@@ -34,7 +31,7 @@ Vagrant.configure("2") do |config|
     # Handles Windows-style line endings.
     config.vm.provision :docker
     config.vm.provision :docker_compose
-    config.vm.provision :shell, binary: true, inline: $run_docker_compose
+    config.vm.provision :shell, binary: true, inline: "cd /vagrant && docker-compose up"
   else
     config.vm.provision :docker
     config.vm.provision :docker_compose, yml: "/vagrant/docker-compose.yml", run: "always"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,12 +23,15 @@ Vagrant.configure("2") do |config|
 
   $run_docker_compose = "cd /vagrant && docker-compose up"
 
-  config.vm.provision :docker
+  config.vm.synced_folder ".", "/vagrant"
+
   if Gem.win_platform?
     # Handles Windows-style line endings.
+    config.vm.provision :docker
     config.vm.provision :docker_compose
     config.vm.provision :shell, binary: true, inline: $run_docker_compose
   else
+    config.vm.provision :docker
     config.vm.provision :docker_compose, yml: "/vagrant/docker-compose.yml", run: "always"
   end
 end

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -283,7 +283,11 @@ At the QuantumLink home screen, ensure that the selector is placed over the **Pe
 
 ![QuantumLink People Connection Screen](https://s3.amazonaws.com/ssalevan/neohabitat/people_connection.png)
 
-After reaching it, press **F7** to bring up the department menu.  Select **Play or observe an online game** with the **arrow keys** and press **F1**.  Select **Start a game (pick your partners)** with the and press **F1** again.
+After reaching it, press **F7** to bring up the department menu.  Select **Play or observe an online game** with the **arrow keys** and press **F1**:
+
+![QuantumLink People Connection Department Menu](https://s3.amazonaws.com/ssalevan/neohabitat/department_menu.png)
+
+Select **Start a game (pick your partners)** with the and press **F1** again.
 
 Finally, select **Club Caribe** from the list and press **F1** one last time.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -102,6 +102,7 @@ Step 2 - Build and Start Neohabitat Services (with Vagrant)
 Open a **standard Windows command line (cmd.exe, not Bash or PowerShell)** and navigate via ```cd``` to the location of your Neohabitat checkout.  Run the following command:
 
 ```bash
+vagrant plugin install vagrant-reload
 vagrant plugin install vagrant-docker-compose
 vagrant up --provider=virtualbox
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -107,7 +107,7 @@ vagrant plugin install vagrant-docker-compose
 vagrant up --provider=virtualbox
 ```
 
-Vagrant will proceed to download the Ubuntu image, launch it, then install Docker and run the docker-compose build step.  If all goes well during this step, you can skip Step 2, as Vagrant will now cover the building and assembly of all Docker-based services; launch time will also be greatly minimized.
+Vagrant will proceed to download the Ubuntu image, launch it, then install Docker and run the docker-compose build step.
 
 After the build procedure has concluded, you can develop and build new artifacts on your local machine and they will be synced through to Docker.  Furthermore, the following service ports will be forwarded to your local environment:
 
@@ -133,7 +133,7 @@ docker-compose restart neohabitat
 
 **Troubleshooting**
 
-If all does not go well, it's likely that either Vagrant can't find VirtualBox or one of the upstream Linux package repositories is having issues.
+If all does not go well during the Vagrant provisioning step, it's likely that either Vagrant can't find VirtualBox or one of the upstream Linux package repositories is having issues.
 
 If Vagrant returns an error like so:
 

--- a/script/update_vbox_additions.sh
+++ b/script/update_vbox_additions.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Updates VirtualBox guest additions.
+
+set -euo pipefail
+
+echo "Attempting to update VBoxAdditions..."
+
+VERSION=$(curl http://download.virtualbox.org/virtualbox/LATEST.TXT)
+echo "Updating VBoxAdditions for latest VirtualBox: ${VERSION}"
+
+curl -so /tmp/additions.iso \
+  http://download.virtualbox.org/virtualbox/${VERSION}/VBoxGuestAdditions_${VERSION}.iso
+
+sudo mkdir -p /mnt/vboxadditions
+sudo mount -o loop /tmp/additions.iso /mnt/vboxadditions || true
+
+sudo bash -c "cd /mnt/vboxadditions && yes | sudo sh ./VBoxLinuxAdditions.run --nox11"
+sudo /etc/init.d/vboxadd setup


### PR DESCRIPTION
During our Vagrantfile creation process, I noticed that standard Vagrant images do not update the necessary VirtualBox additions, which can lead to shared folder and port forwarding issues.  This PR adds two changes

- Updater script to ensure that new Vagrant VMs are properly updated with the latest VBox additions
- Updates to documentation to provide further screenshots