### PR TITLE
Adds additional logging to bridge, enables debug loglevel by default

### DIFF
--- a/bridge/Habitat2ElkoBridge.js
+++ b/bridge/Habitat2ElkoBridge.js
@@ -101,7 +101,7 @@ function confirmOrCreateUser(fullName) {
 		Assert.equal(null, err);
 		testUser(db, {ref: userRef}, function(err, result) {
 			if (result === null || Argv.force) {
-
+				Trace.debug("Inserting user into MongoDB:", userRef);
 				insertUser(db, {
 					"type": "user",
 					"ref": userRef,
@@ -116,12 +116,13 @@ function confirmOrCreateUser(fullName) {
 							"custom": [rnd(15) + rnd(15)*16, rnd(15) + rnd(15)*16],
 							"nitty_bits": 0
 						}
-						]
+					]
 				}, function() {
+					Trace.debug("Successfully inserted record for user:", userRef);
 					db.close();
 				});
-
 			} else {
+				Trace.debug("Found result for QLink user:", userRef, result);
 				db.close();
 			}
 		});

--- a/run
+++ b/run
@@ -72,9 +72,9 @@ fi
 # Starts the Habitat-to-Elko bridge process if requested.
 if [ "${SHOULD_RUN_BRIDGE}" == true ]; then
   if [ "${SHOULD_BACKGROUND_BRIDGE}" == true ]; then
-    supervisor -w bridge -- ${GIT_BASE_DIR}/bridge/Habitat2ElkoBridge.js -l "${BRIDGE_HOST}:${BRIDGE_PORT}" -m "${MONGO_HOST}" &
+    supervisor -w bridge -- ${GIT_BASE_DIR}/bridge/Habitat2ElkoBridge.js -l "${BRIDGE_HOST}:${BRIDGE_PORT}" -m "${MONGO_HOST}" -t debug &
   else
-    supervisor -w bridge -- ${GIT_BASE_DIR}/bridge/Habitat2ElkoBridge.js -l "${BRIDGE_HOST}:${BRIDGE_PORT}" -m "${MONGO_HOST}"
+    supervisor -w bridge -- ${GIT_BASE_DIR}/bridge/Habitat2ElkoBridge.js -l "${BRIDGE_HOST}:${BRIDGE_PORT}" -m "${MONGO_HOST}" -t debug
   fi
 fi
 

--- a/run
+++ b/run
@@ -72,9 +72,9 @@ fi
 # Starts the Habitat-to-Elko bridge process if requested.
 if [ "${SHOULD_RUN_BRIDGE}" == true ]; then
   if [ "${SHOULD_BACKGROUND_BRIDGE}" == true ]; then
-    supervisor -w bridge -- ${GIT_BASE_DIR}/bridge/Habitat2ElkoBridge.js -l "${BRIDGE_HOST}:${BRIDGE_PORT}" -m "${MONGO_HOST}" -t debug &
+    supervisor -w bridge -- ${GIT_BASE_DIR}/bridge/Habitat2ElkoBridge.js -l "${BRIDGE_HOST}:${BRIDGE_PORT}" -m "${MONGO_HOST}/elko" -t debug &
   else
-    supervisor -w bridge -- ${GIT_BASE_DIR}/bridge/Habitat2ElkoBridge.js -l "${BRIDGE_HOST}:${BRIDGE_PORT}" -m "${MONGO_HOST}" -t debug
+    supervisor -w bridge -- ${GIT_BASE_DIR}/bridge/Habitat2ElkoBridge.js -l "${BRIDGE_HOST}:${BRIDGE_PORT}" -m "${MONGO_HOST}/elko" -t debug
   fi
 fi
 


### PR DESCRIPTION
This PR adds three small changes:

- Explicitly specifies database name in bridge MongoDB connection string
- Adds additional logging to user creation logic
- Sets debug bridge loglevels by default