### PR TITLE
Align arguments and enforce Maven shade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+            </plugins>
         </pluginManagement>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -67,18 +67,17 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
-                    <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                    </configuration>
-                </plugin>
-            </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,6 @@
 
         <pluginManagement>
             <plugins>
-                <!--This plugin's configuration is used to store Eclipse 
-                    m2e settings only. It has no influence on the Maven build itself. -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
@@ -78,28 +76,30 @@
                         <target>1.8</target>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.1</version>
-                    <executions>
-                        <execution>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>shade</goal>
-                            </goals>
-                            <configuration>
-                                <transformers>
-                                    <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                        <mainClass>org.elkoserver.foundation.boot.Boot</mainClass>
-                                    </transformer>
-                                </transformers>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.elkoserver.foundation.boot.Boot</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/run
+++ b/run
@@ -23,7 +23,7 @@ SHOULD_RUN_NEOHABITAT="${NEOHABITAT_SHOULD_RUN_NEOHABITAT-true}"
 PORT_RESV_TCP="${NEOHABITAT_PORT_RESV_TCP-9000}"
 
 BASE_ARGS=(
-  trace_cont=EVENT
+  trace_cont=DEBUG
   trace_comm=EVENT
   # Forcibly logs to stdout to comply with 12 Factor App guidelines.
   tracelog_dir=/plz/log/to/stdout
@@ -31,11 +31,9 @@ BASE_ARGS=(
   conf.listen.host="${SERVER_HOST}:${PORT_RESV_TCP}"
   conf.listen.bind="${SERVER_BIND}:${PORT_RESV_TCP}"
   conf.listen.protocol=tcp
-  conf.listen.auth.mode=open
-  conf.register.auto=true
   conf.comm.jsonstrictness=true
-  conf.context.entrytimeout=300
-  conf.context.odb=mongo
+  conf.context.entrytimeout=999999
+  conf.context.odb=odb
   conf.context.odb.mongo.hostport="${MONGO_HOST}"
   conf.context.objstore=org.elkoserver.objdb.store.mongostore.MongoObjectStore
   conf.context.name="${SERVER_NAME}"


### PR DESCRIPTION
Upon further testing, I found that enclosing the Shade plugin within the <pluginManagement> tag led to Maven not executing Shade at all; this behavior has been corrected.

This PR also aligns our runtime arguments to current best practices for debugging.