### PR TITLE
Using rendered form for Getting Started docs

### DIFF
--- a/docs/docindex.html
+++ b/docs/docindex.html
@@ -10,14 +10,14 @@ ul { list-style: none; }
 <h1>API Documents for NeoHabitat</h1>
 <ul>
 	<li><h3>Get, Run and Develop NeoHabitat</h3></li><ul>
-		<li><a href="getting_started.md">Play Habitat</a> (TBD) For now, you need to run your own server.</li>
-		<li><a href="getting_started.md">Dev Installation Instructions</a> - current supported environments: Docker, Vagrant and Eclipse</li>
+		<li><a href="https://github.com/frandallfarmer/neohabitat/blob/master/docs/getting_started.md">Play Habitat</a> (TBD) For now, you need to run your own server.</li>
+		<li><a href="https://github.com/frandallfarmer/neohabitat/blob/master/docs/getting_started.md">Dev Installation Instructions</a> - current supported environments: Docker, Vagrant and Eclipse</li>
 		<li><a href="https://github.com/frandallfarmer/neohabitat">frandallfarmer/neohabitat</a> devs, fork this GitHub repository.</li>
 		<li><a href="http://neohabitat.slack.com">NeoHabitat Slack</a> (Devs join this!) We make up the documentation gap...</li>
 	</ul>
 	<li><h3>Developer Documentation</h3></li><ul>
 		<li><a href="apidocs/index.html">API Root <small> (javadoc)</small></a> includes all java components.</li><ul>
-		<li><a href="apidocs/org/made/neohabitat/package-summary.html">org.made.neohabitat</a> interfaces & superclasses for the Neohabitat mod-objects</li>
+		<li><a href="apidocs/org/made/neohabitat/package-summary.html">org.made.neohabitat</a> interfaces &amp; superclasses for the Neohabitat mod-objects</li>
 		<li><a href="apidocs/org/made/neohabitat/mods/package-summary.html">org.made.neohabitat.mods</a> classes for regions, avatars, and all the object types.</li></ul>
 		<li><a href="bridge/symbols/_global_.html">bridge/Habitat2ElkoBridge.js<small> (jsdoc)</small></a> bridges a 30 year development gap</li>
 		<li><a href="test/symbols/_global_.html">test/Telko.js<small> (jsdoc)</small></a> Telnet + Elko: Paste JSON with simple keyword substitution</li>


### PR DESCRIPTION
This is a small change which points to the rendered form of the Getting Started docs instead of the Markdown representation.

Let me know what you think and thanks for the consideration!