### PR TITLE
Adding Weapons: Gun, Knife, Club, and Stun_gun

### DIFF
--- a/bridge/Habitat2ElkoBridge.js
+++ b/bridge/Habitat2ElkoBridge.js
@@ -806,12 +806,15 @@ var encodeState = {
 		Chest:		function (state, container, buf) { return (this.openable(state, container, buf)); },
 		Plant: 		function (state, container, buf) { return (this.massive (state, container, buf)); },
 		Flag: 		function (state, container, buf) { return (this.massive (state, container, buf)); },
-		Trapezoid: 	function (state, container, buf) { return (this.polygonal(state,container, buf)); },
+		Trapezoid: 	function (state, container, buf) { return (this.polygonal(state, container, buf)); },
 		Hot_tub:    function (state, container, buf) { return (this.common  (state, container, buf)); },
+		Compass:  function(state, container, buf) { return (this.common(state, container, buf)); },
+		Gun:  function(state, container, buf) { return (this.common(state, container, buf)); },
+		Knife:  function(state, container, buf) { return (this.common(state, container, buf)); },
+		Club:  function(state, container, buf) { return (this.common(state, container, buf)); },
+		Stun_gun:  function(state, container, buf) { return (this.common(state, container, buf)); },
 		Fountain:   function (state, container, buf) { return (this.common  (state, container, buf)); },
-		Compass:    function (state, container, buf) { return (this.common  (state, container, buf)); },
-		Coke_machine:function (state, container, buf){ return (this.common  (state, container, buf)); }
-
+		Coke_machine:function (state, container, buf) { return (this.common  (state, container, buf)); }
 };
 
 function habitatEncodeElkoModState (state, container, buf) {

--- a/bridge/hcode.js
+++ b/bridge/hcode.js
@@ -6,8 +6,6 @@
 /* jslint bitwise: true */
 /* jshint esversion: 6 */
 
-const Trace		 	= require('winston');
-
 this.MICROCOSM_ID_BYTE	= 0x55;
 this.ESCAPE_CHAR		= 0x5D;
 this.END_OF_MESSAGE		= 0x0D;
@@ -143,8 +141,6 @@ this.SERVER_OPS = {
 		"CHANGE$": 				{ reqno: 8 },
 		"CHANGE_CONTAINERS_$":	{ reqno: 19,
 			toClient: function (o, b) {
-				Trace.debug("Changing container: noid=%s, contnoid=%s, x=%d, y=%d",
-					o.object_noid, o.container_noid, o.x, o.y);
 				b.add(o.object_noid);
 				b.add(o.container_noid);
 				b.add(o.x);

--- a/bridge/hcode.js
+++ b/bridge/hcode.js
@@ -6,6 +6,8 @@
 /* jslint bitwise: true */
 /* jshint esversion: 6 */
 
+const Trace		 	= require('winston');
+
 this.MICROCOSM_ID_BYTE	= 0x55;
 this.ESCAPE_CHAR		= 0x5D;
 this.END_OF_MESSAGE		= 0x0D;
@@ -114,13 +116,23 @@ this.SERVER_OPS = {
 			}
 		},
 		"ARRIVAL_$": 			{ reqno: 9 },
-		"ATTACK$": 				{ reqno: 9 },
+		"ATTACK$": 				{ reqno: 9,
+			toClient: function (o, b) {
+				b.add(o.ATTACK_TARGET);
+				b.add(o.ATTACK_DAMAGE);
+			}
+		},
 		"AUTO_TELEPORT_$": 		{ reqno: 21,
 			toClient: function (o, b) {
 				b.add(o.direction);
 			}
 		},
-		"BASH$": 				{ reqno: 10 },
+		"BASH$": 				{ reqno: 10,
+			toClient: function (o, b) {
+				b.add(o.BASH_TARGET);
+				b.add(o.BASH_SUCCESS);
+			}
+		},
 		"BEEP$": 				{ reqno: 8 },
 		"BLAST$": 				{ reqno: 8 },
 		"CAUGHT_UP_$":	 		{ reqno: 17,
@@ -129,7 +141,16 @@ this.SERVER_OPS = {
 			},
 		},
 		"CHANGE$": 				{ reqno: 8 },
-		"CHANGE_CONTAINERS_$":	{ reqno: 19 },
+		"CHANGE_CONTAINERS_$":	{ reqno: 19,
+			toClient: function (o, b) {
+				Trace.debug("Changing container: noid=%s, contnoid=%s, x=%d, y=%d",
+					o.object_noid, o.container_noid, o.x, o.y);
+				b.add(o.object_noid);
+				b.add(o.container_noid);
+				b.add(o.x);
+				b.add(o.y);
+			}
+		},
 		"BUGOUT$": 				{ reqno: 8 },
 		"CHANGESTATE$": 		{ reqno: 8 },
 		"CHANGESTATE_$": 		{ reqno: 8 },
@@ -558,7 +579,7 @@ this.translate = {
 				b.add(o.nextpage);
 				b.add(o.text.getBytes());
 				return true;		// This reply should be split upon transmission to the client.
-			},
+			}
  		},
 		LEAVE: {
 			toServer: function(a, m) {
@@ -589,6 +610,15 @@ this.translate = {
 				b.add(o.text.getBytes());
 			}
 		},
+		ATTACK: {
+			toServer: function(a, m) {
+				m.pointed_noid = a[0];
+			},
+			toClient: function(o, b) {
+				b.add(o.ATTACK_result);
+				b.add(o.ATTACK_target);
+			}
+		},
 		PAYTO: {
 			toServer: function(a,m) {
 				m.target_id	= a[0];
@@ -611,6 +641,14 @@ this.translate = {
 			toServer: function(a,m) {
 				m.amount_lo = a[0];
 				m.amount_hi = a[1];
+			},
+			toClient: function(o, b) {
+				b.add(o.err);
+			}
+		},
+		STUN: {
+			toServer: function(a,m) {
+				m.target = a[0];
 			},
 			toClient: function(o, b) {
 				b.add(o.err);
@@ -768,6 +806,15 @@ this.Tokens = {
 		}
 }
 
+this.Stun_gun = {
+		clientMessages: {
+			0:{ op:"HELP" },
+			1:{ op:"GET" },
+			2:{ op:"PUT" },
+			5:{ op:"STUN" }
+		}
+}
+
 this.Coke_machine = {
 		clientMessages: {
 			0:{ op:"HELP" },
@@ -783,6 +830,15 @@ this.magical	= {
 			3:{ op:"THROW" },
 			4:{ op:"MAGIC" }
 		}		
+};
+
+this.weapon = {
+		clientMessages: {
+			0:{ op:"HELP" },
+			1:{ op:"GET" },
+			2:{ op:"PUT" },
+			5:{ op:"ATTACK" }
+		}
 };
 
 this.help		= { 
@@ -820,3 +876,6 @@ this.Trapezoid			= this.help;
 this.Super_trapezoid 	= this.help;
 this.Flat				= this.help;
 this.Hot_tub		 	= this.help;
+this.Gun       = this.weapon;
+this.Knife   = this.weapon;
+this.Club   = this.weapon;

--- a/db/classes-habitat.json
+++ b/db/classes-habitat.json
@@ -203,6 +203,16 @@
 		},
 		{
 			"type": "class",
+			"tag": "Gun",
+			"name": "org.made.neohabitat.mods.Gun"
+		},
+		{
+			"type": "class",
+			"tag": "Knife",
+			"name": "org.made.neohabitat.mods.Knife"
+		},
+		{
+			"type": "class",
 			"tag": "Tokens",
 			"name": "org.made.neohabitat.mods.Tokens"
 		},
@@ -210,6 +220,16 @@
 			"type": "class",
 			"tag": "Coke_machine",
 			"name": "org.made.neohabitat.mods.Coke_machine"
+		},
+		{
+			"type": "class",
+			"tag": "Club",
+			"name": "org.made.neohabitat.mods.Club"
+		},
+		{
+			"type": "class",
+			"tag": "Stun_gun",
+			"name": "org.made.neohabitat.mods.Stun_gun"
 		}
 	]
 }

--- a/db/context-library.json
+++ b/db/context-library.json
@@ -8,7 +8,7 @@
 			"town_dir": "here",
 			"port_dir": "",
 			"type": "Region",
-			"nitty_bits": 3,
+			"nitty_bits": 2,
 			"neighbors": ["context-back4t_01", "context-table", "context-test", ""]
 		}
 	]

--- a/db/context-table.json
+++ b/db/context-table.json
@@ -8,7 +8,7 @@
 			"town_dir": "through either door",
 			"port_dir": "",
 			"type": "Region",
-			"nitty_bits": 3,
+			"nitty_bits": 2,
 			"neighbors": ["", "context-frontyard", "", ""]
 		}
 	]

--- a/db/context-test.json
+++ b/db/context-test.json
@@ -8,7 +8,7 @@
 			"town_dir": "",
 			"port_dir": "missing",
 			"type": "Region",
-			"nitty_bits": 3,
+			"nitty_bits": 2,
 			"neighbors": ["context-library", "context-table", "", ""]
 		}
 	]

--- a/db/item-table.gun.json
+++ b/db/item-table.gun.json
@@ -2,11 +2,11 @@
   "type": "item",
   "ref": "item-library.gun",
   "deletable": true,
-  "name": "Stun_gun",
+  "name": "Gun",
   "in": "item-table.table",
   "mods": [
     {
-      "type": "Stun_gun",
+      "type": "Gun",
       "style": 0,
       "x": 2,
       "y": 1,

--- a/db/item-table.gun.json
+++ b/db/item-table.gun.json
@@ -1,0 +1,17 @@
+{
+  "type": "item",
+  "ref": "item-library.gun",
+  "deletable": true,
+  "name": "Stun_gun",
+  "in": "item-table.table",
+  "mods": [
+    {
+      "type": "Stun_gun",
+      "style": 0,
+      "x": 2,
+      "y": 1,
+      "gr_state": 0,
+      "orientation": 0
+    }
+  ]
+}

--- a/db/user-pcollins.json
+++ b/db/user-pcollins.json
@@ -1,0 +1,65 @@
+[
+  {
+    "type": "user",
+    "ref": "user-pcollins",
+    "name": "Pcollins",
+    "mods": [
+      {
+        "type": "Avatar",
+        "x": 100,
+        "y": 130,
+        "bodyType": "male",
+        "bankBalance": 2000,
+        "custom": [17, 151],
+        "nitty_bits": 8
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-pcollins.head",
+    "deletable": true,
+    "name": "Pcollins's Head",
+    "in": "user-pcollins",
+    "mods": [
+      {
+        "type": "Head",
+        "style": 28,
+        "orientation": 16,
+        "y":6
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-pcollins.godtool",
+    "deletable": true,
+    "name": "Tool to rule the universe.",
+    "in": "user-pcollins",
+    "mods": [
+      {
+        "type": "Knick_knack",
+        "style": 2,
+        "y": 2,
+        "orientation": 8,
+        "magic_type": 17,
+        "charges": 255
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-pcollins.compass",
+    "deletable": true,
+    "name": "Compass",
+    "in": "user-pcollins",
+    "mods": [
+      {
+        "type": "Compass",
+        "style": 0,
+        "y": 1,
+        "orientation": 0
+      }
+    ]
+  }
+]

--- a/db/user-steve.json
+++ b/db/user-steve.json
@@ -46,5 +46,20 @@
 				"charges": 255
 			}
 		]
+	},
+	{
+		"type": "item",
+		"ref": "item-steve.compass",
+		"deletable": true,
+		"name": "Compass",
+		"in": "user-steve",
+		"mods": [
+			{
+				"type": "Compass",
+				"style": 0,
+				"y": 1,
+				"orientation": 0
+			}
+		]
 	}
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,11 +25,13 @@ services:
       - .:/neohabitat
     environment:
       - NEOHABITAT_MONGO_HOST=mongo:27017
+      - NEOHABITAT_SHOULD_ENABLE_DEBUGGER=true
       - NEOHABITAT_SHOULD_RUN_BRIDGE=true
       - NEOHABITAT_SHOULD_RUN_NEOHABITAT=true
       - NEOHABITAT_SHOULD_UPDATE_SCHEMA=true
     ports:
       - "1337:1337"
+      - "1898:1898"
       - "9000:9000"
     depends_on:
       - mongo

--- a/run
+++ b/run
@@ -35,14 +35,17 @@ BRIDGE_PORT="${NEOHABITAT_BRIDGE_PORT-1337}"
 SERVER_HOST="${NEOHABITAT_SERVER_HOST-0.0.0.0}"
 SERVER_NAME="${NEOHABITAT_SERVER_NAME-neohabitat}"
 SERVER_BIND="${NEOHABITAT_SERVER_PORT-0.0.0.0}"
+DEBUGGER_PORT="${NEOHABITAT_DEBUGGER_PORT-1898}"
 SHUTDOWN_PASSWORD="${NEOHABITAT_SHUTDOWN_PASSWORD-figleaf}"
 SHOULD_BACKGROUND_BRIDGE="${NEOHABITAT_SHOULD_BACKGROUND_BRIDGE-true}"
+SHOULD_ENABLE_DEBUGGER="${NEOHABITAT_SHOULD_ENABLE_DEBUGGER-false}"
 SHOULD_RUN_BRIDGE="${NEOHABITAT_SHOULD_RUN_BRIDGE-true}"
 SHOULD_RUN_NEOHABITAT="${NEOHABITAT_SHOULD_RUN_NEOHABITAT-true}"
 SHOULD_UPDATE_SCHEMA="${NEOHABITAT_SHOULD_UPDATE_SCHEMA-true}"
 PORT_RESV_TCP="${NEOHABITAT_PORT_RESV_TCP-9000}"
 
 BASE_ARGS=(
+  org.elkoserver.server.context.ContextServerBoot
   trace_cont=DEBUG
   trace_comm=EVENT
   # Forcibly logs to stdout to comply with 12 Factor App guidelines.
@@ -59,8 +62,14 @@ BASE_ARGS=(
   conf.context.name="${SERVER_NAME}"
   conf.context.shutdownpassword="${SHUTDOWN_PASSWORD}"
   conf.msgdiagnostics=true
-  org.elkoserver.server.context.ContextServerBoot
 )
+
+JVM_ARGS=()
+
+if [ "${SHOULD_ENABLE_DEBUGGER}" == true ]; then
+  echo " - Enabling JMX debugging for Neohabitat..."
+  JVM_ARGS+=("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${DEBUGGER_PORT}")
+fi
 
 if [ "${SHOULD_UPDATE_SCHEMA}" == true ]; then
   cd ${GIT_BASE_DIR}/db
@@ -79,5 +88,6 @@ fi
 
 # Starts the Habitat Elko server if requested.
 if [ "${SHOULD_RUN_NEOHABITAT}" == true ]; then
-  java -jar ${GIT_BASE_DIR}/target/neohabitat-${VERSION}.jar "${BASE_ARGS[@]}" "${@}"
+  echo " - Running Neohabitat Elko server with args: ${BASE_ARGS[@]}"
+  java "${JVM_ARGS[@]}" -jar ${GIT_BASE_DIR}/target/neohabitat-${VERSION}.jar "${BASE_ARGS[@]}" "${@}"
 fi

--- a/src/main/java/org/made/neohabitat/HabitatMod.java
+++ b/src/main/java/org/made/neohabitat/HabitatMod.java
@@ -2752,7 +2752,7 @@ public abstract class HabitatMod extends Mod implements HabitatVerbs, ObjectComp
 	 *               The Avatar to terminate.
 	 */
 	public void kill_avatar(Avatar victim) {
-			for (int i = 0; i < victim.capacity() - 1; i++) {
+		for (int i = 0; i < victim.capacity() - 1; i++) {
 			if (victim.contents(i) != null) {
 				if (i == HANDS) {
 					victim.drop_object_in_hand();
@@ -2773,22 +2773,22 @@ public abstract class HabitatMod extends Mod implements HabitatVerbs, ObjectComp
 		// Penalize the victim's tokens if they are holding any.
 		trace_msg("Avatar %s is transitioning on DEATH_ENTRY", obj_id());
 		for (int i = 0; i < victim.capacity() - 1; i++) {
-				HabitatMod curMod = victim.contents(i);
-				if (curMod != null && curMod.HabitatClass() == CLASS_TOKENS) {
-						Tokens token = (Tokens) curMod;
-						int denom = (token.denom_lo + token.denom_hi * 256) * 50 / 100;
-						trace_msg(
-								"Found tokens on DEATH_ENTRY for Avatar %s, denom_lo=%d, denom_hi=%d, denom=%d",
-								obj_id(), token.denom_lo, token.denom_hi, denom);
-						token.denom_lo = denom % 256;
-						token.denom_hi = (denom - token.denom_lo) / 256;
-						if (denom == 0)
-								token.denom_lo = 1;
-						token.gen_flags[MODIFIED] = true;
-						token.checkpoint_object(token);
-						trace_msg("New tokens on DEATH_ENTRY for Avatar %s, denom_lo=%d, denom_hi=%d", obj_id(),
-										token.denom_lo, token.denom_hi);
-				}
+			HabitatMod curMod = victim.contents(i);
+			if (curMod != null && curMod.HabitatClass() == CLASS_TOKENS) {
+				Tokens token = (Tokens) curMod;
+				int denom = (token.denom_lo + token.denom_hi * 256) * 50 / 100;
+				trace_msg(
+					"Found tokens on DEATH_ENTRY for Avatar %s, denom_lo=%d, denom_hi=%d, denom=%d",
+					obj_id(), token.denom_lo, token.denom_hi, denom);
+				token.denom_lo = denom % 256;
+				token.denom_hi = (denom - token.denom_lo) / 256;
+				if (denom == 0)
+					token.denom_lo = 1;
+				token.gen_flags[MODIFIED] = true;
+				token.checkpoint_object(token);
+				trace_msg("New tokens on DEATH_ENTRY for Avatar %s, denom_lo=%d, denom_hi=%d", obj_id(),
+					token.denom_lo, token.denom_hi);
+			}
 		}
 
 		victim.change_regions(victim.turf, AUTO_TELEPORT_DIR, DEATH_ENTRY);

--- a/src/main/java/org/made/neohabitat/HabitatMod.java
+++ b/src/main/java/org/made/neohabitat/HabitatMod.java
@@ -731,13 +731,13 @@ public abstract class HabitatMod extends Mod implements HabitatVerbs, ObjectComp
 		msg.finish();
 		context().sendToNeighbors(from, msg);
 
-		/* TODO Opaque container handling        
-				if (Avatar.getConnectionType() == CONNECTION_JSON) {
-						if (!container_is_opaque(oldContainer, oldY) && container_is_opaque(cont, y)) {
-								context().sendToNeighbors(from, Msg.msgDelete(this.object()));
-						}
+/* TODO Opaque container handling        
+		if (Avatar.getConnectionType() == CONNECTION_JSON) {
+				if (!container_is_opaque(oldContainer, oldY) && container_is_opaque(cont, y)) {
+						context().sendToNeighbors(from, Msg.msgDelete(this.object()));
 				}
-		 */       
+		}
+ */       
 		send_reply_msg(from, noid, "err", TRUE, "pos", this.y);
 
 		/* If putting into a pawn machine, announce the value of the object */
@@ -880,14 +880,14 @@ public abstract class HabitatMod extends Mod implements HabitatVerbs, ObjectComp
 
 		send_neighbor_msg(from, avatar.noid, "THROW$", "obj", noid, "x", new_x, "y", new_y, "hit", TRUE);
 
-		/* TODO Opaque container handling        
+/* TODO Opaque container handling        
 
-				if (Avatar.getConnectionType() == CONNECTION_JSON) {
-						if (!container_is_opaque(oldContainer, oldY) && container_is_opaque(target, y)) {
-								context().sendToNeighbors(from, Msg.msgDelete(this.object()));
-						}
+		if (Avatar.getConnectionType() == CONNECTION_JSON) {
+				if (!container_is_opaque(oldContainer, oldY) && container_is_opaque(target, y)) {
+						context().sendToNeighbors(from, Msg.msgDelete(this.object()));
 				}
-		 */
+		}
+ */
 
 		send_throw_reply(from, noid, target.noid, new_x, new_y, TRUE);
 

--- a/src/main/java/org/made/neohabitat/Weapon.java
+++ b/src/main/java/org/made/neohabitat/Weapon.java
@@ -34,25 +34,25 @@ public abstract class Weapon extends HabitatMod {
 		super(style, x, y, orientation, gr_state);
 	}
 
-    @JSONMethod
-    public void HELP(User from) {
-    	generic_HELP(from);
-    }
-    
-    @JSONMethod
-    public void GET(User from) {
-        generic_GET(from);
-    }
+	@JSONMethod
+	public void HELP(User from) {
+		generic_HELP(from);
+	}
+	
+	@JSONMethod
+	public void GET(User from) {
+		generic_GET(from);
+	}
 
-    @JSONMethod({ "containerNoid", "x", "y", "orientation" })
-    public void PUT(User from, OptInteger containerNoid, OptInteger x, OptInteger y, OptInteger orientation) {
-        generic_PUT(from, containerNoid.value(THE_REGION), avatar(from).x, avatar(from).y, avatar(from).orientation);
-    }
-    
-    @JSONMethod({ "pointed_noid" })
-    public void ATTACK(User from, OptInteger pointed_noid) {
-    	generic_ATTACK(from, current_region().noids[pointed_noid.value(0)]);
-    }
+	@JSONMethod({ "containerNoid", "x", "y", "orientation" })
+	public void PUT(User from, OptInteger containerNoid, OptInteger x, OptInteger y, OptInteger orientation) {
+		generic_PUT(from, containerNoid.value(THE_REGION), avatar(from).x, avatar(from).y, avatar(from).orientation);
+	}
+	
+	@JSONMethod({ "pointed_noid" })
+	public void ATTACK(User from, OptInteger pointed_noid) {
+		generic_ATTACK(from, current_region().noids[pointed_noid.value(0)]);
+	}
 	
 	public void generic_ATTACK(User from, HabitatMod target) {
 		if (target == null) {

--- a/src/main/java/org/made/neohabitat/Weapon.java
+++ b/src/main/java/org/made/neohabitat/Weapon.java
@@ -1,0 +1,145 @@
+package org.made.neohabitat;
+
+import org.elkoserver.foundation.json.JSONMethod;
+import org.elkoserver.foundation.json.OptInteger;
+import org.elkoserver.server.context.User;
+import org.elkoserver.util.trace.Trace;
+import org.made.neohabitat.mods.Avatar;
+
+
+/**
+ * This is the base class for any ranged or non-ranged handheld weapon,
+ * such as the Gun, Knife, or Club.
+ *
+ * @author steve
+ */
+public abstract class Weapon extends HabitatMod {
+
+	/* The total amount of damage to be rendered by an ATTACK. */
+	public static final int DAMAGE_DECREMENT = 20;
+
+	/* The activity ID of sitting on the ground */
+	public static final int SIT_GROUND = 132;
+	/* no effect, beep at player */
+	public static final int MISS = 0;
+	/* destroy object that is target */
+	public static final int DESTROY = 1;
+	/* keester avatar that is target */
+	public static final int HIT = 2;
+	/* kill avatar that is target */
+	public static final int DEATH = 3;
+	
+	public Weapon(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
+		OptInteger gr_state) {
+		super(style, x, y, orientation, gr_state);
+	}
+
+    @JSONMethod
+    public void HELP(User from) {
+    	generic_HELP(from);
+    }
+    
+    @JSONMethod
+    public void GET(User from) {
+        generic_GET(from);
+    }
+
+    @JSONMethod({ "containerNoid", "x", "y", "orientation" })
+    public void PUT(User from, OptInteger containerNoid, OptInteger x, OptInteger y, OptInteger orientation) {
+        generic_PUT(from, containerNoid.value(THE_REGION), avatar(from).x, avatar(from).y, avatar(from).orientation);
+    }
+    
+    @JSONMethod({ "pointed_noid" })
+    public void ATTACK(User from, OptInteger pointed_noid) {
+    	generic_ATTACK(from, current_region().noids[pointed_noid.value(0)]);
+    }
+	
+	public void generic_ATTACK(User from, HabitatMod target) {
+		if (target == null) {
+			send_reply_msg(from, FALSE);
+			return;
+		}
+		int success = TRUE;
+		Avatar fromAvatar = avatar(from);
+		if (fromAvatar.stun_count > 0) {
+			success = FALSE;
+			send_private_msg(from, fromAvatar.noid, from, "SPEAK$",
+				"I can't attack.  I am stunned.");
+		} else if (current_region().nitty_bits[WEAPONS_FREE]) {
+			object_say(from,
+				"This is a weapons-free zone.  Your weapon will not operate here.");
+		} else if (adjacent(target) || is_ranged_weapon()) {
+			HabitatMod damageableTarget = target;
+			if (target.HabitatClass() == CLASS_HEAD) {
+				// If the weapon is attacking an Avatar's head, set the target to the
+				// Avatar which contains it.
+				damageableTarget = target.container();
+				trace_msg("Weapon target is head, container is: %s", damageableTarget.obj_id());
+			}
+			if (damageableTarget.HabitatClass() == CLASS_AVATAR) {
+				Avatar damageableAvatar = (Avatar) damageableTarget;
+				damageableAvatar.activity = SIT_GROUND;
+				success = damage_avatar(damageableAvatar);
+				trace_msg("Avatar %s damaged, health=%d, success=%d", damageableAvatar.obj_id(),
+					damageableAvatar.health, success);
+				send_neighbor_msg(from, fromAvatar.noid, "ATTACK$",
+					"ATTACK_TARGET", damageableTarget.noid,
+					"ATTACK_DAMAGE", success);
+			} else {
+				success = damage_object(damageableTarget);
+				if (success == DESTROY) {
+					trace_msg("Object %s destroyed by weapon", damageableTarget.obj_id());
+				} else {
+					trace_msg("Object %s NOT destroyed by weapon", damageableTarget.obj_id());
+				}
+				send_neighbor_msg(from, fromAvatar.noid, "BASH$",
+					"BASH_TARGET", damageableTarget.noid,
+					"BASH_SUCCESS", success);
+			}
+		} else {
+			success = FALSE;
+		}
+
+		send_reply_msg(from, noid,
+			"ATTACK_target", target.noid,
+			"ATTACK_result", success);
+
+		if (success == DEATH) {
+			trace_msg("Killing Avatar %s...", target.obj_id());
+			kill_avatar((Avatar) target);
+		}
+	}
+
+	public int damage_avatar(Avatar who) {
+		trace_msg("Damaging Avatar %s...", who.obj_id());
+		who.health -= DAMAGE_DECREMENT;
+		if (who.health <= 0) {
+			// He's dead, Jim.
+			trace_msg("Avatar %s has been killed", who.obj_id());
+			return DEATH;
+		} else {
+			// Naw, he's only wounded.
+			trace_msg("Avatar %s has been wounded", who.obj_id());
+			return HIT;
+		}
+	}
+	
+	public int damage_object(HabitatMod object) {
+		if (damageable(object)) {
+			// TODO(steve): Uncomment when object deletion works.
+			//destroy_object(object);
+			return DESTROY;
+		} else {
+			return FALSE;
+		}
+	}
+	
+	public boolean damageable(HabitatMod object) {
+		return object.HabitatClass() == CLASS_MAILBOX;
+	}
+	
+	public boolean is_ranged_weapon() {
+		return HabitatClass() == CLASS_GUN;
+	}
+
+}

--- a/src/main/java/org/made/neohabitat/mods/Avatar.java
+++ b/src/main/java/org/made/neohabitat/mods/Avatar.java
@@ -25,779 +25,779 @@ import org.elkoserver.json.JSONLiteral;
  */
 
 public class Avatar extends Container implements UserMod {
-    
-    public static final int SIT_GROUND  = 132;
-    public static final int SIT_CHAIR   = 133;
-    public static final int SIT_FRONT   = 157;
-    public static final int STAND_FRONT = 146;
-    public static final int STAND_LEFT  = 251;
-    public static final int STAND_RIGHT = 252;
-    public static final int STAND       = 129;
-    public static final int FACE_FRONT  = 146;
-    public static final int FACE_BACK   = 143;
-    public static final int FACE_LEFT   = 254;
-    public static final int FACE_RIGHT  = 255;
-    public static final int GENDER_BIT  = 8;
-    public static final int XRIGHT      = 148;
-    public static final int XLEFT       = 12;
-    public static final int YUP         = 159;
-    public static final int YDOWN       = 129;
-    
-    
-    public static final int	STAND_UP	= 0;
-    public static final int	SIT_DOWN	= 1;
-    
-    public static final int    XMAX        = 144;
-    public static final double XMAXFLOAT   = 144.0;
-    
-    public static final int DOOR_OFFSET = 12;
-    public static final int BUILDING_OFFSET = 28;
-    
-    public static final String DEFAULT_TURF = "context-test";
-    
-    public int HabitatClass() {
-        return CLASS_AVATAR;
-    }
-    
-    public String HabitatModName() {
-        return "Avatar";
-    }
-    
-    public int capacity() {
-        return AVATAR_CAPACITY;
-    }
-    
-    public int pc_state_bytes() {
-        return 6;
-    };
-    
-    public boolean known() {
-        return true;
-    }
-    
-    public boolean opaque_container() {
-        return true;
-    }
-    
-    public boolean filler() {
-        return false;
-    }
-    
-    /**
-     * Static constant CONNECTION_TYPE indicates the kind of client connected
-     * for this session
-     */
-    protected static int ConnectionType = CONNECTION_JSON; /*
-     * Soon to default to
-     * CONNECTION_HABITAT
-     */
-    
-    /**
-     * Set the ConnectionType for this user.
-     * 
-     * @param type
-     *            CONNECTION_JSON or CONNECTION_HABITAT
-     */
-    public static void setConnectionType(int type) {
-        ConnectionType = type;
-    }
-    
-    /**
-     * Get the ConnectionType for this user.
-     * 
-     * @return CONNECTION_JSON or CONNECTION_HABITAT
-     */
-    public static int getConnectionType() {
-        return ConnectionType;
-    }
-    
-    /** The body type for the avatar TODO */
-    protected String  bodyType        = "male";
-    /** A collection of server-side Avatar status flags */
-    public boolean    nitty_bits[]    = new boolean[32];
-    /** Cache of avatar.contents(HEAD).style to restore after a curse. */
-    public int        true_head_style = 0;
-    /** Non-zero when the Avatar-User is cursed. */
-    public int        curse_type      = CURSE_NONE;
-    /** Non-zero when the Avatar-User is stunned. */
-    public int        stun_count      = 0;
-    /** The number of tokens this avatar has in the bank (not cash-on-hand.) */
-    public int        bankBalance     = 0;
-    /** The current avatar pose */
-    public int        activity        = STAND_FRONT;
-    /** TODO Doc */
-    public int        action          = STAND_FRONT;
-    /** Hit Points. Reaching 0 == death */
-    public int        health          = MAX_HEALTH;
-    /** TODO Doc */
-    public int        restrainer      = 0;
-    /** Avatar customization TODO Doc */
-    public int        custom[]        = new int[2];
-    /** TODO Doc */
-    public int        dest_x          = 0;
-    public int        dest_y          = 0;
-    
-    /** This is workaround - replacing the containership-based original model for seating used by the original Habtiat */
-    public int		  sittingIn			= 0;
-    public int		  sittingSlot		= 0;
-    public int		  sittingAction		= AV_ACT_sit_front;
-        
-    public String     turf            = "context-test";
-        
-    private String     from_region		= "";
-    private String     to_region		= "";	   
-    private int        from_orientation	= 0;
-    private int        from_direction	= 0;
-    private int        transition_type	= WALK_ENTRY;
-    
-    /**
-     * Target NOID and magic item saved between events, such as for the GOD TOOL
-     * (see Magical.java). This is a transient value and not persisted.
-     */
-    public HabitatMod savedTarget     = null;
-    public Magical    savedMagical    = null;
-    
-    @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "nitty_bits", "bodyType", "stun_count", "bankBalance",
-        "activity", "action", "health", "restrainer", "transition_type", "from_orientation", "from_direction", "from_region", "to_region",
-        "turf", "custom" })
-    public Avatar(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-            OptInteger nitty_bits, OptString bodyType, OptInteger stun_count, OptInteger bankBalance,
-            OptInteger activity, OptInteger action, OptInteger health, OptInteger restrainer, 
-            OptInteger transition_type, OptInteger from_orientation, OptInteger from_direction,
-            OptString from_region, OptString to_region, OptString turf, int[] custom) {
-        super(style, x, y, orientation, gr_state);
-        if (nitty_bits.value(-1) != -1) {
-            this.nitty_bits = unpackBits(nitty_bits.value());
-        }
-        this.bodyType = bodyType.value("male");
-        if ("female".equals(this.bodyType)) {
-            this.orientation = this.set_bit(this.orientation, GENDER_BIT);
-        } else {
-            this.orientation = this.clear_bit(this.orientation, GENDER_BIT);
-        }
-        this.stun_count = stun_count.value(0);
-        this.bankBalance = bankBalance.value(0);
-        this.activity = activity.value(STAND_FRONT);
-        this.action = action.value(this.activity);
-        this.health = health.value(MAX_HEALTH);
-        this.restrainer = restrainer.value(0);
-        this.from_direction = from_direction.value(0);
-        this.from_orientation = from_orientation.value(0);
-        this.transition_type = transition_type.value(WALK_ENTRY);
-        this.from_region = from_region.value("");
-        this.to_region = to_region.value("");
-        this.turf = turf.value(DEFAULT_TURF);
-        this.custom = custom;
-    }
-    
-    @Override
-    public JSONLiteral encode(EncodeControl control) {
-        JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));
-        if (packBits(nitty_bits) != 0) {
-            result.addParameter("nitty_bits", packBits(nitty_bits));
-        }
-        result.addParameter("bodyType", bodyType);
-        result.addParameter("stun_count", stun_count);
-        result.addParameter("bankBalance", bankBalance);
-        result.addParameter("activity", activity);
-        result.addParameter("action", action);
-        result.addParameter("health", health);
-        result.addParameter("restrainer", restrainer);
-        result.addParameter("custom", custom);
-        if (result.control().toRepository()) {
-            result.addParameter("from_region",      from_region);
-            result.addParameter("to_region",      	to_region);
-            result.addParameter("from_orientation", from_orientation);
-            result.addParameter("from_direction",   from_direction);
-            result.addParameter("transition_type",	transition_type);
-            result.addParameter("turf", turf);
-        }
-        if (result.control().toClient() && sittingIn != 0) {
-        	result.addParameter("sittingIn", sittingIn);
-        	result.addParameter("sittingSlot", sittingSlot);
-        	result.addParameter("sittingAction", sittingAction);
+	
+	public static final int SIT_GROUND  = 132;
+	public static final int SIT_CHAIR   = 133;
+	public static final int SIT_FRONT   = 157;
+	public static final int STAND_FRONT = 146;
+	public static final int STAND_LEFT  = 251;
+	public static final int STAND_RIGHT = 252;
+	public static final int STAND       = 129;
+	public static final int FACE_FRONT  = 146;
+	public static final int FACE_BACK   = 143;
+	public static final int FACE_LEFT   = 254;
+	public static final int FACE_RIGHT  = 255;
+	public static final int GENDER_BIT  = 8;
+	public static final int XRIGHT      = 148;
+	public static final int XLEFT       = 12;
+	public static final int YUP         = 159;
+	public static final int YDOWN       = 129;
+	
+	
+	public static final int	STAND_UP	= 0;
+	public static final int	SIT_DOWN	= 1;
+	
+	public static final int    XMAX        = 144;
+	public static final double XMAXFLOAT   = 144.0;
+	
+	public static final int DOOR_OFFSET = 12;
+	public static final int BUILDING_OFFSET = 28;
+	
+	public static final String DEFAULT_TURF = "context-test";
+	
+	public int HabitatClass() {
+		return CLASS_AVATAR;
+	}
+	
+	public String HabitatModName() {
+		return "Avatar";
+	}
+	
+	public int capacity() {
+		return AVATAR_CAPACITY;
+	}
+	
+	public int pc_state_bytes() {
+		return 6;
+	};
+	
+	public boolean known() {
+		return true;
+	}
+	
+	public boolean opaque_container() {
+		return true;
+	}
+	
+	public boolean filler() {
+		return false;
+	}
+	
+	/**
+	 * Static constant CONNECTION_TYPE indicates the kind of client connected
+	 * for this session
+	 */
+	protected static int ConnectionType = CONNECTION_JSON; /*
+	 * Soon to default to
+	 * CONNECTION_HABITAT
+	 */
+	
+	/**
+	 * Set the ConnectionType for this user.
+	 * 
+	 * @param type
+	 *            CONNECTION_JSON or CONNECTION_HABITAT
+	 */
+	public static void setConnectionType(int type) {
+		ConnectionType = type;
+	}
+	
+	/**
+	 * Get the ConnectionType for this user.
+	 * 
+	 * @return CONNECTION_JSON or CONNECTION_HABITAT
+	 */
+	public static int getConnectionType() {
+		return ConnectionType;
+	}
+	
+	/** The body type for the avatar TODO */
+	protected String  bodyType        = "male";
+	/** A collection of server-side Avatar status flags */
+	public boolean    nitty_bits[]    = new boolean[32];
+	/** Cache of avatar.contents(HEAD).style to restore after a curse. */
+	public int        true_head_style = 0;
+	/** Non-zero when the Avatar-User is cursed. */
+	public int        curse_type      = CURSE_NONE;
+	/** Non-zero when the Avatar-User is stunned. */
+	public int        stun_count      = 0;
+	/** The number of tokens this avatar has in the bank (not cash-on-hand.) */
+	public int        bankBalance     = 0;
+	/** The current avatar pose */
+	public int        activity        = STAND_FRONT;
+	/** TODO Doc */
+	public int        action          = STAND_FRONT;
+	/** Hit Points. Reaching 0 == death */
+	public int        health          = MAX_HEALTH;
+	/** TODO Doc */
+	public int        restrainer      = 0;
+	/** Avatar customization TODO Doc */
+	public int        custom[]        = new int[2];
+	/** TODO Doc */
+	public int        dest_x          = 0;
+	public int        dest_y          = 0;
+	
+	/** This is workaround - replacing the containership-based original model for seating used by the original Habtiat */
+	public int		  sittingIn			= 0;
+	public int		  sittingSlot		= 0;
+	public int		  sittingAction		= AV_ACT_sit_front;
+		
+	public String     turf            = "context-test";
+		
+	private String     from_region		= "";
+	private String     to_region		= "";	   
+	private int        from_orientation	= 0;
+	private int        from_direction	= 0;
+	private int        transition_type	= WALK_ENTRY;
+	
+	/**
+	 * Target NOID and magic item saved between events, such as for the GOD TOOL
+	 * (see Magical.java). This is a transient value and not persisted.
+	 */
+	public HabitatMod savedTarget     = null;
+	public Magical    savedMagical    = null;
+	
+	@JSONMethod({ "style", "x", "y", "orientation", "gr_state", "nitty_bits", "bodyType", "stun_count", "bankBalance",
+		"activity", "action", "health", "restrainer", "transition_type", "from_orientation", "from_direction", "from_region", "to_region",
+		"turf", "custom" })
+	public Avatar(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
+			OptInteger nitty_bits, OptString bodyType, OptInteger stun_count, OptInteger bankBalance,
+			OptInteger activity, OptInteger action, OptInteger health, OptInteger restrainer, 
+			OptInteger transition_type, OptInteger from_orientation, OptInteger from_direction,
+			OptString from_region, OptString to_region, OptString turf, int[] custom) {
+		super(style, x, y, orientation, gr_state);
+		if (nitty_bits.value(-1) != -1) {
+			this.nitty_bits = unpackBits(nitty_bits.value());
+		}
+		this.bodyType = bodyType.value("male");
+		if ("female".equals(this.bodyType)) {
+			this.orientation = this.set_bit(this.orientation, GENDER_BIT);
+		} else {
+			this.orientation = this.clear_bit(this.orientation, GENDER_BIT);
+		}
+		this.stun_count = stun_count.value(0);
+		this.bankBalance = bankBalance.value(0);
+		this.activity = activity.value(STAND_FRONT);
+		this.action = action.value(this.activity);
+		this.health = health.value(MAX_HEALTH);
+		this.restrainer = restrainer.value(0);
+		this.from_direction = from_direction.value(0);
+		this.from_orientation = from_orientation.value(0);
+		this.transition_type = transition_type.value(WALK_ENTRY);
+		this.from_region = from_region.value("");
+		this.to_region = to_region.value("");
+		this.turf = turf.value(DEFAULT_TURF);
+		this.custom = custom;
+	}
+	
+	@Override
+	public JSONLiteral encode(EncodeControl control) {
+		JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));
+		if (packBits(nitty_bits) != 0) {
+			result.addParameter("nitty_bits", packBits(nitty_bits));
+		}
+		result.addParameter("bodyType", bodyType);
+		result.addParameter("stun_count", stun_count);
+		result.addParameter("bankBalance", bankBalance);
+		result.addParameter("activity", activity);
+		result.addParameter("action", action);
+		result.addParameter("health", health);
+		result.addParameter("restrainer", restrainer);
+		result.addParameter("custom", custom);
+		if (result.control().toRepository()) {
+			result.addParameter("from_region",      from_region);
+			result.addParameter("to_region",      	to_region);
+			result.addParameter("from_orientation", from_orientation);
+			result.addParameter("from_direction",   from_direction);
+			result.addParameter("transition_type",	transition_type);
+			result.addParameter("turf", turf);
+		}
+		if (result.control().toClient() && sittingIn != 0) {
+			result.addParameter("sittingIn", sittingIn);
+			result.addParameter("sittingSlot", sittingSlot);
+			result.addParameter("sittingAction", sittingAction);
 			// Having a non-persistent client-only variables is unusual.
-        	// This is a work around because the client expects a seated avatar to be "contained" by the seat
-        	// That's terrible, so the workaround is to say that seating is live-session-only.
-        	// This prevents a LOT of problems since objects can change state/existence between sessions.
-        }
-        result.finish();
-        return result;
-    }
-    
-    
-    /** Avatars need to be repositioned upon arrival in a region based on the method used to arrive. */
-    public void objectIsComplete() {
-        Region.addToNoids(this);
-        /** Was pl1 region_entry_daemon: */
-        
-        // If traveling as a ghost, don't do ANYTHING fancy 
-        if (noid == GHOST_NOID)
-            return;
+			// This is a work around because the client expects a seated avatar to be "contained" by the seat
+			// That's terrible, so the workaround is to say that seating is live-session-only.
+			// This prevents a LOT of problems since objects can change state/existence between sessions.
+		}
+		result.finish();
+		return result;
+	}
+	
+	
+	/** Avatars need to be repositioned upon arrival in a region based on the method used to arrive. */
+	public void objectIsComplete() {
+		Region.addToNoids(this);
+		/** Was pl1 region_entry_daemon: */
+		
+		// If traveling as a ghost, don't do ANYTHING fancy 
+		if (noid == GHOST_NOID)
+			return;
 
-        // If the avatar has any objects in their hands, perform any necessary side effects.
-        in_hands_side_effects(this);
-        
-        // If walking in, set the new (x,y) based on the old (x,y), the entry
-        // direction, the rotation of the region transition, the horizon of the
-        // new region, and so on 
-        int new_x           = x;
-        int new_y           = y & ~FOREGROUND_BIT;
-        int new_activity    = FACE_LEFT;
-        int rotation        = 0;
-        int arrival_face    = 0;
+		// If the avatar has any objects in their hands, perform any necessary side effects.
+		in_hands_side_effects(this);
+		
+		// If walking in, set the new (x,y) based on the old (x,y), the entry
+		// direction, the rotation of the region transition, the horizon of the
+		// new region, and so on 
+		int new_x           = x;
+		int new_y           = y & ~FOREGROUND_BIT;
+		int new_activity    = FACE_LEFT;
+		int rotation        = 0;
+		int arrival_face    = 0;
 
-        trace_msg("Avatar %s called objectIsComplete, transition_type=%d", obj_id(), transition_type);
-        if (transition_type == WALK_ENTRY) {
-            y &= ~FOREGROUND_BIT;
-            rotation = (from_orientation - current_region().orientation + 4) % 4;
-            arrival_face = (from_direction + rotation + 2) % 4;
-            if (arrival_face == 0) {
-                new_x = XLEFT;
-                new_activity = FACE_RIGHT;
-                if (rotation == 0)
-                    new_y = y;
-                else if (rotation == 1)
-                    new_y = x_scale(x_invert(x));
-                else if (rotation == 2)
-                    new_y = y_invert(y);
-                else
-                    new_y = x_scale(x);
-            } else if (arrival_face == 1) {
-                new_y = current_region().depth;
-                new_activity = FACE_FRONT;
-                if (rotation == 0)
-                    new_x = x;
-                else if (rotation == 1)
-                    new_x = y_scale(y);
-                else if (rotation == 2)
-                    new_x = x_invert(x);
-                else
-                    new_x = y_scale(y_invert(y));
-                HabitatMod noids[] = current_region().noids;
-                for (int i=0; i < noids.length; i++) {
-                    HabitatMod obj = noids[i];
-                    if (noids[i] != null) {
-                        if (obj.HabitatClass() == CLASS_DOOR) {
-                            Door door = (Door) obj;
-                            if (door.connection.equals(from_region) || door.connection.isEmpty()) {
-                                new_y = obj.y;
-                                new_x = obj.x + DOOR_OFFSET;
-                                if (test_bit(obj.orientation, 1))
-                                    new_x = new_x - 16;
-                            }                    
-                        } else if (obj.HabitatClass() == CLASS_BUILDING) {
-                            Building bldg = (Building) obj;
-                            if (bldg.connection == from_region || bldg.connection.isEmpty()) {
-                                new_x = obj.x + BUILDING_OFFSET;
-                            }
-                        }
-                    }
-                }
-            } else if (arrival_face == 2) {
-                new_x = XRIGHT;
-                new_activity = FACE_LEFT;
-                if (rotation == 0)
-                    new_y = y;
-                else if (rotation == 1)
-                    new_y = x_scale(x_invert(x));
-                else if (rotation == 2)
-                    new_y = y_invert(y);
-                else
-                    new_y = x_scale(x);
-            } else {
-                new_y = YDOWN;
-                new_activity = FACE_BACK;
-                if (rotation == 0)
-                    new_x = x;
-                else if (rotation == 1)
-                    new_x = y_scale(y);
-                else if (rotation == 2)
-                    new_x = x_invert(x);
-                else
-                    new_x = y_scale(y_invert(y));
-            }
-            x = new_x & 0b11111100;
-            y = Math.min((new_y & ~FOREGROUND_BIT), current_region().depth) | FOREGROUND_BIT;
-            activity = new_activity;
-        } else if (transition_type == TELEPORT_ENTRY) {
-            // If entering via teleport, make sure we're in foreground
-            y |= FOREGROUND_BIT;
-        } else {
-            trace_msg("ENTRY ERROR: uUnknown transition type: " + transition_type);
-        }
-        
-    }
-    
-    private int x_invert(int x) {
-        return (XMAX - x);         
-    }
-    
-    
-    private int y_invert(int y) {
-        return(current_region().depth - y);
-    }
-    
-    private int x_scale(int x) {
-        double scale = current_region().depth / XMAXFLOAT;
-        return ((int) scale);
-    }
-    
-    private int y_scale(int y) {
-        double scale = XMAXFLOAT / current_region().depth;
-        return ((int) scale);
-    }
-    
-    
-    
-    /*        
-         // If entering on death, penalize the Avatar's tokens, if any 
-         else if (transition_type = DEATH_ENTRY) then do;
-              do i = 0 to 255;
-                   tokenptr = ObjList(i);
-                   if (tokenptr ^= null()) then do;
-                        if (token.class = CLASS_TOKENS) then do;
-                             denom = token.denom_lo + token.denom_hi*256;
-                             denom = divide(denom, 2, 15);
-                             token.denom_hi = divide(denom, 256, 15);
-                             token.denom_lo = mod(denom, 256);
-                             if (denom = 0) then
-                                  token.denom_lo = 1;
-                             token.gen_flags(MODIFIED) = true;
-                        end;
-                   end;
-              end;
-         end;
-        
-         // If entering via teleport, make sure we're in foreground 
-         else if (transition_type = TELEPORT_ENTRY) then do;
-              call set_bit(avatar.y, 8);
-         end; else do;
-              call trace_msg('entry daemon: unknown transition type: ' ||
-                   ltrim(transition_type));
-         end;
-     */
-    
-    /**
-     * Verb (Specific): TODO Grabbing from another avatar.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    @JSONMethod
-    public void GRAB(User from) {
-        unsupported_reply(from, noid, "Avatar.GRAB not implemented yet.");
-    }
-    
-    /**
-     * Verb (Specific): TODO Handing in-hand item to another avatar.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    @JSONMethod
-    public void HAND(User from) {
-        unsupported_reply(from, noid, "Avatar.HAND not implemented yet.");
-    }
-    
-    /**
-     * Verb (Specific): TODO Change this avatar's posture.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    @JSONMethod({ "pose" })
-    public void POSTURE(User from, OptInteger pose) {
-        int new_posture = pose.value(STAND_FRONT);
-        // if (selfptr == avatarptr) { TODO Bullet Proofing Needed
-        if (0 <= new_posture && new_posture < 256) {
-            if (new_posture == SIT_GROUND || new_posture == SIT_CHAIR || new_posture == SIT_FRONT
-                    || new_posture == STAND || new_posture == STAND_FRONT || new_posture == STAND_LEFT
-                    || new_posture == STAND_RIGHT || new_posture == FACE_LEFT || new_posture == FACE_RIGHT) {
-                this.activity = new_posture;
-            }
-            if (new_posture != COLOR_POSTURE) {
-                send_neighbor_msg(from, noid, "POSTURE$", "new_posture", new_posture);
-            }
-            if (new_posture < STAND_LEFT || new_posture == COLOR_POSTURE) {
-                send_reply_success(from);
-            }
-        }
-        // }
-    }
-    
-    /**
-     * Verb (Specific): TODO Speak to the region/ESP to another user
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     * @param esp
-     *            Byte flag indicating that ESP message mode is active on the
-     *            client.
-     * @param text
-     *            The string to speak...
-     */
-    @JSONMethod({ "esp", "text" })
-    public void SPEAK(User from, OptInteger esp, OptString text) {
-        int in_esp = esp.value(FALSE);
-        /* TODO ESP logic Missing */
-        send_broadcast_msg(this.noid, "SPEAK$", text.value("(missing text)"));
-        send_reply_msg(from, this.noid, "esp", in_esp);
-    }
-    
-    /**
-     * Verb (Specific): TODO Walk across the region.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    @JSONMethod({ "x", "y", "how" })
-    public void WALK(User from, OptInteger x, OptInteger y, OptInteger how) {
-        
-        // object_say(from, noid, "Avatar.WALK not implemented yet.");
-        
-        /*
-         * declare destination_x binary(15); declare destination_y binary(15);
-         * declare flip_path bit(1) aligned;
-         * 
-         * x = rank(request(FIRST)); y = rank(request(SECOND)); walk_how =
-         * rank(request(THIRD)); if (selfptr ^= avatarptr) then do;
-         * destination_x = avatar.x; destination_y = avatar.y; end; else if
-         * (avatar.stun_count > 0) then do; avatar.stun_count =
-         * avatar.stun_count - 1; call r_msg_3(avatar.x, avatar.y, walk_how); if
-         * (avatar.stun_count >= 2) then call p_msg_s(selfptr, selfptr, SPEAK$,
-         * 'I can''t move. I am stunned.'); else if (avatar.stun_count = 1) then
-         * call p_msg_s(selfptr, selfptr, SPEAK$, 'I am still stunned.'); else
-         * call p_msg_s(selfptr, selfptr, SPEAK$, 'The stun effect is wearing
-         * off now.'); return; end; else do; call check_path(THE_REGION, x, y,
-         * destination_x, destination_y, flip_path); if (flip_path) then call
-         * set_bit(walk_how, 8); else call clear_bit(walk_how, 8); if
-         * (destination_x ^= self.x | destination_y ^= self.y) then do; self.x =
-         * destination_x; self.y = destination_y; call n_msg_3(selfptr, WALK$,
-         * destination_x, destination_y, walk_how); end; end; call
-         * r_msg_3(destination_x, destination_y, walk_how);
-         */
-        int destination_x = x.value(80);
-        int destination_y = y.value(10) | FOREGROUND_BIT;
-        int walk_how = how.value(0);
+		trace_msg("Avatar %s called objectIsComplete, transition_type=%d", obj_id(), transition_type);
+		if (transition_type == WALK_ENTRY) {
+			y &= ~FOREGROUND_BIT;
+			rotation = (from_orientation - current_region().orientation + 4) % 4;
+			arrival_face = (from_direction + rotation + 2) % 4;
+			if (arrival_face == 0) {
+				new_x = XLEFT;
+				new_activity = FACE_RIGHT;
+				if (rotation == 0)
+					new_y = y;
+				else if (rotation == 1)
+					new_y = x_scale(x_invert(x));
+				else if (rotation == 2)
+					new_y = y_invert(y);
+				else
+					new_y = x_scale(x);
+			} else if (arrival_face == 1) {
+				new_y = current_region().depth;
+				new_activity = FACE_FRONT;
+				if (rotation == 0)
+					new_x = x;
+				else if (rotation == 1)
+					new_x = y_scale(y);
+				else if (rotation == 2)
+					new_x = x_invert(x);
+				else
+					new_x = y_scale(y_invert(y));
+				HabitatMod noids[] = current_region().noids;
+				for (int i=0; i < noids.length; i++) {
+					HabitatMod obj = noids[i];
+					if (noids[i] != null) {
+						if (obj.HabitatClass() == CLASS_DOOR) {
+							Door door = (Door) obj;
+							if (door.connection.equals(from_region) || door.connection.isEmpty()) {
+								new_y = obj.y;
+								new_x = obj.x + DOOR_OFFSET;
+								if (test_bit(obj.orientation, 1))
+									new_x = new_x - 16;
+							}                    
+						} else if (obj.HabitatClass() == CLASS_BUILDING) {
+							Building bldg = (Building) obj;
+							if (bldg.connection == from_region || bldg.connection.isEmpty()) {
+								new_x = obj.x + BUILDING_OFFSET;
+							}
+						}
+					}
+				}
+			} else if (arrival_face == 2) {
+				new_x = XRIGHT;
+				new_activity = FACE_LEFT;
+				if (rotation == 0)
+					new_y = y;
+				else if (rotation == 1)
+					new_y = x_scale(x_invert(x));
+				else if (rotation == 2)
+					new_y = y_invert(y);
+				else
+					new_y = x_scale(x);
+			} else {
+				new_y = YDOWN;
+				new_activity = FACE_BACK;
+				if (rotation == 0)
+					new_x = x;
+				else if (rotation == 1)
+					new_x = y_scale(y);
+				else if (rotation == 2)
+					new_x = x_invert(x);
+				else
+					new_x = y_scale(y_invert(y));
+			}
+			x = new_x & 0b11111100;
+			y = Math.min((new_y & ~FOREGROUND_BIT), current_region().depth) | FOREGROUND_BIT;
+			activity = new_activity;
+		} else if (transition_type == TELEPORT_ENTRY) {
+			// If entering via teleport, make sure we're in foreground
+			y |= FOREGROUND_BIT;
+		} else {
+			trace_msg("ENTRY ERROR: uUnknown transition type: " + transition_type);
+		}
+		
+	}
+	
+	private int x_invert(int x) {
+		return (XMAX - x);         
+	}
+	
+	
+	private int y_invert(int y) {
+		return(current_region().depth - y);
+	}
+	
+	private int x_scale(int x) {
+		double scale = current_region().depth / XMAXFLOAT;
+		return ((int) scale);
+	}
+	
+	private int y_scale(int y) {
+		double scale = XMAXFLOAT / current_region().depth;
+		return ((int) scale);
+	}
+	
+	
+	
+	/*        
+		 // If entering on death, penalize the Avatar's tokens, if any 
+		 else if (transition_type = DEATH_ENTRY) then do;
+			  do i = 0 to 255;
+				   tokenptr = ObjList(i);
+				   if (tokenptr ^= null()) then do;
+						if (token.class = CLASS_TOKENS) then do;
+							 denom = token.denom_lo + token.denom_hi*256;
+							 denom = divide(denom, 2, 15);
+							 token.denom_hi = divide(denom, 256, 15);
+							 token.denom_lo = mod(denom, 256);
+							 if (denom = 0) then
+								  token.denom_lo = 1;
+							 token.gen_flags(MODIFIED) = true;
+						end;
+				   end;
+			  end;
+		 end;
+		
+		 // If entering via teleport, make sure we're in foreground 
+		 else if (transition_type = TELEPORT_ENTRY) then do;
+			  call set_bit(avatar.y, 8);
+		 end; else do;
+			  call trace_msg('entry daemon: unknown transition type: ' ||
+				   ltrim(transition_type));
+		 end;
+	 */
+	
+	/**
+	 * Verb (Specific): TODO Grabbing from another avatar.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	@JSONMethod
+	public void GRAB(User from) {
+		unsupported_reply(from, noid, "Avatar.GRAB not implemented yet.");
+	}
+	
+	/**
+	 * Verb (Specific): TODO Handing in-hand item to another avatar.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	@JSONMethod
+	public void HAND(User from) {
+		unsupported_reply(from, noid, "Avatar.HAND not implemented yet.");
+	}
+	
+	/**
+	 * Verb (Specific): TODO Change this avatar's posture.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	@JSONMethod({ "pose" })
+	public void POSTURE(User from, OptInteger pose) {
+		int new_posture = pose.value(STAND_FRONT);
+		// if (selfptr == avatarptr) { TODO Bullet Proofing Needed
+		if (0 <= new_posture && new_posture < 256) {
+			if (new_posture == SIT_GROUND || new_posture == SIT_CHAIR || new_posture == SIT_FRONT
+					|| new_posture == STAND || new_posture == STAND_FRONT || new_posture == STAND_LEFT
+					|| new_posture == STAND_RIGHT || new_posture == FACE_LEFT || new_posture == FACE_RIGHT) {
+				this.activity = new_posture;
+			}
+			if (new_posture != COLOR_POSTURE) {
+				send_neighbor_msg(from, noid, "POSTURE$", "new_posture", new_posture);
+			}
+			if (new_posture < STAND_LEFT || new_posture == COLOR_POSTURE) {
+				send_reply_success(from);
+			}
+		}
+		// }
+	}
+	
+	/**
+	 * Verb (Specific): TODO Speak to the region/ESP to another user
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 * @param esp
+	 *            Byte flag indicating that ESP message mode is active on the
+	 *            client.
+	 * @param text
+	 *            The string to speak...
+	 */
+	@JSONMethod({ "esp", "text" })
+	public void SPEAK(User from, OptInteger esp, OptString text) {
+		int in_esp = esp.value(FALSE);
+		/* TODO ESP logic Missing */
+		send_broadcast_msg(this.noid, "SPEAK$", text.value("(missing text)"));
+		send_reply_msg(from, this.noid, "esp", in_esp);
+	}
+	
+	/**
+	 * Verb (Specific): TODO Walk across the region.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	@JSONMethod({ "x", "y", "how" })
+	public void WALK(User from, OptInteger x, OptInteger y, OptInteger how) {
+		
+		// object_say(from, noid, "Avatar.WALK not implemented yet.");
+		
+		/*
+		 * declare destination_x binary(15); declare destination_y binary(15);
+		 * declare flip_path bit(1) aligned;
+		 * 
+		 * x = rank(request(FIRST)); y = rank(request(SECOND)); walk_how =
+		 * rank(request(THIRD)); if (selfptr ^= avatarptr) then do;
+		 * destination_x = avatar.x; destination_y = avatar.y; end; else if
+		 * (avatar.stun_count > 0) then do; avatar.stun_count =
+		 * avatar.stun_count - 1; call r_msg_3(avatar.x, avatar.y, walk_how); if
+		 * (avatar.stun_count >= 2) then call p_msg_s(selfptr, selfptr, SPEAK$,
+		 * 'I can''t move. I am stunned.'); else if (avatar.stun_count = 1) then
+		 * call p_msg_s(selfptr, selfptr, SPEAK$, 'I am still stunned.'); else
+		 * call p_msg_s(selfptr, selfptr, SPEAK$, 'The stun effect is wearing
+		 * off now.'); return; end; else do; call check_path(THE_REGION, x, y,
+		 * destination_x, destination_y, flip_path); if (flip_path) then call
+		 * set_bit(walk_how, 8); else call clear_bit(walk_how, 8); if
+		 * (destination_x ^= self.x | destination_y ^= self.y) then do; self.x =
+		 * destination_x; self.y = destination_y; call n_msg_3(selfptr, WALK$,
+		 * destination_x, destination_y, walk_how); end; end; call
+		 * r_msg_3(destination_x, destination_y, walk_how);
+		 */
+		int destination_x = x.value(80);
+		int destination_y = y.value(10) | FOREGROUND_BIT;
+		int walk_how = how.value(0);
 
-        if (stun_count > 0) {
-            stun_count -= 1;
-            send_reply_msg(from, this.noid, "x", this.x, "y", this.y, "how", walk_how);
-            if (stun_count >= 2) {
-                send_private_msg(from, this.noid, from, "SPEAK$", "I can't move.  I am stunned.");
-            } else if (stun_count == 1) {
-                send_private_msg(from, this.noid, from, "SPEAK$", "I am still stunned.");
-            } else {
-                send_private_msg(from, this.noid, from, "SPEAK$", "The stun effect is wearing off now.");
-            }
-            checkpoint_object(this);
-            return;
-        }
+		if (stun_count > 0) {
+			stun_count -= 1;
+			send_reply_msg(from, this.noid, "x", this.x, "y", this.y, "how", walk_how);
+			if (stun_count >= 2) {
+				send_private_msg(from, this.noid, from, "SPEAK$", "I can't move.  I am stunned.");
+			} else if (stun_count == 1) {
+				send_private_msg(from, this.noid, from, "SPEAK$", "I am still stunned.");
+			} else {
+				send_private_msg(from, this.noid, from, "SPEAK$", "The stun effect is wearing off now.");
+			}
+			checkpoint_object(this);
+			return;
+		}
 
-        if ((destination_y & ~FOREGROUND_BIT) > current_region().depth) {
-            destination_y = current_region().depth | FOREGROUND_BIT;
-        }
-        
-        send_neighbor_msg(from, this.noid, "WALK$", "x", destination_x, "y", destination_y, "how", walk_how);
-        send_reply_msg(from, this.noid, "x", destination_x, "y", destination_y, "how", walk_how);
-        
-        this.x = destination_x;
-        this.y = destination_y;
-        checkpoint_object(this);
-    }
-    
-    /**
-     * Verb (Specific): TODO Leave the region for another region.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    @JSONMethod({ "direction", "passage_id" })
-    public void NEWREGION(User from, OptInteger direction, OptInteger passage_id) {
-        avatar_NEWREGION(from, direction.value(1), passage_id.value(0));
-    }
-    
-    /**
-     * Verb (Specific): TODO Turn to/from being a ghost.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    @JSONMethod
-    public void DISCORPORATE(User from) {
-        unsupported_reply(from, noid, "Avatar.DISCORPORATE not implemented yet.");
-    }
-    
-    /**
-     * Verb (Specific): TODO Send a point-to-point message to another
-     * user/avatar.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    @JSONMethod
-    public void ESP(User from) {
-        unsupported_reply(from, noid, "Avatar.ESP not implemented yet.");
-    }
-    
-    /**
-     * Verb (Specific): TODO Sit down. [Stand up?]
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    @JSONMethod({"up_or_down", "seat_id"})
-    public void SITORSTAND(User from, int up_or_down, int seat_id) {
-    	
+		if ((destination_y & ~FOREGROUND_BIT) > current_region().depth) {
+			destination_y = current_region().depth | FOREGROUND_BIT;
+		}
+		
+		send_neighbor_msg(from, this.noid, "WALK$", "x", destination_x, "y", destination_y, "how", walk_how);
+		send_reply_msg(from, this.noid, "x", destination_x, "y", destination_y, "how", walk_how);
+		
+		this.x = destination_x;
+		this.y = destination_y;
+		checkpoint_object(this);
+	}
+	
+	/**
+	 * Verb (Specific): TODO Leave the region for another region.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	@JSONMethod({ "direction", "passage_id" })
+	public void NEWREGION(User from, OptInteger direction, OptInteger passage_id) {
+		avatar_NEWREGION(from, direction.value(1), passage_id.value(0));
+	}
+	
+	/**
+	 * Verb (Specific): TODO Turn to/from being a ghost.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	@JSONMethod
+	public void DISCORPORATE(User from) {
+		unsupported_reply(from, noid, "Avatar.DISCORPORATE not implemented yet.");
+	}
+	
+	/**
+	 * Verb (Specific): TODO Send a point-to-point message to another
+	 * user/avatar.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	@JSONMethod
+	public void ESP(User from) {
+		unsupported_reply(from, noid, "Avatar.ESP not implemented yet.");
+	}
+	
+	/**
+	 * Verb (Specific): TODO Sit down. [Stand up?]
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	@JSONMethod({"up_or_down", "seat_id"})
+	public void SITORSTAND(User from, int up_or_down, int seat_id) {
+		
 //    	if (up_or_down <= SIT_DOWN) {		// TOFO FRF This is always for now until we can work with Elko for a fix.
 //            unsupported_reply(from, noid, "This furniture has a sign that reads 'Do not sit here. Under repair'.");
 //    		return;
 //    	}	
-   	
-    	/** Historically was avatar_SITORSTAND in original pl1 */
-    	Region		region	= current_region();
-    	Seating		seat	= (Seating) region.noids[seat_id];
-    	int			slot	= -1;
-    	if (seat != null) {
-    		if (isSeating(seat)) {
-    			if (up_or_down == STAND_UP) {
-    				if (sittingIn == seat_id) {
-    					slot = sittingSlot;
-    					if (seat.sitters[slot] != noid) {
-    						send_reply_msg(from, noid, "err", FALSE, "slot", 0);
-    						return;
-    					}
-    					activity 			= STAND;
-    					sittingIn			= 0;
-    					seat.sitters[slot]	= 0;
-    					gen_flags[MODIFIED] = true;    					
-    					checkpoint_object(this);
+	
+		/** Historically was avatar_SITORSTAND in original pl1 */
+		Region		region	= current_region();
+		Seating		seat	= (Seating) region.noids[seat_id];
+		int			slot	= -1;
+		if (seat != null) {
+			if (isSeating(seat)) {
+				if (up_or_down == STAND_UP) {
+					if (sittingIn == seat_id) {
+						slot = sittingSlot;
+						if (seat.sitters[slot] != noid) {
+							send_reply_msg(from, noid, "err", FALSE, "slot", 0);
+							return;
+						}
+						activity 			= STAND;
+						sittingIn			= 0;
+						seat.sitters[slot]	= 0;
+						gen_flags[MODIFIED] = true;    					
+						checkpoint_object(this);
 						send_reply_msg(from, noid, "err", TRUE, "slot", 0);
 						send_neighbor_msg(from, noid, "SIT$", "up_or_down", STAND_UP, "cont", seat_id, "slot", 0);
-    					return;
-    				}
-    			} else {
-    				Container cont = (Container) seat;
-    				for (slot = 0; slot < cont.capacity(); slot++) {
-    					if (cont.contents(slot) == null && seat.sitters[slot] == 0) {
-    						if (sittingIn != 0) {
-        						send_reply_msg(from, 0, "err", FALSE, "slot", 0);
-    							return;
-    						}
-    						seat.sitters[slot]	= noid;
-    						sittingIn		= seat.noid;
-    						sittingSlot		= slot;
-    						sittingAction	= ((seat.style & 1) == 1) ? AV_ACT_sit_chair : AV_ACT_sit_front;
-    						send_reply_msg(from, noid, "err", TRUE, "slot", slot);
-    						send_neighbor_msg(from, noid, "SIT$", "up_or_down", SIT_DOWN, "cont", seat_id, "slot", slot);
-    						return;
-    					}
-    				}
-    			}
-    		}
-    	}     
+						return;
+					}
+				} else {
+					Container cont = (Container) seat;
+					for (slot = 0; slot < cont.capacity(); slot++) {
+						if (cont.contents(slot) == null && seat.sitters[slot] == 0) {
+							if (sittingIn != 0) {
+								send_reply_msg(from, 0, "err", FALSE, "slot", 0);
+								return;
+							}
+							seat.sitters[slot]	= noid;
+							sittingIn		= seat.noid;
+							sittingSlot		= slot;
+							sittingAction	= ((seat.style & 1) == 1) ? AV_ACT_sit_chair : AV_ACT_sit_front;
+							send_reply_msg(from, noid, "err", TRUE, "slot", slot);
+							send_neighbor_msg(from, noid, "SIT$", "up_or_down", SIT_DOWN, "cont", seat_id, "slot", slot);
+							return;
+						}
+					}
+				}
+			}
+		}     
 		send_reply_msg(from, noid, "err", FALSE, "slot", 0);
-    }
+	}
 
 
 
-    
-    /**
-     * Verb (Specific): TODO Touch another avatar.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    @JSONMethod
-    public void TOUCH(User from) {
-        unsupported_reply(from, noid, "Avatar.TOUCH not implemented yet.");
-    }
-    
-    /**
-     * Verb (Specific): TODO Deal with FN Key presses.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    @JSONMethod({ "key", "target" })
-    public void FNKEY(User from, OptInteger key, OptInteger target) {
-        switch (key.value(0)) {
-            case 16: // F8
-                object_say(from, "        You are connected to          ");
-                object_say(from, "   The Neoclassical Habitat Server    ");
-                //                object_say(from, "                                     ".substring(BuildVersion.version.length())
-                //                       + BuildVersion.version + " ");
-                object_say(from, "    The MADE, The Museum of Arts &       Digital Entertainment, Oakland CA");
-                object_say(from, "                                      ");
-                object_say(from, "Open source - Join us! NeoHabitat.org ");
-                send_reply_success(from);
-                break;
-            case 11: // F3 & F4 (List last dozen users)
-            case 13: // F5 & F6 (Change Skin Color)
-            default:
-                unsupported_reply(from, noid, "Avatar.FNKEY not implemented yet.");
-                
-        }
-    }
-    
-    /**
-     * Verb (Avatar): Reply with the HELP for this avatar.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    @JSONMethod
-    public void HELP(User from) {
-        avatar_IDENTIFY(from);
-    }
-    
-    /**
-     * Alternate interface to avatar_IDENTIFY, passing this.noid as the missing
-     * second argument.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     */
-    public void avatar_IDENTIFY(User from) {
-        avatar_IDENTIFY(from, this.noid);
-    }
-    
-    /**
-     * A different message is returned depending on if this avatar is the "from"
-     * user or another, the message returned will vary.
-     * 
-     * @param from
-     *            User representing the connection making the request.
-     * @param replyNoid
-     *            which avatar.noid is the one getting the reply.
-     */
-    public void avatar_IDENTIFY(User from, int replyNoid) {
-        User targetUser = (User) this.object();
-        String targetName = targetUser.name();
-        String avatarname = from.name();
-        Avatar avatar = avatar(from);
-        String result = "";
-        
-        if (avatar.noid == this.noid) {
-            result = "Your name is " + avatarname + ".  You are ";
-            if (avatar.stun_count > 0)
-                result = result + "stunned, and you are ";
-            if (avatar.health > 200)
-                result = result + "in the peak of health.";
-            else if (avatar.health > 150)
-                result = result + "in good health.";
-            else if (avatar.health > 100)
-                result = result + "in fair health.";
-            else if (avatar.health > 50)
-                result = result + "in poor health.";
-            else
-                result = result + "near death.";
-        } else {
-            send_private_msg(from, avatar.noid, targetUser, "SPEAK$", "I am " + avatarname);
-            // p_msg_s(from, avatar.noid, targetUser, SPEAK$, "I am " +
-            // avatarname);
-            /*
-             * OBSOLETE CODE REFACTORED An Elko User == Connection, so there is
-             * no Turned to Stone state. And since a Elko Habitat Avatar is
-             * attached 1:1 to a Elko User, this code can never be true in this
-             * server.
-             * 
-             * if (UserList(self.avatarslot)->u.online) result = "This is " +
-             * targetName; else result = "Turned to stone: " + selfname;
-             */
-            result = "This is " + targetName;
-        }
-        send_reply_msg(from, replyNoid, "text",
-                result); /* TODO is replyNoid right? */
-    }
-    
-    public void avatar_NEWREGION(User from, int direction, int passage_id) {
-        Region      region          = current_region();
-        String      new_region      = "";
-        int			entry_type		= WALK_ENTRY;
-        HabitatMod  passage         = region.noids[passage_id];
-        int         direction_index = (direction + region.orientation + 2) % 4;
-        
-        if (direction != AUTO_TELEPORT_DIR && passage_id != 0 &&
-                passage.HabitatClass() == CLASS_DOOR || 
-                passage.HabitatClass() == CLASS_BUILDING) {
-            
-            if (passage.HabitatClass() == CLASS_DOOR) {
-                Door door = (Door) passage;
-                if (!door.getOpenFlag(OPEN_BIT) || 
-                        door.gen_flags[DOOR_AVATAR_RESTRICTED_BIT]) {
-                    send_reply_error(from);
-                    return;
-                } else {
-                    new_region = door.connection;
-                }
-            } else {
-                new_region = ((Building) passage).connection;
-            }
-            
-        }
-        
-        else {
-            if (direction >= 0 && direction < 4) {
-                new_region = region.neighbors[direction_index]; // East,  West, North, South
-            } else {     // direction == AUTO_TELEPORT_DIR 
-            	new_region = to_region;
-            	entry_type = TELEPORT_ENTRY;
-            	direction  = WEST; // TODO Randy needs to revisit this little hack to prevent a loop..
-            }
-        }
-        
-        if (!new_region.isEmpty()) {
-            send_neighbor_msg(from, THE_REGION, "WAITFOR_$", "who", this.noid);
-            send_reply_success(from);
-            change_regions(new_region, direction, entry_type);
-            return;
-        }       
-        object_say(from, "There is nowhere to go in that direction.");
-        send_reply_error(from); 
-    }
-    
-    public void change_regions(String contextRef, int direction, int type) {
-    	Region	region		= current_region();
-    	User	who			= (User) this.object();
+	
+	/**
+	 * Verb (Specific): TODO Touch another avatar.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	@JSONMethod
+	public void TOUCH(User from) {
+		unsupported_reply(from, noid, "Avatar.TOUCH not implemented yet.");
+	}
+	
+	/**
+	 * Verb (Specific): TODO Deal with FN Key presses.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	@JSONMethod({ "key", "target" })
+	public void FNKEY(User from, OptInteger key, OptInteger target) {
+		switch (key.value(0)) {
+			case 16: // F8
+				object_say(from, "        You are connected to          ");
+				object_say(from, "   The Neoclassical Habitat Server    ");
+				//                object_say(from, "                                     ".substring(BuildVersion.version.length())
+				//                       + BuildVersion.version + " ");
+				object_say(from, "    The MADE, The Museum of Arts &       Digital Entertainment, Oakland CA");
+				object_say(from, "                                      ");
+				object_say(from, "Open source - Join us! NeoHabitat.org ");
+				send_reply_success(from);
+				break;
+			case 11: // F3 & F4 (List last dozen users)
+			case 13: // F5 & F6 (Change Skin Color)
+			default:
+				unsupported_reply(from, noid, "Avatar.FNKEY not implemented yet.");
+				
+		}
+	}
+	
+	/**
+	 * Verb (Avatar): Reply with the HELP for this avatar.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	@JSONMethod
+	public void HELP(User from) {
+		avatar_IDENTIFY(from);
+	}
+	
+	/**
+	 * Alternate interface to avatar_IDENTIFY, passing this.noid as the missing
+	 * second argument.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 */
+	public void avatar_IDENTIFY(User from) {
+		avatar_IDENTIFY(from, this.noid);
+	}
+	
+	/**
+	 * A different message is returned depending on if this avatar is the "from"
+	 * user or another, the message returned will vary.
+	 * 
+	 * @param from
+	 *            User representing the connection making the request.
+	 * @param replyNoid
+	 *            which avatar.noid is the one getting the reply.
+	 */
+	public void avatar_IDENTIFY(User from, int replyNoid) {
+		User targetUser = (User) this.object();
+		String targetName = targetUser.name();
+		String avatarname = from.name();
+		Avatar avatar = avatar(from);
+		String result = "";
+		
+		if (avatar.noid == this.noid) {
+			result = "Your name is " + avatarname + ".  You are ";
+			if (avatar.stun_count > 0)
+				result = result + "stunned, and you are ";
+			if (avatar.health > 200)
+				result = result + "in the peak of health.";
+			else if (avatar.health > 150)
+				result = result + "in good health.";
+			else if (avatar.health > 100)
+				result = result + "in fair health.";
+			else if (avatar.health > 50)
+				result = result + "in poor health.";
+			else
+				result = result + "near death.";
+		} else {
+			send_private_msg(from, avatar.noid, targetUser, "SPEAK$", "I am " + avatarname);
+			// p_msg_s(from, avatar.noid, targetUser, SPEAK$, "I am " +
+			// avatarname);
+			/*
+			 * OBSOLETE CODE REFACTORED An Elko User == Connection, so there is
+			 * no Turned to Stone state. And since a Elko Habitat Avatar is
+			 * attached 1:1 to a Elko User, this code can never be true in this
+			 * server.
+			 * 
+			 * if (UserList(self.avatarslot)->u.online) result = "This is " +
+			 * targetName; else result = "Turned to stone: " + selfname;
+			 */
+			result = "This is " + targetName;
+		}
+		send_reply_msg(from, replyNoid, "text",
+				result); /* TODO is replyNoid right? */
+	}
+	
+	public void avatar_NEWREGION(User from, int direction, int passage_id) {
+		Region      region          = current_region();
+		String      new_region      = "";
+		int			entry_type		= WALK_ENTRY;
+		HabitatMod  passage         = region.noids[passage_id];
+		int         direction_index = (direction + region.orientation + 2) % 4;
+		
+		if (direction != AUTO_TELEPORT_DIR && passage_id != 0 &&
+				passage.HabitatClass() == CLASS_DOOR || 
+				passage.HabitatClass() == CLASS_BUILDING) {
+			
+			if (passage.HabitatClass() == CLASS_DOOR) {
+				Door door = (Door) passage;
+				if (!door.getOpenFlag(OPEN_BIT) || 
+						door.gen_flags[DOOR_AVATAR_RESTRICTED_BIT]) {
+					send_reply_error(from);
+					return;
+				} else {
+					new_region = door.connection;
+				}
+			} else {
+				new_region = ((Building) passage).connection;
+			}
+			
+		}
+		
+		else {
+			if (direction >= 0 && direction < 4) {
+				new_region = region.neighbors[direction_index]; // East,  West, North, South
+			} else {     // direction == AUTO_TELEPORT_DIR 
+				new_region = to_region;
+				entry_type = TELEPORT_ENTRY;
+				direction  = WEST; // TODO Randy needs to revisit this little hack to prevent a loop..
+			}
+		}
+		
+		if (!new_region.isEmpty()) {
+			send_neighbor_msg(from, THE_REGION, "WAITFOR_$", "who", this.noid);
+			send_reply_success(from);
+			change_regions(new_region, direction, entry_type);
+			return;
+		}       
+		object_say(from, "There is nowhere to go in that direction.");
+		send_reply_error(from); 
+	}
+	
+	public void change_regions(String contextRef, int direction, int type) {
+		Region	region		= current_region();
+		User	who			= (User) this.object();
 
-        trace_msg("Avatar %s changing regions to context=%s, direction=%d, type=%d", obj_id(),
-            contextRef, direction, type);
+		trace_msg("Avatar %s changing regions to context=%s, direction=%d, type=%d", obj_id(),
+			contextRef, direction, type);
 
-    	// TODO change_regions exceptions! see region.pl1
-    	
-        to_region			= contextRef;    	
-        from_region         = region.obj_id();     // Save exit information in avatar for use on arrival.
-        from_orientation    = region.orientation;
-        from_direction      = direction;
-        transition_type     = type;
-        gen_flags[MODIFIED] = true;
-        checkpoint_object(this);
-        
-    	if (direction == AUTO_TELEPORT_DIR) {
-    		send_private_msg(who, THE_REGION, who, "AUTO_TELEPORT_$", "direction", direction);
-    	} else {
-    		JSONLiteral msg = new JSONLiteral("changeContext", EncodeControl.forClient);
-    		msg.addParameter("context", contextRef);
-    		msg.finish();
-    		who.send(msg);
-    	}
-    }
-    
-    public void drop_object_in_hand() {
-    	if (contents(HANDS) != null) {
-    		HabitatMod obj = contents(HANDS);
-    		obj.x = 8;
-    		obj.y = 130;
-            obj.gen_flags[MODIFIED] = true;
-            obj.change_containers(obj, current_region(), obj.y, true);
-            // For C64-side implementation, see line 110 of actions.m.
-            send_broadcast_msg(THE_REGION, "CHANGE_CONTAINERS_$",
-                    "object_noid", obj.noid,
-                    "container_noid", THE_REGION,
-                    "x", obj.x,
-                    "y", obj.y);
-    	}
-    }
+		// TODO change_regions exceptions! see region.pl1
+		
+		to_region			= contextRef;    	
+		from_region         = region.obj_id();     // Save exit information in avatar for use on arrival.
+		from_orientation    = region.orientation;
+		from_direction      = direction;
+		transition_type     = type;
+		gen_flags[MODIFIED] = true;
+		checkpoint_object(this);
+		
+		if (direction == AUTO_TELEPORT_DIR) {
+			send_private_msg(who, THE_REGION, who, "AUTO_TELEPORT_$", "direction", direction);
+		} else {
+			JSONLiteral msg = new JSONLiteral("changeContext", EncodeControl.forClient);
+			msg.addParameter("context", contextRef);
+			msg.finish();
+			who.send(msg);
+		}
+	}
+	
+	public void drop_object_in_hand() {
+		if (contents(HANDS) != null) {
+			HabitatMod obj = contents(HANDS);
+			obj.x = 8;
+			obj.y = 130;
+			obj.gen_flags[MODIFIED] = true;
+			obj.change_containers(obj, current_region(), obj.y, true);
+			// For C64-side implementation, see line 110 of actions.m.
+			send_broadcast_msg(THE_REGION, "CHANGE_CONTAINERS_$",
+				"object_noid", obj.noid,
+				"container_noid", THE_REGION,
+				"x", obj.x,
+				"y", obj.y);
+		}
+	}
 }

--- a/src/main/java/org/made/neohabitat/mods/Avatar.java
+++ b/src/main/java/org/made/neohabitat/mods/Avatar.java
@@ -143,8 +143,7 @@ public class Avatar extends Container implements UserMod {
     public int		  sittingAction		= AV_ACT_sit_front;
         
     public String     turf            = "context-test";
-    
-    
+        
     private String     from_region		= "";
     private String     to_region		= "";	   
     private int        from_orientation	= 0;
@@ -211,6 +210,7 @@ public class Avatar extends Container implements UserMod {
             result.addParameter("from_orientation", from_orientation);
             result.addParameter("from_direction",   from_direction);
             result.addParameter("transition_type",	transition_type);
+            result.addParameter("turf", turf);
         }
         if (result.control().toClient() && sittingIn != 0) {
         	result.addParameter("sittingIn", sittingIn);
@@ -246,7 +246,8 @@ public class Avatar extends Container implements UserMod {
         int new_activity    = FACE_LEFT;
         int rotation        = 0;
         int arrival_face    = 0;
-        
+
+        trace_msg("Avatar %s called objectIsComplete, transition_type=%d", obj_id(), transition_type);
         if (transition_type == WALK_ENTRY) {
             y &= ~FOREGROUND_BIT;
             rotation = (from_orientation - current_region().orientation + 4) % 4;
@@ -319,29 +320,8 @@ public class Avatar extends Container implements UserMod {
             x = new_x & 0b11111100;
             y = Math.min((new_y & ~FOREGROUND_BIT), current_region().depth) | FOREGROUND_BIT;
             activity = new_activity;
-        }
-        
-        // TODO If entering on death, penalize the Avatar's tokens, if any 
-        else if (transition_type == DEATH_ENTRY) {
-            HabitatMod noids[] = current_region().noids;
-            for (int i=0; i < noids.length; i++) {
-                HabitatMod obj = noids[i];
-                if (obj != null && obj.HabitatClass() == CLASS_TOKENS) {
-                    /*
-                      Tokens token = (Tokens) obj;
-                      int denom = (token.denom_lo + token.denom_hi * 256) * 50 / 100;
-                      token.denom_lo = denom % 256;
-                      token.denom_hi = (denom - token.denom_lo) / 256;
-                      if (denom == 0)
-                          token.denom_lo = 1;
-                      token.gen_flags(MODIFIED) = true;
-                     */                      
-                }
-            }
-        }
-        
-        // If entering via teleport, make sure we're in foreground         
-        else if (transition_type == TELEPORT_ENTRY) {
+        } else if (transition_type == TELEPORT_ENTRY) {
+            // If entering via teleport, make sure we're in foreground
             y |= FOREGROUND_BIT;
         } else {
             trace_msg("ENTRY ERROR: uUnknown transition type: " + transition_type);
@@ -767,7 +747,10 @@ public class Avatar extends Container implements UserMod {
     public void change_regions(String contextRef, int direction, int type) {
     	Region	region		= current_region();
     	User	who			= (User) this.object();
-    	
+
+        trace_msg("Avatar %s changing regions to context=%s, direction=%d, type=%d", obj_id(),
+            contextRef, direction, type);
+
     	// TODO change_regions exceptions! see region.pl1
     	
         to_region			= contextRef;    	
@@ -785,6 +768,22 @@ public class Avatar extends Container implements UserMod {
     		msg.addParameter("context", contextRef);
     		msg.finish();
     		who.send(msg);
+    	}
+    }
+    
+    public void drop_object_in_hand() {
+    	if (contents(HANDS) != null) {
+    		HabitatMod obj = contents(HANDS);
+    		obj.x = 8;
+    		obj.y = 130;
+            obj.gen_flags[MODIFIED] = true;
+            obj.change_containers(obj, current_region(), obj.y, true);
+            // For C64-side implementation, see line 110 of actions.m.
+            send_broadcast_msg(THE_REGION, "CHANGE_CONTAINERS_$",
+                    "object_noid", obj.noid,
+                    "container_noid", THE_REGION,
+                    "x", obj.x,
+                    "y", obj.y);
     	}
     }
 }

--- a/src/main/java/org/made/neohabitat/mods/Avatar.java
+++ b/src/main/java/org/made/neohabitat/mods/Avatar.java
@@ -480,7 +480,21 @@ public class Avatar extends Container implements UserMod {
         int destination_x = x.value(80);
         int destination_y = y.value(10) | FOREGROUND_BIT;
         int walk_how = how.value(0);
-        
+
+        if (stun_count > 0) {
+            stun_count -= 1;
+            send_reply_msg(from, this.noid, "x", this.x, "y", this.y, "how", walk_how);
+            if (stun_count >= 2) {
+                send_private_msg(from, this.noid, from, "SPEAK$", "I can't move.  I am stunned.");
+            } else if (stun_count == 1) {
+                send_private_msg(from, this.noid, from, "SPEAK$", "I am still stunned.");
+            } else {
+                send_private_msg(from, this.noid, from, "SPEAK$", "The stun effect is wearing off now.");
+            }
+            checkpoint_object(this);
+            return;
+        }
+
         if ((destination_y & ~FOREGROUND_BIT) > current_region().depth) {
             destination_y = current_region().depth | FOREGROUND_BIT;
         }

--- a/src/main/java/org/made/neohabitat/mods/Avatar.java
+++ b/src/main/java/org/made/neohabitat/mods/Avatar.java
@@ -25,766 +25,766 @@ import org.elkoserver.json.JSONLiteral;
  */
 
 public class Avatar extends Container implements UserMod {
-	
-	public static final int SIT_GROUND  = 132;
-	public static final int SIT_CHAIR   = 133;
-	public static final int SIT_FRONT   = 157;
-	public static final int STAND_FRONT = 146;
-	public static final int STAND_LEFT  = 251;
-	public static final int STAND_RIGHT = 252;
-	public static final int STAND       = 129;
-	public static final int FACE_FRONT  = 146;
-	public static final int FACE_BACK   = 143;
-	public static final int FACE_LEFT   = 254;
-	public static final int FACE_RIGHT  = 255;
-	public static final int GENDER_BIT  = 8;
-	public static final int XRIGHT      = 148;
-	public static final int XLEFT       = 12;
-	public static final int YUP         = 159;
-	public static final int YDOWN       = 129;
-	
-	
-	public static final int	STAND_UP	= 0;
-	public static final int	SIT_DOWN	= 1;
-	
-	public static final int    XMAX        = 144;
-	public static final double XMAXFLOAT   = 144.0;
-	
-	public static final int DOOR_OFFSET = 12;
-	public static final int BUILDING_OFFSET = 28;
-	
-	public static final String DEFAULT_TURF = "context-test";
-	
-	public int HabitatClass() {
-		return CLASS_AVATAR;
-	}
-	
-	public String HabitatModName() {
-		return "Avatar";
-	}
-	
-	public int capacity() {
-		return AVATAR_CAPACITY;
-	}
-	
-	public int pc_state_bytes() {
-		return 6;
-	};
-	
-	public boolean known() {
-		return true;
-	}
-	
-	public boolean opaque_container() {
-		return true;
-	}
-	
-	public boolean filler() {
-		return false;
-	}
-	
-	/**
-	 * Static constant CONNECTION_TYPE indicates the kind of client connected
-	 * for this session
-	 */
-	protected static int ConnectionType = CONNECTION_JSON; /*
-	 * Soon to default to
-	 * CONNECTION_HABITAT
-	 */
-	
-	/**
-	 * Set the ConnectionType for this user.
-	 * 
-	 * @param type
-	 *            CONNECTION_JSON or CONNECTION_HABITAT
-	 */
-	public static void setConnectionType(int type) {
-		ConnectionType = type;
-	}
-	
-	/**
-	 * Get the ConnectionType for this user.
-	 * 
-	 * @return CONNECTION_JSON or CONNECTION_HABITAT
-	 */
-	public static int getConnectionType() {
-		return ConnectionType;
-	}
-	
-	/** The body type for the avatar TODO */
-	protected String  bodyType        = "male";
-	/** A collection of server-side Avatar status flags */
-	public boolean    nitty_bits[]    = new boolean[32];
-	/** Cache of avatar.contents(HEAD).style to restore after a curse. */
-	public int        true_head_style = 0;
-	/** Non-zero when the Avatar-User is cursed. */
-	public int        curse_type      = CURSE_NONE;
-	/** Non-zero when the Avatar-User is stunned. */
-	public int        stun_count      = 0;
-	/** The number of tokens this avatar has in the bank (not cash-on-hand.) */
-	public int        bankBalance     = 0;
-	/** The current avatar pose */
-	public int        activity        = STAND_FRONT;
-	/** TODO Doc */
-	public int        action          = STAND_FRONT;
-	/** Hit Points. Reaching 0 == death */
-	public int        health          = MAX_HEALTH;
-	/** TODO Doc */
-	public int        restrainer      = 0;
-	/** Avatar customization TODO Doc */
-	public int        custom[]        = new int[2];
-	/** TODO Doc */
-	public int        dest_x          = 0;
-	public int        dest_y          = 0;
-	
-	/** This is workaround - replacing the containership-based original model for seating used by the original Habtiat */
-	public int		  sittingIn			= 0;
-	public int		  sittingSlot		= 0;
-	public int		  sittingAction		= AV_ACT_sit_front;
-		
-	public String     turf            = "context-test";
-		
-	private String     from_region		= "";
-	private String     to_region		= "";	   
-	private int        from_orientation	= 0;
-	private int        from_direction	= 0;
-	private int        transition_type	= WALK_ENTRY;
-	
-	/**
-	 * Target NOID and magic item saved between events, such as for the GOD TOOL
-	 * (see Magical.java). This is a transient value and not persisted.
-	 */
-	public HabitatMod savedTarget     = null;
-	public Magical    savedMagical    = null;
-	
-	@JSONMethod({ "style", "x", "y", "orientation", "gr_state", "nitty_bits", "bodyType", "stun_count", "bankBalance",
-		"activity", "action", "health", "restrainer", "transition_type", "from_orientation", "from_direction", "from_region", "to_region",
-		"turf", "custom" })
-	public Avatar(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-			OptInteger nitty_bits, OptString bodyType, OptInteger stun_count, OptInteger bankBalance,
-			OptInteger activity, OptInteger action, OptInteger health, OptInteger restrainer, 
-			OptInteger transition_type, OptInteger from_orientation, OptInteger from_direction,
-			OptString from_region, OptString to_region, OptString turf, int[] custom) {
-		super(style, x, y, orientation, gr_state);
-		if (nitty_bits.value(-1) != -1) {
-			this.nitty_bits = unpackBits(nitty_bits.value());
-		}
-		this.bodyType = bodyType.value("male");
-		if ("female".equals(this.bodyType)) {
-			this.orientation = this.set_bit(this.orientation, GENDER_BIT);
-		} else {
-			this.orientation = this.clear_bit(this.orientation, GENDER_BIT);
-		}
-		this.stun_count = stun_count.value(0);
-		this.bankBalance = bankBalance.value(0);
-		this.activity = activity.value(STAND_FRONT);
-		this.action = action.value(this.activity);
-		this.health = health.value(MAX_HEALTH);
-		this.restrainer = restrainer.value(0);
-		this.from_direction = from_direction.value(0);
-		this.from_orientation = from_orientation.value(0);
-		this.transition_type = transition_type.value(WALK_ENTRY);
-		this.from_region = from_region.value("");
-		this.to_region = to_region.value("");
-		this.turf = turf.value(DEFAULT_TURF);
-		this.custom = custom;
-	}
-	
-	@Override
-	public JSONLiteral encode(EncodeControl control) {
-		JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));
-		if (packBits(nitty_bits) != 0) {
-			result.addParameter("nitty_bits", packBits(nitty_bits));
-		}
-		result.addParameter("bodyType", bodyType);
-		result.addParameter("stun_count", stun_count);
-		result.addParameter("bankBalance", bankBalance);
-		result.addParameter("activity", activity);
-		result.addParameter("action", action);
-		result.addParameter("health", health);
-		result.addParameter("restrainer", restrainer);
-		result.addParameter("custom", custom);
-		if (result.control().toRepository()) {
-			result.addParameter("from_region",      from_region);
-			result.addParameter("to_region",      	to_region);
-			result.addParameter("from_orientation", from_orientation);
-			result.addParameter("from_direction",   from_direction);
-			result.addParameter("transition_type",	transition_type);
-			result.addParameter("turf", turf);
-		}
-		if (result.control().toClient() && sittingIn != 0) {
-			result.addParameter("sittingIn", sittingIn);
-			result.addParameter("sittingSlot", sittingSlot);
-			result.addParameter("sittingAction", sittingAction);
+    
+    public static final int SIT_GROUND  = 132;
+    public static final int SIT_CHAIR   = 133;
+    public static final int SIT_FRONT   = 157;
+    public static final int STAND_FRONT = 146;
+    public static final int STAND_LEFT  = 251;
+    public static final int STAND_RIGHT = 252;
+    public static final int STAND       = 129;
+    public static final int FACE_FRONT  = 146;
+    public static final int FACE_BACK   = 143;
+    public static final int FACE_LEFT   = 254;
+    public static final int FACE_RIGHT  = 255;
+    public static final int GENDER_BIT  = 8;
+    public static final int XRIGHT      = 148;
+    public static final int XLEFT       = 12;
+    public static final int YUP         = 159;
+    public static final int YDOWN       = 129;
+    
+    
+    public static final int	STAND_UP	= 0;
+    public static final int	SIT_DOWN	= 1;
+    
+    public static final int    XMAX        = 144;
+    public static final double XMAXFLOAT   = 144.0;
+    
+    public static final int DOOR_OFFSET = 12;
+    public static final int BUILDING_OFFSET = 28;
+    
+    public static final String DEFAULT_TURF = "context-test";
+    
+    public int HabitatClass() {
+        return CLASS_AVATAR;
+    }
+    
+    public String HabitatModName() {
+        return "Avatar";
+    }
+    
+    public int capacity() {
+        return AVATAR_CAPACITY;
+    }
+    
+    public int pc_state_bytes() {
+        return 6;
+    };
+    
+    public boolean known() {
+        return true;
+    }
+    
+    public boolean opaque_container() {
+        return true;
+    }
+    
+    public boolean filler() {
+        return false;
+    }
+    
+    /**
+     * Static constant CONNECTION_TYPE indicates the kind of client connected
+     * for this session
+     */
+    protected static int ConnectionType = CONNECTION_JSON; /*
+     * Soon to default to
+     * CONNECTION_HABITAT
+     */
+    
+    /**
+     * Set the ConnectionType for this user.
+     * 
+     * @param type
+     *            CONNECTION_JSON or CONNECTION_HABITAT
+     */
+    public static void setConnectionType(int type) {
+        ConnectionType = type;
+    }
+    
+    /**
+     * Get the ConnectionType for this user.
+     * 
+     * @return CONNECTION_JSON or CONNECTION_HABITAT
+     */
+    public static int getConnectionType() {
+        return ConnectionType;
+    }
+    
+    /** The body type for the avatar TODO */
+    protected String  bodyType        = "male";
+    /** A collection of server-side Avatar status flags */
+    public boolean    nitty_bits[]    = new boolean[32];
+    /** Cache of avatar.contents(HEAD).style to restore after a curse. */
+    public int        true_head_style = 0;
+    /** Non-zero when the Avatar-User is cursed. */
+    public int        curse_type      = CURSE_NONE;
+    /** Non-zero when the Avatar-User is stunned. */
+    public int        stun_count      = 0;
+    /** The number of tokens this avatar has in the bank (not cash-on-hand.) */
+    public int        bankBalance     = 0;
+    /** The current avatar pose */
+    public int        activity        = STAND_FRONT;
+    /** TODO Doc */
+    public int        action          = STAND_FRONT;
+    /** Hit Points. Reaching 0 == death */
+    public int        health          = MAX_HEALTH;
+    /** TODO Doc */
+    public int        restrainer      = 0;
+    /** Avatar customization TODO Doc */
+    public int        custom[]        = new int[2];
+    /** TODO Doc */
+    public int        dest_x          = 0;
+    public int        dest_y          = 0;
+    
+    /** This is workaround - replacing the containership-based original model for seating used by the original Habtiat */
+    public int		  sittingIn			= 0;
+    public int		  sittingSlot		= 0;
+    public int		  sittingAction		= AV_ACT_sit_front;
+        
+    public String     turf            = "context-test";
+        
+    private String     from_region		= "";
+    private String     to_region		= "";	   
+    private int        from_orientation	= 0;
+    private int        from_direction	= 0;
+    private int        transition_type	= WALK_ENTRY;
+    
+    /**
+     * Target NOID and magic item saved between events, such as for the GOD TOOL
+     * (see Magical.java). This is a transient value and not persisted.
+     */
+    public HabitatMod savedTarget     = null;
+    public Magical    savedMagical    = null;
+    
+    @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "nitty_bits", "bodyType", "stun_count", "bankBalance",
+        "activity", "action", "health", "restrainer", "transition_type", "from_orientation", "from_direction", "from_region", "to_region",
+        "turf", "custom" })
+    public Avatar(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
+            OptInteger nitty_bits, OptString bodyType, OptInteger stun_count, OptInteger bankBalance,
+            OptInteger activity, OptInteger action, OptInteger health, OptInteger restrainer, 
+            OptInteger transition_type, OptInteger from_orientation, OptInteger from_direction,
+            OptString from_region, OptString to_region, OptString turf, int[] custom) {
+        super(style, x, y, orientation, gr_state);
+        if (nitty_bits.value(-1) != -1) {
+            this.nitty_bits = unpackBits(nitty_bits.value());
+        }
+        this.bodyType = bodyType.value("male");
+        if ("female".equals(this.bodyType)) {
+            this.orientation = this.set_bit(this.orientation, GENDER_BIT);
+        } else {
+            this.orientation = this.clear_bit(this.orientation, GENDER_BIT);
+        }
+        this.stun_count = stun_count.value(0);
+        this.bankBalance = bankBalance.value(0);
+        this.activity = activity.value(STAND_FRONT);
+        this.action = action.value(this.activity);
+        this.health = health.value(MAX_HEALTH);
+        this.restrainer = restrainer.value(0);
+        this.from_direction = from_direction.value(0);
+        this.from_orientation = from_orientation.value(0);
+        this.transition_type = transition_type.value(WALK_ENTRY);
+        this.from_region = from_region.value("");
+        this.to_region = to_region.value("");
+        this.turf = turf.value(DEFAULT_TURF);
+        this.custom = custom;
+    }
+    
+    @Override
+    public JSONLiteral encode(EncodeControl control) {
+        JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));
+        if (packBits(nitty_bits) != 0) {
+            result.addParameter("nitty_bits", packBits(nitty_bits));
+        }
+        result.addParameter("bodyType", bodyType);
+        result.addParameter("stun_count", stun_count);
+        result.addParameter("bankBalance", bankBalance);
+        result.addParameter("activity", activity);
+        result.addParameter("action", action);
+        result.addParameter("health", health);
+        result.addParameter("restrainer", restrainer);
+        result.addParameter("custom", custom);
+        if (result.control().toRepository()) {
+            result.addParameter("from_region",      from_region);
+            result.addParameter("to_region",      	to_region);
+            result.addParameter("from_orientation", from_orientation);
+            result.addParameter("from_direction",   from_direction);
+            result.addParameter("transition_type",	transition_type);
+            result.addParameter("turf", turf);
+        }
+        if (result.control().toClient() && sittingIn != 0) {
+        	result.addParameter("sittingIn", sittingIn);
+        	result.addParameter("sittingSlot", sittingSlot);
+        	result.addParameter("sittingAction", sittingAction);
 			// Having a non-persistent client-only variables is unusual.
-			// This is a work around because the client expects a seated avatar to be "contained" by the seat
-			// That's terrible, so the workaround is to say that seating is live-session-only.
-			// This prevents a LOT of problems since objects can change state/existence between sessions.
-		}
-		result.finish();
-		return result;
-	}
-	
-	
-	/** Avatars need to be repositioned upon arrival in a region based on the method used to arrive. */
-	public void objectIsComplete() {
-		Region.addToNoids(this);
-		/** Was pl1 region_entry_daemon: */
-		
-		// If traveling as a ghost, don't do ANYTHING fancy 
-		if (noid == GHOST_NOID)
-			return;
+        	// This is a work around because the client expects a seated avatar to be "contained" by the seat
+        	// That's terrible, so the workaround is to say that seating is live-session-only.
+        	// This prevents a LOT of problems since objects can change state/existence between sessions.
+        }
+        result.finish();
+        return result;
+    }
+    
+    
+    /** Avatars need to be repositioned upon arrival in a region based on the method used to arrive. */
+    public void objectIsComplete() {
+        Region.addToNoids(this);
+        /** Was pl1 region_entry_daemon: */
+        
+        // If traveling as a ghost, don't do ANYTHING fancy 
+        if (noid == GHOST_NOID)
+            return;
 
-		// If the avatar has any objects in their hands, perform any necessary side effects.
-		in_hands_side_effects(this);
-		
-		// If walking in, set the new (x,y) based on the old (x,y), the entry
-		// direction, the rotation of the region transition, the horizon of the
-		// new region, and so on 
-		int new_x           = x;
-		int new_y           = y & ~FOREGROUND_BIT;
-		int new_activity    = FACE_LEFT;
-		int rotation        = 0;
-		int arrival_face    = 0;
+        // If the avatar has any objects in their hands, perform any necessary side effects.
+        in_hands_side_effects(this);
+        
+        // If walking in, set the new (x,y) based on the old (x,y), the entry
+        // direction, the rotation of the region transition, the horizon of the
+        // new region, and so on 
+        int new_x           = x;
+        int new_y           = y & ~FOREGROUND_BIT;
+        int new_activity    = FACE_LEFT;
+        int rotation        = 0;
+        int arrival_face    = 0;
 
-		trace_msg("Avatar %s called objectIsComplete, transition_type=%d", obj_id(), transition_type);
-		if (transition_type == WALK_ENTRY) {
-			y &= ~FOREGROUND_BIT;
-			rotation = (from_orientation - current_region().orientation + 4) % 4;
-			arrival_face = (from_direction + rotation + 2) % 4;
-			if (arrival_face == 0) {
-				new_x = XLEFT;
-				new_activity = FACE_RIGHT;
-				if (rotation == 0)
-					new_y = y;
-				else if (rotation == 1)
-					new_y = x_scale(x_invert(x));
-				else if (rotation == 2)
-					new_y = y_invert(y);
-				else
-					new_y = x_scale(x);
-			} else if (arrival_face == 1) {
-				new_y = current_region().depth;
-				new_activity = FACE_FRONT;
-				if (rotation == 0)
-					new_x = x;
-				else if (rotation == 1)
-					new_x = y_scale(y);
-				else if (rotation == 2)
-					new_x = x_invert(x);
-				else
-					new_x = y_scale(y_invert(y));
-				HabitatMod noids[] = current_region().noids;
-				for (int i=0; i < noids.length; i++) {
-					HabitatMod obj = noids[i];
-					if (noids[i] != null) {
-						if (obj.HabitatClass() == CLASS_DOOR) {
-							Door door = (Door) obj;
-							if (door.connection.equals(from_region) || door.connection.isEmpty()) {
-								new_y = obj.y;
-								new_x = obj.x + DOOR_OFFSET;
-								if (test_bit(obj.orientation, 1))
-									new_x = new_x - 16;
-							}                    
-						} else if (obj.HabitatClass() == CLASS_BUILDING) {
-							Building bldg = (Building) obj;
-							if (bldg.connection == from_region || bldg.connection.isEmpty()) {
-								new_x = obj.x + BUILDING_OFFSET;
-							}
-						}
-					}
-				}
-			} else if (arrival_face == 2) {
-				new_x = XRIGHT;
-				new_activity = FACE_LEFT;
-				if (rotation == 0)
-					new_y = y;
-				else if (rotation == 1)
-					new_y = x_scale(x_invert(x));
-				else if (rotation == 2)
-					new_y = y_invert(y);
-				else
-					new_y = x_scale(x);
-			} else {
-				new_y = YDOWN;
-				new_activity = FACE_BACK;
-				if (rotation == 0)
-					new_x = x;
-				else if (rotation == 1)
-					new_x = y_scale(y);
-				else if (rotation == 2)
-					new_x = x_invert(x);
-				else
-					new_x = y_scale(y_invert(y));
-			}
-			x = new_x & 0b11111100;
-			y = Math.min((new_y & ~FOREGROUND_BIT), current_region().depth) | FOREGROUND_BIT;
-			activity = new_activity;
-		} else if (transition_type == TELEPORT_ENTRY) {
-			// If entering via teleport, make sure we're in foreground
-			y |= FOREGROUND_BIT;
-		} else {
-			trace_msg("ENTRY ERROR: uUnknown transition type: " + transition_type);
-		}
-		
-	}
-	
-	private int x_invert(int x) {
-		return (XMAX - x);         
-	}
-	
-	
-	private int y_invert(int y) {
-		return(current_region().depth - y);
-	}
-	
-	private int x_scale(int x) {
-		double scale = current_region().depth / XMAXFLOAT;
-		return ((int) scale);
-	}
-	
-	private int y_scale(int y) {
-		double scale = XMAXFLOAT / current_region().depth;
-		return ((int) scale);
-	}
-	
-	
-	
-	/*        
-		 // If entering on death, penalize the Avatar's tokens, if any 
-		 else if (transition_type = DEATH_ENTRY) then do;
-			  do i = 0 to 255;
-				   tokenptr = ObjList(i);
-				   if (tokenptr ^= null()) then do;
-						if (token.class = CLASS_TOKENS) then do;
-							 denom = token.denom_lo + token.denom_hi*256;
-							 denom = divide(denom, 2, 15);
-							 token.denom_hi = divide(denom, 256, 15);
-							 token.denom_lo = mod(denom, 256);
-							 if (denom = 0) then
-								  token.denom_lo = 1;
-							 token.gen_flags(MODIFIED) = true;
-						end;
-				   end;
-			  end;
-		 end;
-		
-		 // If entering via teleport, make sure we're in foreground 
-		 else if (transition_type = TELEPORT_ENTRY) then do;
-			  call set_bit(avatar.y, 8);
-		 end; else do;
-			  call trace_msg('entry daemon: unknown transition type: ' ||
-				   ltrim(transition_type));
-		 end;
-	 */
-	
-	/**
-	 * Verb (Specific): TODO Grabbing from another avatar.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	@JSONMethod
-	public void GRAB(User from) {
-		unsupported_reply(from, noid, "Avatar.GRAB not implemented yet.");
-	}
-	
-	/**
-	 * Verb (Specific): TODO Handing in-hand item to another avatar.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	@JSONMethod
-	public void HAND(User from) {
-		unsupported_reply(from, noid, "Avatar.HAND not implemented yet.");
-	}
-	
-	/**
-	 * Verb (Specific): TODO Change this avatar's posture.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	@JSONMethod({ "pose" })
-	public void POSTURE(User from, OptInteger pose) {
-		int new_posture = pose.value(STAND_FRONT);
-		// if (selfptr == avatarptr) { TODO Bullet Proofing Needed
-		if (0 <= new_posture && new_posture < 256) {
-			if (new_posture == SIT_GROUND || new_posture == SIT_CHAIR || new_posture == SIT_FRONT
-					|| new_posture == STAND || new_posture == STAND_FRONT || new_posture == STAND_LEFT
-					|| new_posture == STAND_RIGHT || new_posture == FACE_LEFT || new_posture == FACE_RIGHT) {
-				this.activity = new_posture;
-			}
-			if (new_posture != COLOR_POSTURE) {
-				send_neighbor_msg(from, noid, "POSTURE$", "new_posture", new_posture);
-			}
-			if (new_posture < STAND_LEFT || new_posture == COLOR_POSTURE) {
-				send_reply_success(from);
-			}
-		}
-		// }
-	}
-	
-	/**
-	 * Verb (Specific): TODO Speak to the region/ESP to another user
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 * @param esp
-	 *            Byte flag indicating that ESP message mode is active on the
-	 *            client.
-	 * @param text
-	 *            The string to speak...
-	 */
-	@JSONMethod({ "esp", "text" })
-	public void SPEAK(User from, OptInteger esp, OptString text) {
-		int in_esp = esp.value(FALSE);
-		/* TODO ESP logic Missing */
-		send_broadcast_msg(this.noid, "SPEAK$", text.value("(missing text)"));
-		send_reply_msg(from, this.noid, "esp", in_esp);
-	}
-	
-	/**
-	 * Verb (Specific): TODO Walk across the region.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	@JSONMethod({ "x", "y", "how" })
-	public void WALK(User from, OptInteger x, OptInteger y, OptInteger how) {
-		
-		// object_say(from, noid, "Avatar.WALK not implemented yet.");
-		
-		/*
-		 * declare destination_x binary(15); declare destination_y binary(15);
-		 * declare flip_path bit(1) aligned;
-		 * 
-		 * x = rank(request(FIRST)); y = rank(request(SECOND)); walk_how =
-		 * rank(request(THIRD)); if (selfptr ^= avatarptr) then do;
-		 * destination_x = avatar.x; destination_y = avatar.y; end; else if
-		 * (avatar.stun_count > 0) then do; avatar.stun_count =
-		 * avatar.stun_count - 1; call r_msg_3(avatar.x, avatar.y, walk_how); if
-		 * (avatar.stun_count >= 2) then call p_msg_s(selfptr, selfptr, SPEAK$,
-		 * 'I can''t move. I am stunned.'); else if (avatar.stun_count = 1) then
-		 * call p_msg_s(selfptr, selfptr, SPEAK$, 'I am still stunned.'); else
-		 * call p_msg_s(selfptr, selfptr, SPEAK$, 'The stun effect is wearing
-		 * off now.'); return; end; else do; call check_path(THE_REGION, x, y,
-		 * destination_x, destination_y, flip_path); if (flip_path) then call
-		 * set_bit(walk_how, 8); else call clear_bit(walk_how, 8); if
-		 * (destination_x ^= self.x | destination_y ^= self.y) then do; self.x =
-		 * destination_x; self.y = destination_y; call n_msg_3(selfptr, WALK$,
-		 * destination_x, destination_y, walk_how); end; end; call
-		 * r_msg_3(destination_x, destination_y, walk_how);
-		 */
-		int destination_x = x.value(80);
-		int destination_y = y.value(10) | FOREGROUND_BIT;
-		int walk_how = how.value(0);
+        trace_msg("Avatar %s called objectIsComplete, transition_type=%d", obj_id(), transition_type);
+        if (transition_type == WALK_ENTRY) {
+            y &= ~FOREGROUND_BIT;
+            rotation = (from_orientation - current_region().orientation + 4) % 4;
+            arrival_face = (from_direction + rotation + 2) % 4;
+            if (arrival_face == 0) {
+                new_x = XLEFT;
+                new_activity = FACE_RIGHT;
+                if (rotation == 0)
+                    new_y = y;
+                else if (rotation == 1)
+                    new_y = x_scale(x_invert(x));
+                else if (rotation == 2)
+                    new_y = y_invert(y);
+                else
+                    new_y = x_scale(x);
+            } else if (arrival_face == 1) {
+                new_y = current_region().depth;
+                new_activity = FACE_FRONT;
+                if (rotation == 0)
+                    new_x = x;
+                else if (rotation == 1)
+                    new_x = y_scale(y);
+                else if (rotation == 2)
+                    new_x = x_invert(x);
+                else
+                    new_x = y_scale(y_invert(y));
+                HabitatMod noids[] = current_region().noids;
+                for (int i=0; i < noids.length; i++) {
+                    HabitatMod obj = noids[i];
+                    if (noids[i] != null) {
+                        if (obj.HabitatClass() == CLASS_DOOR) {
+                            Door door = (Door) obj;
+                            if (door.connection.equals(from_region) || door.connection.isEmpty()) {
+                                new_y = obj.y;
+                                new_x = obj.x + DOOR_OFFSET;
+                                if (test_bit(obj.orientation, 1))
+                                    new_x = new_x - 16;
+                            }                    
+                        } else if (obj.HabitatClass() == CLASS_BUILDING) {
+                            Building bldg = (Building) obj;
+                            if (bldg.connection == from_region || bldg.connection.isEmpty()) {
+                                new_x = obj.x + BUILDING_OFFSET;
+                            }
+                        }
+                    }
+                }
+            } else if (arrival_face == 2) {
+                new_x = XRIGHT;
+                new_activity = FACE_LEFT;
+                if (rotation == 0)
+                    new_y = y;
+                else if (rotation == 1)
+                    new_y = x_scale(x_invert(x));
+                else if (rotation == 2)
+                    new_y = y_invert(y);
+                else
+                    new_y = x_scale(x);
+            } else {
+                new_y = YDOWN;
+                new_activity = FACE_BACK;
+                if (rotation == 0)
+                    new_x = x;
+                else if (rotation == 1)
+                    new_x = y_scale(y);
+                else if (rotation == 2)
+                    new_x = x_invert(x);
+                else
+                    new_x = y_scale(y_invert(y));
+            }
+            x = new_x & 0b11111100;
+            y = Math.min((new_y & ~FOREGROUND_BIT), current_region().depth) | FOREGROUND_BIT;
+            activity = new_activity;
+        } else if (transition_type == TELEPORT_ENTRY) {
+            // If entering via teleport, make sure we're in foreground
+            y |= FOREGROUND_BIT;
+        } else {
+            trace_msg("ENTRY ERROR: uUnknown transition type: " + transition_type);
+        }
+        
+    }
+    
+    private int x_invert(int x) {
+        return (XMAX - x);         
+    }
+    
+    
+    private int y_invert(int y) {
+        return(current_region().depth - y);
+    }
+    
+    private int x_scale(int x) {
+        double scale = current_region().depth / XMAXFLOAT;
+        return ((int) scale);
+    }
+    
+    private int y_scale(int y) {
+        double scale = XMAXFLOAT / current_region().depth;
+        return ((int) scale);
+    }
+    
+    
+    
+    /*        
+         // If entering on death, penalize the Avatar's tokens, if any 
+         else if (transition_type = DEATH_ENTRY) then do;
+              do i = 0 to 255;
+                   tokenptr = ObjList(i);
+                   if (tokenptr ^= null()) then do;
+                        if (token.class = CLASS_TOKENS) then do;
+                             denom = token.denom_lo + token.denom_hi*256;
+                             denom = divide(denom, 2, 15);
+                             token.denom_hi = divide(denom, 256, 15);
+                             token.denom_lo = mod(denom, 256);
+                             if (denom = 0) then
+                                  token.denom_lo = 1;
+                             token.gen_flags(MODIFIED) = true;
+                        end;
+                   end;
+              end;
+         end;
+        
+         // If entering via teleport, make sure we're in foreground 
+         else if (transition_type = TELEPORT_ENTRY) then do;
+              call set_bit(avatar.y, 8);
+         end; else do;
+              call trace_msg('entry daemon: unknown transition type: ' ||
+                   ltrim(transition_type));
+         end;
+     */
+    
+    /**
+     * Verb (Specific): TODO Grabbing from another avatar.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod
+    public void GRAB(User from) {
+        unsupported_reply(from, noid, "Avatar.GRAB not implemented yet.");
+    }
+    
+    /**
+     * Verb (Specific): TODO Handing in-hand item to another avatar.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod
+    public void HAND(User from) {
+        unsupported_reply(from, noid, "Avatar.HAND not implemented yet.");
+    }
+    
+    /**
+     * Verb (Specific): TODO Change this avatar's posture.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod({ "pose" })
+    public void POSTURE(User from, OptInteger pose) {
+        int new_posture = pose.value(STAND_FRONT);
+        // if (selfptr == avatarptr) { TODO Bullet Proofing Needed
+        if (0 <= new_posture && new_posture < 256) {
+            if (new_posture == SIT_GROUND || new_posture == SIT_CHAIR || new_posture == SIT_FRONT
+                    || new_posture == STAND || new_posture == STAND_FRONT || new_posture == STAND_LEFT
+                    || new_posture == STAND_RIGHT || new_posture == FACE_LEFT || new_posture == FACE_RIGHT) {
+                this.activity = new_posture;
+            }
+            if (new_posture != COLOR_POSTURE) {
+                send_neighbor_msg(from, noid, "POSTURE$", "new_posture", new_posture);
+            }
+            if (new_posture < STAND_LEFT || new_posture == COLOR_POSTURE) {
+                send_reply_success(from);
+            }
+        }
+        // }
+    }
+    
+    /**
+     * Verb (Specific): TODO Speak to the region/ESP to another user
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     * @param esp
+     *            Byte flag indicating that ESP message mode is active on the
+     *            client.
+     * @param text
+     *            The string to speak...
+     */
+    @JSONMethod({ "esp", "text" })
+    public void SPEAK(User from, OptInteger esp, OptString text) {
+        int in_esp = esp.value(FALSE);
+        /* TODO ESP logic Missing */
+        send_broadcast_msg(this.noid, "SPEAK$", text.value("(missing text)"));
+        send_reply_msg(from, this.noid, "esp", in_esp);
+    }
+    
+    /**
+     * Verb (Specific): TODO Walk across the region.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod({ "x", "y", "how" })
+    public void WALK(User from, OptInteger x, OptInteger y, OptInteger how) {
+        
+        // object_say(from, noid, "Avatar.WALK not implemented yet.");
+        
+        /*
+         * declare destination_x binary(15); declare destination_y binary(15);
+         * declare flip_path bit(1) aligned;
+         * 
+         * x = rank(request(FIRST)); y = rank(request(SECOND)); walk_how =
+         * rank(request(THIRD)); if (selfptr ^= avatarptr) then do;
+         * destination_x = avatar.x; destination_y = avatar.y; end; else if
+         * (avatar.stun_count > 0) then do; avatar.stun_count =
+         * avatar.stun_count - 1; call r_msg_3(avatar.x, avatar.y, walk_how); if
+         * (avatar.stun_count >= 2) then call p_msg_s(selfptr, selfptr, SPEAK$,
+         * 'I can''t move. I am stunned.'); else if (avatar.stun_count = 1) then
+         * call p_msg_s(selfptr, selfptr, SPEAK$, 'I am still stunned.'); else
+         * call p_msg_s(selfptr, selfptr, SPEAK$, 'The stun effect is wearing
+         * off now.'); return; end; else do; call check_path(THE_REGION, x, y,
+         * destination_x, destination_y, flip_path); if (flip_path) then call
+         * set_bit(walk_how, 8); else call clear_bit(walk_how, 8); if
+         * (destination_x ^= self.x | destination_y ^= self.y) then do; self.x =
+         * destination_x; self.y = destination_y; call n_msg_3(selfptr, WALK$,
+         * destination_x, destination_y, walk_how); end; end; call
+         * r_msg_3(destination_x, destination_y, walk_how);
+         */
+        int destination_x = x.value(80);
+        int destination_y = y.value(10) | FOREGROUND_BIT;
+        int walk_how = how.value(0);
 
-		if (stun_count > 0) {
-			stun_count -= 1;
-			send_reply_msg(from, this.noid, "x", this.x, "y", this.y, "how", walk_how);
-			if (stun_count >= 2) {
-				send_private_msg(from, this.noid, from, "SPEAK$", "I can't move.  I am stunned.");
-			} else if (stun_count == 1) {
-				send_private_msg(from, this.noid, from, "SPEAK$", "I am still stunned.");
-			} else {
-				send_private_msg(from, this.noid, from, "SPEAK$", "The stun effect is wearing off now.");
-			}
-			checkpoint_object(this);
-			return;
-		}
+        if (stun_count > 0) {
+            stun_count -= 1;
+            send_reply_msg(from, this.noid, "x", this.x, "y", this.y, "how", walk_how);
+            if (stun_count >= 2) {
+                send_private_msg(from, this.noid, from, "SPEAK$", "I can't move.  I am stunned.");
+            } else if (stun_count == 1) {
+                send_private_msg(from, this.noid, from, "SPEAK$", "I am still stunned.");
+            } else {
+                send_private_msg(from, this.noid, from, "SPEAK$", "The stun effect is wearing off now.");
+            }
+            checkpoint_object(this);
+            return;
+        }
 
-		if ((destination_y & ~FOREGROUND_BIT) > current_region().depth) {
-			destination_y = current_region().depth | FOREGROUND_BIT;
-		}
-		
-		send_neighbor_msg(from, this.noid, "WALK$", "x", destination_x, "y", destination_y, "how", walk_how);
-		send_reply_msg(from, this.noid, "x", destination_x, "y", destination_y, "how", walk_how);
-		
-		this.x = destination_x;
-		this.y = destination_y;
-		checkpoint_object(this);
-	}
-	
-	/**
-	 * Verb (Specific): TODO Leave the region for another region.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	@JSONMethod({ "direction", "passage_id" })
-	public void NEWREGION(User from, OptInteger direction, OptInteger passage_id) {
-		avatar_NEWREGION(from, direction.value(1), passage_id.value(0));
-	}
-	
-	/**
-	 * Verb (Specific): TODO Turn to/from being a ghost.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	@JSONMethod
-	public void DISCORPORATE(User from) {
-		unsupported_reply(from, noid, "Avatar.DISCORPORATE not implemented yet.");
-	}
-	
-	/**
-	 * Verb (Specific): TODO Send a point-to-point message to another
-	 * user/avatar.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	@JSONMethod
-	public void ESP(User from) {
-		unsupported_reply(from, noid, "Avatar.ESP not implemented yet.");
-	}
-	
-	/**
-	 * Verb (Specific): TODO Sit down. [Stand up?]
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	@JSONMethod({"up_or_down", "seat_id"})
-	public void SITORSTAND(User from, int up_or_down, int seat_id) {
-		
+        if ((destination_y & ~FOREGROUND_BIT) > current_region().depth) {
+            destination_y = current_region().depth | FOREGROUND_BIT;
+        }
+        
+        send_neighbor_msg(from, this.noid, "WALK$", "x", destination_x, "y", destination_y, "how", walk_how);
+        send_reply_msg(from, this.noid, "x", destination_x, "y", destination_y, "how", walk_how);
+        
+        this.x = destination_x;
+        this.y = destination_y;
+        checkpoint_object(this);
+    }
+    
+    /**
+     * Verb (Specific): TODO Leave the region for another region.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod({ "direction", "passage_id" })
+    public void NEWREGION(User from, OptInteger direction, OptInteger passage_id) {
+        avatar_NEWREGION(from, direction.value(1), passage_id.value(0));
+    }
+    
+    /**
+     * Verb (Specific): TODO Turn to/from being a ghost.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod
+    public void DISCORPORATE(User from) {
+        unsupported_reply(from, noid, "Avatar.DISCORPORATE not implemented yet.");
+    }
+    
+    /**
+     * Verb (Specific): TODO Send a point-to-point message to another
+     * user/avatar.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod
+    public void ESP(User from) {
+        unsupported_reply(from, noid, "Avatar.ESP not implemented yet.");
+    }
+    
+    /**
+     * Verb (Specific): TODO Sit down. [Stand up?]
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod({"up_or_down", "seat_id"})
+    public void SITORSTAND(User from, int up_or_down, int seat_id) {
+    	
 //    	if (up_or_down <= SIT_DOWN) {		// TOFO FRF This is always for now until we can work with Elko for a fix.
 //            unsupported_reply(from, noid, "This furniture has a sign that reads 'Do not sit here. Under repair'.");
 //    		return;
 //    	}	
-	
-		/** Historically was avatar_SITORSTAND in original pl1 */
-		Region		region	= current_region();
-		Seating		seat	= (Seating) region.noids[seat_id];
-		int			slot	= -1;
-		if (seat != null) {
-			if (isSeating(seat)) {
-				if (up_or_down == STAND_UP) {
-					if (sittingIn == seat_id) {
-						slot = sittingSlot;
-						if (seat.sitters[slot] != noid) {
-							send_reply_msg(from, noid, "err", FALSE, "slot", 0);
-							return;
-						}
-						activity 			= STAND;
-						sittingIn			= 0;
-						seat.sitters[slot]	= 0;
-						gen_flags[MODIFIED] = true;    					
-						checkpoint_object(this);
+   	
+    	/** Historically was avatar_SITORSTAND in original pl1 */
+    	Region		region	= current_region();
+    	Seating		seat	= (Seating) region.noids[seat_id];
+    	int			slot	= -1;
+    	if (seat != null) {
+    		if (isSeating(seat)) {
+    			if (up_or_down == STAND_UP) {
+    				if (sittingIn == seat_id) {
+    					slot = sittingSlot;
+    					if (seat.sitters[slot] != noid) {
+    						send_reply_msg(from, noid, "err", FALSE, "slot", 0);
+    						return;
+    					}
+    					activity 			= STAND;
+    					sittingIn			= 0;
+    					seat.sitters[slot]	= 0;
+    					gen_flags[MODIFIED] = true;    					
+    					checkpoint_object(this);
 						send_reply_msg(from, noid, "err", TRUE, "slot", 0);
 						send_neighbor_msg(from, noid, "SIT$", "up_or_down", STAND_UP, "cont", seat_id, "slot", 0);
-						return;
-					}
-				} else {
-					Container cont = (Container) seat;
-					for (slot = 0; slot < cont.capacity(); slot++) {
-						if (cont.contents(slot) == null && seat.sitters[slot] == 0) {
-							if (sittingIn != 0) {
-								send_reply_msg(from, 0, "err", FALSE, "slot", 0);
-								return;
-							}
-							seat.sitters[slot]	= noid;
-							sittingIn		= seat.noid;
-							sittingSlot		= slot;
-							sittingAction	= ((seat.style & 1) == 1) ? AV_ACT_sit_chair : AV_ACT_sit_front;
-							send_reply_msg(from, noid, "err", TRUE, "slot", slot);
-							send_neighbor_msg(from, noid, "SIT$", "up_or_down", SIT_DOWN, "cont", seat_id, "slot", slot);
-							return;
-						}
-					}
-				}
-			}
-		}     
+    					return;
+    				}
+    			} else {
+    				Container cont = (Container) seat;
+    				for (slot = 0; slot < cont.capacity(); slot++) {
+    					if (cont.contents(slot) == null && seat.sitters[slot] == 0) {
+    						if (sittingIn != 0) {
+        						send_reply_msg(from, 0, "err", FALSE, "slot", 0);
+    							return;
+    						}
+    						seat.sitters[slot]	= noid;
+    						sittingIn		= seat.noid;
+    						sittingSlot		= slot;
+    						sittingAction	= ((seat.style & 1) == 1) ? AV_ACT_sit_chair : AV_ACT_sit_front;
+    						send_reply_msg(from, noid, "err", TRUE, "slot", slot);
+    						send_neighbor_msg(from, noid, "SIT$", "up_or_down", SIT_DOWN, "cont", seat_id, "slot", slot);
+    						return;
+    					}
+    				}
+    			}
+    		}
+    	}     
 		send_reply_msg(from, noid, "err", FALSE, "slot", 0);
-	}
+    }
 
 
 
-	
-	/**
-	 * Verb (Specific): TODO Touch another avatar.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	@JSONMethod
-	public void TOUCH(User from) {
-		unsupported_reply(from, noid, "Avatar.TOUCH not implemented yet.");
-	}
-	
-	/**
-	 * Verb (Specific): TODO Deal with FN Key presses.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	@JSONMethod({ "key", "target" })
-	public void FNKEY(User from, OptInteger key, OptInteger target) {
-		switch (key.value(0)) {
-			case 16: // F8
-				object_say(from, "        You are connected to          ");
-				object_say(from, "   The Neoclassical Habitat Server    ");
-				//                object_say(from, "                                     ".substring(BuildVersion.version.length())
-				//                       + BuildVersion.version + " ");
-				object_say(from, "    The MADE, The Museum of Arts &       Digital Entertainment, Oakland CA");
-				object_say(from, "                                      ");
-				object_say(from, "Open source - Join us! NeoHabitat.org ");
-				send_reply_success(from);
-				break;
-			case 11: // F3 & F4 (List last dozen users)
-			case 13: // F5 & F6 (Change Skin Color)
-			default:
-				unsupported_reply(from, noid, "Avatar.FNKEY not implemented yet.");
-				
-		}
-	}
-	
-	/**
-	 * Verb (Avatar): Reply with the HELP for this avatar.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	@JSONMethod
-	public void HELP(User from) {
-		avatar_IDENTIFY(from);
-	}
-	
-	/**
-	 * Alternate interface to avatar_IDENTIFY, passing this.noid as the missing
-	 * second argument.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 */
-	public void avatar_IDENTIFY(User from) {
-		avatar_IDENTIFY(from, this.noid);
-	}
-	
-	/**
-	 * A different message is returned depending on if this avatar is the "from"
-	 * user or another, the message returned will vary.
-	 * 
-	 * @param from
-	 *            User representing the connection making the request.
-	 * @param replyNoid
-	 *            which avatar.noid is the one getting the reply.
-	 */
-	public void avatar_IDENTIFY(User from, int replyNoid) {
-		User targetUser = (User) this.object();
-		String targetName = targetUser.name();
-		String avatarname = from.name();
-		Avatar avatar = avatar(from);
-		String result = "";
-		
-		if (avatar.noid == this.noid) {
-			result = "Your name is " + avatarname + ".  You are ";
-			if (avatar.stun_count > 0)
-				result = result + "stunned, and you are ";
-			if (avatar.health > 200)
-				result = result + "in the peak of health.";
-			else if (avatar.health > 150)
-				result = result + "in good health.";
-			else if (avatar.health > 100)
-				result = result + "in fair health.";
-			else if (avatar.health > 50)
-				result = result + "in poor health.";
-			else
-				result = result + "near death.";
-		} else {
-			send_private_msg(from, avatar.noid, targetUser, "SPEAK$", "I am " + avatarname);
-			// p_msg_s(from, avatar.noid, targetUser, SPEAK$, "I am " +
-			// avatarname);
-			/*
-			 * OBSOLETE CODE REFACTORED An Elko User == Connection, so there is
-			 * no Turned to Stone state. And since a Elko Habitat Avatar is
-			 * attached 1:1 to a Elko User, this code can never be true in this
-			 * server.
-			 * 
-			 * if (UserList(self.avatarslot)->u.online) result = "This is " +
-			 * targetName; else result = "Turned to stone: " + selfname;
-			 */
-			result = "This is " + targetName;
-		}
-		send_reply_msg(from, replyNoid, "text",
-				result); /* TODO is replyNoid right? */
-	}
-	
-	public void avatar_NEWREGION(User from, int direction, int passage_id) {
-		Region      region          = current_region();
-		String      new_region      = "";
-		int			entry_type		= WALK_ENTRY;
-		HabitatMod  passage         = region.noids[passage_id];
-		int         direction_index = (direction + region.orientation + 2) % 4;
-		
-		if (direction != AUTO_TELEPORT_DIR && passage_id != 0 &&
-				passage.HabitatClass() == CLASS_DOOR || 
-				passage.HabitatClass() == CLASS_BUILDING) {
-			
-			if (passage.HabitatClass() == CLASS_DOOR) {
-				Door door = (Door) passage;
-				if (!door.getOpenFlag(OPEN_BIT) || 
-						door.gen_flags[DOOR_AVATAR_RESTRICTED_BIT]) {
-					send_reply_error(from);
-					return;
-				} else {
-					new_region = door.connection;
-				}
-			} else {
-				new_region = ((Building) passage).connection;
-			}
-			
-		}
-		
-		else {
-			if (direction >= 0 && direction < 4) {
-				new_region = region.neighbors[direction_index]; // East,  West, North, South
-			} else {     // direction == AUTO_TELEPORT_DIR 
-				new_region = to_region;
-				entry_type = TELEPORT_ENTRY;
-				direction  = WEST; // TODO Randy needs to revisit this little hack to prevent a loop..
-			}
-		}
-		
-		if (!new_region.isEmpty()) {
-			send_neighbor_msg(from, THE_REGION, "WAITFOR_$", "who", this.noid);
-			send_reply_success(from);
-			change_regions(new_region, direction, entry_type);
-			return;
-		}       
-		object_say(from, "There is nowhere to go in that direction.");
-		send_reply_error(from); 
-	}
-	
-	public void change_regions(String contextRef, int direction, int type) {
-		Region	region		= current_region();
-		User	who			= (User) this.object();
+    
+    /**
+     * Verb (Specific): TODO Touch another avatar.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod
+    public void TOUCH(User from) {
+        unsupported_reply(from, noid, "Avatar.TOUCH not implemented yet.");
+    }
+    
+    /**
+     * Verb (Specific): TODO Deal with FN Key presses.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod({ "key", "target" })
+    public void FNKEY(User from, OptInteger key, OptInteger target) {
+        switch (key.value(0)) {
+            case 16: // F8
+                object_say(from, "        You are connected to          ");
+                object_say(from, "   The Neoclassical Habitat Server    ");
+                //                object_say(from, "                                     ".substring(BuildVersion.version.length())
+                //                       + BuildVersion.version + " ");
+                object_say(from, "    The MADE, The Museum of Arts &       Digital Entertainment, Oakland CA");
+                object_say(from, "                                      ");
+                object_say(from, "Open source - Join us! NeoHabitat.org ");
+                send_reply_success(from);
+                break;
+            case 11: // F3 & F4 (List last dozen users)
+            case 13: // F5 & F6 (Change Skin Color)
+            default:
+                unsupported_reply(from, noid, "Avatar.FNKEY not implemented yet.");
+                
+        }
+    }
+    
+    /**
+     * Verb (Avatar): Reply with the HELP for this avatar.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod
+    public void HELP(User from) {
+        avatar_IDENTIFY(from);
+    }
+    
+    /**
+     * Alternate interface to avatar_IDENTIFY, passing this.noid as the missing
+     * second argument.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     */
+    public void avatar_IDENTIFY(User from) {
+        avatar_IDENTIFY(from, this.noid);
+    }
+    
+    /**
+     * A different message is returned depending on if this avatar is the "from"
+     * user or another, the message returned will vary.
+     * 
+     * @param from
+     *            User representing the connection making the request.
+     * @param replyNoid
+     *            which avatar.noid is the one getting the reply.
+     */
+    public void avatar_IDENTIFY(User from, int replyNoid) {
+        User targetUser = (User) this.object();
+        String targetName = targetUser.name();
+        String avatarname = from.name();
+        Avatar avatar = avatar(from);
+        String result = "";
+        
+        if (avatar.noid == this.noid) {
+            result = "Your name is " + avatarname + ".  You are ";
+            if (avatar.stun_count > 0)
+                result = result + "stunned, and you are ";
+            if (avatar.health > 200)
+                result = result + "in the peak of health.";
+            else if (avatar.health > 150)
+                result = result + "in good health.";
+            else if (avatar.health > 100)
+                result = result + "in fair health.";
+            else if (avatar.health > 50)
+                result = result + "in poor health.";
+            else
+                result = result + "near death.";
+        } else {
+            send_private_msg(from, avatar.noid, targetUser, "SPEAK$", "I am " + avatarname);
+            // p_msg_s(from, avatar.noid, targetUser, SPEAK$, "I am " +
+            // avatarname);
+            /*
+             * OBSOLETE CODE REFACTORED An Elko User == Connection, so there is
+             * no Turned to Stone state. And since a Elko Habitat Avatar is
+             * attached 1:1 to a Elko User, this code can never be true in this
+             * server.
+             * 
+             * if (UserList(self.avatarslot)->u.online) result = "This is " +
+             * targetName; else result = "Turned to stone: " + selfname;
+             */
+            result = "This is " + targetName;
+        }
+        send_reply_msg(from, replyNoid, "text",
+                result); /* TODO is replyNoid right? */
+    }
+    
+    public void avatar_NEWREGION(User from, int direction, int passage_id) {
+        Region      region          = current_region();
+        String      new_region      = "";
+        int			entry_type		= WALK_ENTRY;
+        HabitatMod  passage         = region.noids[passage_id];
+        int         direction_index = (direction + region.orientation + 2) % 4;
+        
+        if (direction != AUTO_TELEPORT_DIR && passage_id != 0 &&
+                passage.HabitatClass() == CLASS_DOOR || 
+                passage.HabitatClass() == CLASS_BUILDING) {
+            
+            if (passage.HabitatClass() == CLASS_DOOR) {
+                Door door = (Door) passage;
+                if (!door.getOpenFlag(OPEN_BIT) || 
+                        door.gen_flags[DOOR_AVATAR_RESTRICTED_BIT]) {
+                    send_reply_error(from);
+                    return;
+                } else {
+                    new_region = door.connection;
+                }
+            } else {
+                new_region = ((Building) passage).connection;
+            }
+            
+        }
+        
+        else {
+            if (direction >= 0 && direction < 4) {
+                new_region = region.neighbors[direction_index]; // East,  West, North, South
+            } else {     // direction == AUTO_TELEPORT_DIR 
+            	new_region = to_region;
+            	entry_type = TELEPORT_ENTRY;
+            	direction  = WEST; // TODO Randy needs to revisit this little hack to prevent a loop..
+            }
+        }
+        
+        if (!new_region.isEmpty()) {
+            send_neighbor_msg(from, THE_REGION, "WAITFOR_$", "who", this.noid);
+            send_reply_success(from);
+            change_regions(new_region, direction, entry_type);
+            return;
+        }       
+        object_say(from, "There is nowhere to go in that direction.");
+        send_reply_error(from); 
+    }
+    
+    public void change_regions(String contextRef, int direction, int type) {
+    	Region	region		= current_region();
+    	User	who			= (User) this.object();
 
-		trace_msg("Avatar %s changing regions to context=%s, direction=%d, type=%d", obj_id(),
-			contextRef, direction, type);
+        trace_msg("Avatar %s changing regions to context=%s, direction=%d, type=%d", obj_id(),
+            contextRef, direction, type);
 
-		// TODO change_regions exceptions! see region.pl1
-		
-		to_region			= contextRef;    	
-		from_region         = region.obj_id();     // Save exit information in avatar for use on arrival.
-		from_orientation    = region.orientation;
-		from_direction      = direction;
-		transition_type     = type;
-		gen_flags[MODIFIED] = true;
-		checkpoint_object(this);
-		
-		if (direction == AUTO_TELEPORT_DIR) {
-			send_private_msg(who, THE_REGION, who, "AUTO_TELEPORT_$", "direction", direction);
-		} else {
-			JSONLiteral msg = new JSONLiteral("changeContext", EncodeControl.forClient);
-			msg.addParameter("context", contextRef);
-			msg.finish();
-			who.send(msg);
-		}
-	}
-	
+    	// TODO change_regions exceptions! see region.pl1
+    	
+        to_region			= contextRef;    	
+        from_region         = region.obj_id();     // Save exit information in avatar for use on arrival.
+        from_orientation    = region.orientation;
+        from_direction      = direction;
+        transition_type     = type;
+        gen_flags[MODIFIED] = true;
+        checkpoint_object(this);
+        
+    	if (direction == AUTO_TELEPORT_DIR) {
+    		send_private_msg(who, THE_REGION, who, "AUTO_TELEPORT_$", "direction", direction);
+    	} else {
+    		JSONLiteral msg = new JSONLiteral("changeContext", EncodeControl.forClient);
+    		msg.addParameter("context", contextRef);
+    		msg.finish();
+    		who.send(msg);
+    	}
+    }
+    
 	public void drop_object_in_hand() {
 		if (contents(HANDS) != null) {
 			HabitatMod obj = contents(HANDS);
@@ -800,4 +800,5 @@ public class Avatar extends Container implements UserMod {
 				"y", obj.y);
 		}
 	}
+
 }

--- a/src/main/java/org/made/neohabitat/mods/Club.java
+++ b/src/main/java/org/made/neohabitat/mods/Club.java
@@ -4,24 +4,23 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
-import org.made.neohabitat.HabitatMod;
+import org.made.neohabitat.Weapon;
 
 /**
- * Habitat Window Mod
+ * Habitat Club Mod
  *
- * Windows don't really do much, only responding to HELP messages and serving a
- * decorative purpose.
+ * This is very similar to the Knife mod, a non-ranged melee weapon.
  *
  * @author steve
  */
-public class Window extends HabitatMod {
+public class Club extends Weapon {
 
     public int HabitatClass() {
-        return CLASS_WINDOW;
+        return CLASS_CLUB;
     }
 
     public String HabitatModName() {
-        return "Window";
+        return "Club";
     }
 
     public int capacity() {
@@ -45,7 +44,7 @@ public class Window extends HabitatMod {
     }
 
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
-    public Window(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
+    public Club(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
 

--- a/src/main/java/org/made/neohabitat/mods/Gun.java
+++ b/src/main/java/org/made/neohabitat/mods/Gun.java
@@ -4,56 +4,57 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
-import org.made.neohabitat.HabitatMod;
+import org.made.neohabitat.Weapon;
 
 /**
- * Habitat Window Mod
- *
- * Windows don't really do much, only responding to HELP messages and serving a
- * decorative purpose.
- *
+ * Habitat Gun Mod
+ * 
+ * With this mod, you've got two tickets to the gun show.  It's a ranged weapon
+ * allowing for ranged attacks on either Avatars or damageable objects (currently
+ * just mailboxes).
+ * 
  * @author steve
  */
-public class Window extends HabitatMod {
-
+public class Gun extends Weapon {
+    
     public int HabitatClass() {
-        return CLASS_WINDOW;
+        return CLASS_GUN;
     }
-
+    
     public String HabitatModName() {
-        return "Window";
+        return "Gun";
     }
-
+    
     public int capacity() {
         return 0;
     }
-
+    
     public int pc_state_bytes() {
         return 0;
     };
-
+    
     public boolean known() {
         return true;
     }
-
+    
     public boolean opaque_container() {
         return false;
     }
-
+    
     public boolean filler() {
         return false;
     }
-
+    
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
-    public Window(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
+    public Gun(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-
+    
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));
         result.finish();
         return result;
     }
-
+    
 }

--- a/src/main/java/org/made/neohabitat/mods/Knife.java
+++ b/src/main/java/org/made/neohabitat/mods/Knife.java
@@ -4,56 +4,56 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
-import org.made.neohabitat.HabitatMod;
+import org.made.neohabitat.Weapon;
 
 /**
- * Habitat Window Mod
- *
- * Windows don't really do much, only responding to HELP messages and serving a
- * decorative purpose.
- *
+ * Habitat Knife Mod
+ * 
+ * This is very similar to the Gun mod, except that the Avatar using it must
+ * be standing adjacent to the Avatar or object they wish to damage.
+ * 
  * @author steve
  */
-public class Window extends HabitatMod {
-
+public class Knife extends Weapon {
+    
     public int HabitatClass() {
-        return CLASS_WINDOW;
+        return CLASS_KNIFE;
     }
-
+    
     public String HabitatModName() {
-        return "Window";
+        return "Knife";
     }
-
+    
     public int capacity() {
         return 0;
     }
-
+    
     public int pc_state_bytes() {
         return 0;
     };
-
+    
     public boolean known() {
         return true;
     }
-
+    
     public boolean opaque_container() {
         return false;
     }
-
+    
     public boolean filler() {
         return false;
     }
-
+    
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
-    public Window(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
+    public Knife(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-
+    
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));
         result.finish();
         return result;
     }
-
+    
 }

--- a/src/main/java/org/made/neohabitat/mods/Region.java
+++ b/src/main/java/org/made/neohabitat/mods/Region.java
@@ -82,7 +82,7 @@ public class Region extends Container implements ContextMod, Constants {
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "nitty_bits", "depth", "lighting", "town_dir", "port_dir", "neighbors" })
     Region(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
             OptInteger nitty_bits, OptInteger depth, OptInteger lighting, 
-            OptString town_dir, OptString port_dir, 
+            OptString town_dir, OptString port_dir,
             String[] neighbors) {
         super(style, x, y, orientation, gr_state);
         if (nitty_bits.value(-1) != -1) {

--- a/src/main/java/org/made/neohabitat/mods/Stun_gun.java
+++ b/src/main/java/org/made/neohabitat/mods/Stun_gun.java
@@ -18,75 +18,74 @@ import org.made.neohabitat.HabitatMod;
  */
 public class Stun_gun extends HabitatMod {
 
-    public int HabitatClass() {
-        return CLASS_STUN_GUN;
-    }
+	public int HabitatClass() {
+		return CLASS_STUN_GUN;
+	}
 
-    public String HabitatModName() {
-        return "Stun_gun";
-    }
+	public String HabitatModName() {
+		return "Stun_gun";
+	}
 
-    public int capacity() {
-        return 0;
-    }
+	public int capacity() {
+		return 0;
+	}
 
-    public int pc_state_bytes() {
-        return 0;
-    };
+	public int pc_state_bytes() {
+		return 0;
+	};
 
-    public boolean known() {
-        return true;
-    }
+	public boolean known() {
+		return true;
+	}
 
-    public boolean opaque_container() {
-        return false;
-    }
+	public boolean opaque_container() {
+		return false;
+	}
 
-    public boolean filler() {
-        return false;
-    }
+	public boolean filler() {
+		return false;
+	}
 
-    @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
-    public Stun_gun(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
-                     OptInteger gr_state) {
-        super(style, x, y, orientation, gr_state);
-    }
+	@JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
+	public Stun_gun(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
+					 OptInteger gr_state) {
+		super(style, x, y, orientation, gr_state);
+	}
 
-    @Override
-    public JSONLiteral encode(EncodeControl control) {
-        JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));
-        result.finish();
-        return result;
-    }
+	@Override
+	public JSONLiteral encode(EncodeControl control) {
+		JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));
+		result.finish();
+		return result;
+	}
 
-    @JSONMethod
-    public void HELP(User from) {
-        generic_HELP(from);
-    }
+	@JSONMethod
+	public void HELP(User from) {
+		generic_HELP(from);
+	}
 
-    @JSONMethod
-    public void GET(User from) {
-        generic_GET(from);
-    }
+	@JSONMethod
+	public void GET(User from) {
+		generic_GET(from);
+	}
 
-    @JSONMethod({ "containerNoid", "x", "y", "orientation" })
-    public void PUT(User from, OptInteger containerNoid, OptInteger x, OptInteger y, OptInteger orientation) {
-        generic_PUT(from, containerNoid.value(THE_REGION), avatar(from).x, avatar(from).y, avatar(from).orientation);
-    }
+	@JSONMethod({ "containerNoid", "x", "y", "orientation" })
+	public void PUT(User from, OptInteger containerNoid, OptInteger x, OptInteger y, OptInteger orientation) {
+		generic_PUT(from, containerNoid.value(THE_REGION), avatar(from).x, avatar(from).y, avatar(from).orientation);
+	}
 
-
-    @JSONMethod({ "target" })
-    public void STUN(User from, int target) {
-        HabitatMod targetMod = current_region().noids[target];
-        Avatar avatar = avatar(from);
-        if (holding(avatar, this) && targetMod.HabitatClass() == CLASS_AVATAR) {
-            Avatar avatarTarget = (Avatar) targetMod;
-            avatarTarget.stun_count = 3;
-            send_neighbor_msg(from, avatar.noid, "ATTACK$",
-                "ATTACK_TARGET", target,
-                "ATTACK_DAMAGE", 0);
-            send_reply_success(from);
-        }
-    }
+	@JSONMethod({ "target" })
+	public void STUN(User from, int target) {
+		HabitatMod targetMod = current_region().noids[target];
+		Avatar avatar = avatar(from);
+		if (holding(avatar, this) && targetMod.HabitatClass() == CLASS_AVATAR) {
+			Avatar avatarTarget = (Avatar) targetMod;
+			avatarTarget.stun_count = 3;
+			send_neighbor_msg(from, avatar.noid, "ATTACK$",
+				"ATTACK_TARGET", target,
+				"ATTACK_DAMAGE", 0);
+			send_reply_success(from);
+		}
+	}
 
 }

--- a/src/main/java/org/made/neohabitat/mods/Stun_gun.java
+++ b/src/main/java/org/made/neohabitat/mods/Stun_gun.java
@@ -1,0 +1,92 @@
+package org.made.neohabitat.mods;
+
+import org.elkoserver.foundation.json.JSONMethod;
+import org.elkoserver.foundation.json.OptInteger;
+import org.elkoserver.json.EncodeControl;
+import org.elkoserver.json.JSONLiteral;
+import org.elkoserver.server.context.User;
+import org.made.neohabitat.HabitatMod;
+
+
+/**
+ * Habitat Stun Gun Mod
+ *
+ * Stun guns will stun an Avatar, rendering them unable to use weapons
+ * for a period of time.
+ *
+ * @author steve
+ */
+public class Stun_gun extends HabitatMod {
+
+    public int HabitatClass() {
+        return CLASS_STUN_GUN;
+    }
+
+    public String HabitatModName() {
+        return "Stun_gun";
+    }
+
+    public int capacity() {
+        return 0;
+    }
+
+    public int pc_state_bytes() {
+        return 0;
+    };
+
+    public boolean known() {
+        return true;
+    }
+
+    public boolean opaque_container() {
+        return false;
+    }
+
+    public boolean filler() {
+        return false;
+    }
+
+    @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
+    public Stun_gun(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
+                     OptInteger gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public JSONLiteral encode(EncodeControl control) {
+        JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));
+        result.finish();
+        return result;
+    }
+
+    @JSONMethod
+    public void HELP(User from) {
+        generic_HELP(from);
+    }
+
+    @JSONMethod
+    public void GET(User from) {
+        generic_GET(from);
+    }
+
+    @JSONMethod({ "containerNoid", "x", "y", "orientation" })
+    public void PUT(User from, OptInteger containerNoid, OptInteger x, OptInteger y, OptInteger orientation) {
+        generic_PUT(from, containerNoid.value(THE_REGION), avatar(from).x, avatar(from).y, avatar(from).orientation);
+    }
+
+
+    @JSONMethod({ "target" })
+    public void STUN(User from, int target) {
+        HabitatMod targetMod = current_region().noids[target];
+        Avatar avatar = avatar(from);
+        if (holding(avatar, this) && targetMod.HabitatClass() == CLASS_AVATAR) {
+            Avatar avatarTarget = (Avatar) targetMod;
+            avatarTarget.stun_count = 3;
+            send_neighbor_msg(from, avatar.noid, "ATTACK$",
+                "ATTACK_TARGET", target,
+                "ATTACK_DAMAGE", 0);
+            send_reply_success(from);
+        }
+    }
+
+}

--- a/src/main/java/org/made/neohabitat/mods/Tokens.java
+++ b/src/main/java/org/made/neohabitat/mods/Tokens.java
@@ -50,8 +50,8 @@ public class Tokens extends HabitatMod {
     
 
     /** denom_hi * 256 + denom_lo is the value of this token., 0 value tokens will self-destruct */
-    private	int	denom_lo	= 0;
-    private int denom_hi	= 0;
+    public int denom_lo = 0;
+    public int denom_hi = 0;
     
     /**
      * Get the value of the token.

--- a/test/shoot.elko
+++ b/test/shoot.elko
@@ -1,0 +1,5 @@
+
+{"to":"gun","op":"ATTACK","pointed_noid":"$pcollins.noid", "Telko": { "delay": 2 }}
+{"to":"gun","op":"ATTACK","pointed_noid":"$pcollins.noid", "Telko": { "delay": 2 }}
+{"to":"gun","op":"ATTACK","pointed_noid":"$pcollins.noid", "Telko": { "delay": 2 }}
+{"to":"gun","op":"ATTACK","pointed_noid":"$pcollins.noid", "Telko": { "delay": 2 }}


### PR DESCRIPTION
It's about time we added a touch of spice to Habitat, so this PR includes the implementations for four different types of weapon objects: **Gun**, **Knife**, **Club**, and **Stun_gun**.  Gun, Knife, and Club all derive from a toplevel class called **Weapon**.

Each of these works as you'd expect, and Avatars are penalized both by the tokens held and their bank balance upon death, as in the original.

Please note: this change introduces a few minor differences from the PL/1 code for Elko compatibility purposes:

*  During a DEATH_ENTRY, objectIsComplete is not called; the token penalization logic has therefore been added to kill_avatar alongside the bank balance reduction logic.  As you'll see below, this logic works as expected.
*  Upon Avatar death, the Avatar will drop anything it is carrying into the current_region before teleporting to their turf.  In the original PL/1, the CHANGE_CONTAINER_$ broadcast message is called before the DB-specific change_container is called.  During testing, I found that Avatars would still be holding a copy of the object they dropped upon reanimation, so this ordering has been inverted.  After extensive testing, I found this change to conclusively correct this problem.
*  The logic in damage_avatar() performs the damage decrement immediately then checks for bounding; the original PL/1 code was written to handle the unique integer signing behavior of the language.

This change was added to support token penalization:

*  The visibility on the Tokens class' denom_hi and denom_lo fields has been changed to public from private.

This functionality has been extensively tested via dual-client functional testing:

![screen shot 2017-02-16 at 7 19 06 pm](https://cloud.githubusercontent.com/assets/15283/23056341/dd22b5d2-f49f-11e6-9c38-4fdf9aa26b38.png)
![screen shot 2017-02-16 at 10 07 07 pm](https://cloud.githubusercontent.com/assets/15283/23056345/e1dfffb2-f49f-11e6-961f-4f8fb605bdbd.png)
![screen shot 2017-02-16 at 10 08 08 pm](https://cloud.githubusercontent.com/assets/15283/23056348/e343953a-f49f-11e6-87c4-204e8f59d5ed.png)
![screen shot 2017-02-16 at 10 20 16 pm](https://cloud.githubusercontent.com/assets/15283/23056350/e4d710f2-f49f-11e6-83ca-b9746b3a89ce.png)
![screen shot 2017-02-16 at 10 32 56 pm](https://cloud.githubusercontent.com/assets/15283/23056351/e5d4eac4-f49f-11e6-9abb-8391033d254f.png)
![screen shot 2017-02-16 at 11 53 59 pm](https://cloud.githubusercontent.com/assets/15283/23057076/5734cf06-f4a3-11e6-8117-24ed11760601.png)

Finally, this branch adds remote debugger support to the ```run``` script and enhances trace_msg() with variadic format parameters.

Let me know what you think, and thanks for the consideration!