### PR TITLE
Slack updates on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you'd like to contribute to Habitat, developer documentation can be found her
 Slack
 -----
 
-If you'd like to join the Neohabitat community, come join our Slack: [Neoclassical Habitat](https://neohabitat.slack.com)
+If you'd like to join the Neohabitat community, come join our Slack: [Neoclassical Habitat](http://slack.neohabitat.org/)
 
 If you have any issues when playing Habitat, feel free to ask questions in the **#troubleshooting** room.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ NeoHabitat.org: The Neoclassical Habitat Server Project
 [![Build Status](https://travis-ci.org/frandallfarmer/neohabitat.svg?branch=master)](https://travis-ci.org/frandallfarmer/neohabitat)
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/frandallfarmer/neohabitat/blob/master/LICENSE)
 [![Twitter Follow](https://img.shields.io/twitter/follow/NeoHabitatProj.svg?style=social&label=Follow)](https://twitter.com/NeoHabitatProj)
+[![Slack](http://slack.neohabitat.org/badge.svg)](http://slack.neohabitat.org/)
 
 We're recreating [Habitat](https://en.wikipedia.org/wiki/Habitat_(video_game)), the world's first MMO, using modern technology.  We'd love it if you joined us!
 


### PR DESCRIPTION
- Updating the Slack link on the README to go to Habitat's Slackin site since new users cannot sign up from the Slack team page currently linked.
- Adding the Slack badge to the top of the README. I can remove that from the PR if you don't want it.

You can see the modified README rendered [here](https://github.com/davidalber/neohabitat/tree/readme).