### PR TITLE
Force all DB code to have Unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 build text eol=lf
 run   text eol=lf
 *.sh  text eol=lf
+db/*  text eol=lf

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -236,7 +236,7 @@ When this task is complete, you'll be brought to the QuantumLink home screen; it
 Step 6 - Load MongoDB Models
 ----------------------------
 
-Recall the username you entered above then create a file in the **db/** folder called **user-username.json**.  For instance, if your username was **Steve**, you'd add the following to **db/user-steve.json**:
+Recall the username you entered above then create a file in the **db/** folder called **user-<lowercase_username>.json**.  For instance, if your username was **Steve** ('steve' in lowercase form), you'd add the following to **db/user-steve.json**:
 
 ```json
 {
@@ -256,6 +256,8 @@ Recall the username you entered above then create a file in the **db/** folder c
   ]
 }
 ```
+
+Please note that your username within the above "name" field **must also be lowercase**.
 
 After you've completed this step, you can load all models into MongoDB by running the following commands from your Neohabitat checkout:
 

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -61,6 +61,7 @@ sudo systemctl start mysql.service
 
 # Launches the Neohabitat build process.
 cd /neohabitat
+npm install --no-bin-links
 ./build
 
 # Installs Neohabitat MongoDB schema and models.


### PR DESCRIPTION
When importing DB records within a Vagrant guest, Windows line endings will confuse the MongoDB shell, as it's expecting Unix-style LF endings as opposed to Windows-style CRLF endings.

This forces these files to be terminated with Unix-style LF endings to allow for Vagrant provisioning; in our testing, this allows for a successful Vagrant provision.