### PR TITLE
Adapts image links to use Git LFS

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--
-Design by TEMPLATED
+Design by TEMPLATED 
 http://templated.co
 Released for free under the Creative Commons Attribution License
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,16 +57,16 @@ Released   : 20131010
 		<div id="logo">
 			<h1><a href="#">The Neoclassical Habitat Server Project</a></h1>
 			<span>neohabitat.org</span></br></br>
-			<img height="200px" src="images/habitat-loading.jpg"/>
-			<img height="200px" src="images/head-region.png"/>
-			<img height="200px" src="images/clubcaribe-loading.png"/>
+			<img height="200px" src="https://media.githubusercontent.com/media/frandallfarmer/neohabitat/master/docs/images/habitat-loading.jpg"/>
+			<img height="200px" src="https://media.githubusercontent.com/media/frandallfarmer/neohabitat/master/docs/images/head-region.png"/>
+			<img height="200px" src="https://media.githubusercontent.com/media/frandallfarmer/neohabitat/master/docs/images/clubcaribe-loading.png"/>
 		</div>
 		<div id="menu">
 			<ul>
 				<li class="current_page_item"><a href="#" accesskey="1" title="">Homepage</a></li>
 				<li><a href="#History" accesskey="2" title="">History</a></li>
 				<li><a href="#Code" accesskey="3" title="">Project Links</a></li>
-				<li><a href="https://github.com/frandallfarmer/neohabitat/wiki/NeoHabtiat.org:-The-Neoclassical-Habitat-Server-Project" accesskey="4" title="">Dev Docs</a></li>
+				<li><a href="https://github.com/frandallfarmer/neohabitat/wiki/NeoHabitat.org:-The-Neoclassical-Habitat-Server-Project" accesskey="4" title="">Dev Docs</a></li>
 				<li><a href="#Connect" accesskey="5" title="">Connect</a></li>
 			</ul>
 		</div>
@@ -123,28 +123,28 @@ Released   : 20131010
 			<h2>Code and Documentation Links</h2>
 			<span class="byline">How to join the team and access project documentation</span> </div>
 		<div class="column1">
-			<div class="box"> <a href="architecture/"><img height="180px" src="images/braindump.png" alt="" class="image image-full" /></a>
+			<div class="box"> <a href="architecture/"><img height="180px" src="https://media.githubusercontent.com/media/frandallfarmer/neohabitat/master/docs/images/braindump.png" alt="" class="image image-full" /></a>
 				<h3>30 years of Architecture</h3>
 				<p>Diagrams and explanations of how it worked then; and how it works now.</p>
 				<a href="architecture" class="button button-small">Architecture Documentation</a> </div>
 		</div>
 		<div class="column2">
-			<div class="box"> <a href="team/"><img height="180px" src="images/habitat-team.jpg" alt="" class="image image-full" /></a>
+			<div class="box"> <a href="team/"><img height="180px" src="https://media.githubusercontent.com/media/frandallfarmer/neohabitat/master/docs/images/habitat-team.jpg" alt="" class="image image-full" /></a>
 				<h3>Join the Team</h3>
 				<p>It's Open Source, and we need many particular sets of skills.</p>
 				<a href="team/" class="button button-small">Join The Team</a> </div>
 		</div>
 		<div class="column3">
-			<div class="box"><a href="https://github.com/frandallfarmer/neohabitat"><img height="180px" src="images/Octocat.jpg" alt="" class="image image-full" /></a>
+			<div class="box"><a href="https://github.com/frandallfarmer/neohabitat"><img height="180px" src="https://media.githubusercontent.com/media/frandallfarmer/neohabitat/master/docs/images/Octocat.jpg" alt="" class="image image-full" /></a>
 				<h3>Get the code</h3>
 				<p>Links to all the different code required - archival and modern.</p>
 				<a href="https://github.com/frandallfarmer/neohabitat" class="button button-small">Fork this Repository</a> </div>
 		</div>
 		<div class="column4">
-			<div class="box"> <a href="source/"><img height="180px" src="images/packet.jpg" alt="" class="image image-full" /></a>
+			<div class="box"> <a href="source/"><img height="180px" src="https://media.githubusercontent.com/media/frandallfarmer/neohabitat/master/docs/images/packet.jpg" alt="" class="image image-full" /></a>
 				<h3>Read the documentation</h3>
 				<p>NeoHabitat's Java and JS docs, and bitwise details about the c64 client and protocol.</p>
-				<a href="https://github.com/frandallfarmer/neohabitat/wiki/NeoHabtiat.org:-The-Neoclassical-Habitat-Server-Project" class="button button-small">Java/JS Docs</a> </div>
+				<a href="https://github.com/frandallfarmer/neohabitat/wiki/NeoHabitat.org:-The-Neoclassical-Habitat-Server-Project" class="button button-small">Java/JS Docs</a> </div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Images at neohabitat.org are currently broken after our transition to Git LFS.  This PR corrects this issue by rehoming links at their Git LFS URLs.