### PR TITLE
Adds explicit constructors and Copyable interface and implementation to all current mods

### DIFF
--- a/bridge/Habitat2ElkoBridge.js
+++ b/bridge/Habitat2ElkoBridge.js
@@ -723,7 +723,12 @@ var encodeState = {
 			}
 			var bal = state.bankBalance ||  0;
 			buf.add(state.terrain_type	||  0);
-			buf.add(state.lighting		||  1);
+			// Sets default Region lighting at 1 if no lighting specified.
+			if (state.lighting === undefined) {
+				buf.add(1);
+			} else {
+				buf.add(state.lighting);
+			}
 			buf.add(state.depth			|| 32);
 			buf.add(state.region_class	||  0);
 			buf.add(state.Who_am_I		|| -1);    	

--- a/db/Back4t/back4t_01.json
+++ b/db/Back4t/back4t_01.json
@@ -15,7 +15,7 @@
           "context-library", 
           "context-back4t_11"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_02.json
+++ b/db/Back4t/back4t_02.json
@@ -15,7 +15,7 @@
           "context-back4t_01", 
           "context-back4t_12"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_03.json
+++ b/db/Back4t/back4t_03.json
@@ -15,7 +15,7 @@
           "context-back4t_02", 
           "context-back4t_13"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_04.json
+++ b/db/Back4t/back4t_04.json
@@ -15,7 +15,7 @@
           "context-back4t_03", 
           "context-back4t_14"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_05.json
+++ b/db/Back4t/back4t_05.json
@@ -15,7 +15,7 @@
           "context-back4t_04", 
           "context-back4t_15"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_11.json
+++ b/db/Back4t/back4t_11.json
@@ -15,7 +15,7 @@
           "context-back4t_01", 
           "context-back4t_21"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_12.json
+++ b/db/Back4t/back4t_12.json
@@ -15,7 +15,7 @@
           "context-back4t_11", 
           "context-back4t_22"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_13.json
+++ b/db/Back4t/back4t_13.json
@@ -15,7 +15,7 @@
           "context-back4t_12", 
           "context-back4t_23"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_14.json
+++ b/db/Back4t/back4t_14.json
@@ -15,7 +15,7 @@
           "context-back4t_13", 
           "context-back4t_24"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_15.json
+++ b/db/Back4t/back4t_15.json
@@ -15,7 +15,7 @@
           "context-back4t_14", 
           "context-back4t_25"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_20.json
+++ b/db/Back4t/back4t_20.json
@@ -15,7 +15,7 @@
           "", 
           "context-back4t_30"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_21.json
+++ b/db/Back4t/back4t_21.json
@@ -15,7 +15,7 @@
           "context-back4t_20", 
           "context-back4t_31"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_22.json
+++ b/db/Back4t/back4t_22.json
@@ -15,7 +15,7 @@
           "context-back4t_21", 
           "context-back4t_32"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_23.json
+++ b/db/Back4t/back4t_23.json
@@ -15,7 +15,7 @@
           "context-back4t_22", 
           "context-back4t_33"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_24.json
+++ b/db/Back4t/back4t_24.json
@@ -15,7 +15,7 @@
           "", 
           "context-back4t_34"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_25.json
+++ b/db/Back4t/back4t_25.json
@@ -15,7 +15,7 @@
           "", 
           "context-back4t_35"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_30.json
+++ b/db/Back4t/back4t_30.json
@@ -15,7 +15,7 @@
           "", 
           ""
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_31.json
+++ b/db/Back4t/back4t_31.json
@@ -15,7 +15,7 @@
           "", 
           "context-back4t_41"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_32.json
+++ b/db/Back4t/back4t_32.json
@@ -15,7 +15,7 @@
           "context-back4t_31", 
           "context-back4t_42"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_33.json
+++ b/db/Back4t/back4t_33.json
@@ -15,7 +15,7 @@
           "context-back4t_32", 
           "context-back4t_43"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_34.json
+++ b/db/Back4t/back4t_34.json
@@ -15,7 +15,7 @@
           "context-back4t_33", 
           "context-back4t_44"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_35.json
+++ b/db/Back4t/back4t_35.json
@@ -15,7 +15,7 @@
           "context-back4t_34", 
           "context-back4t_45"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_41.json
+++ b/db/Back4t/back4t_41.json
@@ -15,7 +15,7 @@
           "context-back4t_51", 
           "context-back4t_51"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_42.json
+++ b/db/Back4t/back4t_42.json
@@ -15,7 +15,7 @@
           "context-back4t_41", 
           "context-back4t_52"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_43.json
+++ b/db/Back4t/back4t_43.json
@@ -15,7 +15,7 @@
           "context-back4t_42", 
           "context-back4t_53"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_44.json
+++ b/db/Back4t/back4t_44.json
@@ -15,7 +15,7 @@
           "context-back4t_43", 
           "context-back4t_54"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_45.json
+++ b/db/Back4t/back4t_45.json
@@ -15,7 +15,7 @@
           "context-back4t_44", 
           "context-back4t_55"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_51.json
+++ b/db/Back4t/back4t_51.json
@@ -15,7 +15,7 @@
           "context-back4t_41", 
           "context-back4t_61"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_52.json
+++ b/db/Back4t/back4t_52.json
@@ -15,7 +15,7 @@
           "context-back4t_51", 
           "context-back4t_62"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_53.json
+++ b/db/Back4t/back4t_53.json
@@ -15,7 +15,7 @@
           "context-back4t_52", 
           "context-back4t_63"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_54.json
+++ b/db/Back4t/back4t_54.json
@@ -15,7 +15,7 @@
           "context-back4t_53", 
           "context-back4t_64"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_55.json
+++ b/db/Back4t/back4t_55.json
@@ -15,7 +15,7 @@
           "context-back4t_54", 
           "context-back4t_65"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_56.json
+++ b/db/Back4t/back4t_56.json
@@ -15,7 +15,7 @@
           "context-back4t_55", 
           ""
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_61.json
+++ b/db/Back4t/back4t_61.json
@@ -15,7 +15,7 @@
           "context-back4t_71", 
           "context-back4t_71"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_62.json
+++ b/db/Back4t/back4t_62.json
@@ -15,7 +15,7 @@
           "context-back4t_61", 
           "context-back4t_72"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_63.json
+++ b/db/Back4t/back4t_63.json
@@ -15,7 +15,7 @@
           "context-back4t_62", 
           "context-back4t_73"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_64.json
+++ b/db/Back4t/back4t_64.json
@@ -15,7 +15,7 @@
           "context-back4t_63", 
           "context-back4t_74"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_65.json
+++ b/db/Back4t/back4t_65.json
@@ -15,7 +15,7 @@
           "context-back4t_64", 
           "context-back4t_75"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_71.json
+++ b/db/Back4t/back4t_71.json
@@ -15,7 +15,7 @@
           "context-back4t_61", 
           "context-back4t_72"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_72.json
+++ b/db/Back4t/back4t_72.json
@@ -15,7 +15,7 @@
           "context-back4t_71", 
           "context-back4t_71"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_73.json
+++ b/db/Back4t/back4t_73.json
@@ -15,7 +15,7 @@
           "context-back4t_72", 
           "context-back4t_74"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_74.json
+++ b/db/Back4t/back4t_74.json
@@ -15,7 +15,7 @@
           "context-back4t_73", 
           "context-back4t_73"
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Back4t/back4t_75.json
+++ b/db/Back4t/back4t_75.json
@@ -15,7 +15,7 @@
           "context-back4t_74", 
           ""
         ], 
-        "nitty_bits": 3
+        "nitty_bits": 2
       }
     ]
   }, 

--- a/db/Backroom/context-turf.json
+++ b/db/Backroom/context-turf.json
@@ -13,5 +13,5 @@
 			"orientation": 2,
 			"neighbors": ["", "", "", ""]
 		}
-		]
+	]
 }

--- a/regionator/region.py
+++ b/regionator/region.py
@@ -18,11 +18,13 @@ JSONEncoder.default = _default
 
 
 class Mod(object):
-  def __init__(self, region, identifier, params={}, additional_params={}):
+  def __init__(self, region, identifier, params={}, additional_params={},
+      contained_mods=[]):
     self.region = region
     self.identifier = identifier
     self.params = params
     self.additional_params = additional_params
+    self.contained_mods = contained_mods
     self.id = str(uuid.uuid4())[:4]
 
   def __repr__(self):

--- a/src/main/java/org/made/neohabitat/Coinop.java
+++ b/src/main/java/org/made/neohabitat/Coinop.java
@@ -24,6 +24,11 @@ public abstract class Coinop extends HabitatMod {
 		this.take = take.value(0);
 	}
 
+	public Coinop(int style, int x, int y, int orientation, int gr_state, int take) {
+		super(style, x, y, orientation, gr_state);
+		this.take = take;
+	}
+
 	public JSONLiteral encodeCoinop(JSONLiteral result) {
 		result = super.encodeCommon(result);
 		if (result.control().toRepository()) {

--- a/src/main/java/org/made/neohabitat/Container.java
+++ b/src/main/java/org/made/neohabitat/Container.java
@@ -32,7 +32,11 @@ public abstract class Container extends HabitatMod {
     public Container(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-    
+
+    public Container(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
     public JSONLiteral encodeContainer(JSONLiteral result) {
         result = super.encodeCommon(result);
         return result;

--- a/src/main/java/org/made/neohabitat/Copyable.java
+++ b/src/main/java/org/made/neohabitat/Copyable.java
@@ -1,0 +1,9 @@
+package org.made.neohabitat;
+
+/**
+ * If a Habitat mod implements this interface, it indicates that it can
+ * be copied.
+ */
+public interface Copyable {
+    HabitatMod copyThisMod();
+}

--- a/src/main/java/org/made/neohabitat/Document.java
+++ b/src/main/java/org/made/neohabitat/Document.java
@@ -33,7 +33,15 @@ public abstract class Document extends HabitatMod {
         this.last_page = (pages.length > 0) ? pages.length : last_page;
         this.path = path;
     }
-    
+
+    public Document(int style, int x, int y, int orientation, int gr_state, int last_page,
+        String[] pages, String path) {
+        super(style, x, y, orientation, gr_state);
+        this.pages = pages;
+        this.last_page = last_page;
+        this.path = path;
+    }
+
     public JSONLiteral encodeDocument(JSONLiteral result) {
         result = super.encodeCommon(result);
         result.addParameter("last_page", last_page);

--- a/src/main/java/org/made/neohabitat/Magical.java
+++ b/src/main/java/org/made/neohabitat/Magical.java
@@ -47,7 +47,19 @@ public abstract class Magical extends HabitatMod {
         this.magic_data4 = magic_data4.value(0);
         this.magic_data5 = magic_data5.value(0);
     }
-    
+
+    public Magical(int style, int x, int y, int orientation, int gr_state, int magic_type, int charges, int magic_data,
+        int magic_data2, int magic_data3, int magic_data4, int magic_data5) {
+        super(style, x, y, orientation, gr_state);
+        this.magic_type = magic_type;
+        this.charges = charges;
+        this.magic_data = magic_data;
+        this.magic_data2 = magic_data2;
+        this.magic_data3 = magic_data3;
+        this.magic_data4 = magic_data4;
+        this.magic_data5 = magic_data5;
+    }
+
     public JSONLiteral encodeMagical(JSONLiteral result) {
         result = super.encodeCommon(result);
         if (0 != magic_type) {

--- a/src/main/java/org/made/neohabitat/Massive.java
+++ b/src/main/java/org/made/neohabitat/Massive.java
@@ -25,7 +25,12 @@ public abstract class Massive extends HabitatMod {
         super(style, x, y, orientation, gr_state);
         this.mass = mass.value(0);
     }
-    
+
+    public Massive(int style, int x, int y, int orientation, int gr_state, int mass) {
+        super(style, x, y, orientation, gr_state);
+        this.mass = mass;
+    }
+
     public JSONLiteral encodeMassive(JSONLiteral result) {
         result = super.encodeCommon(result);
         

--- a/src/main/java/org/made/neohabitat/Openable.java
+++ b/src/main/java/org/made/neohabitat/Openable.java
@@ -54,7 +54,20 @@ public abstract class Openable extends Container {
         this.key_lo = key_lo.value(0);
         this.key_hi = key_hi.value(0);
     }
-    
+
+    public Openable(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags) {
+        super(style, x, y, orientation, gr_state);
+        this.open_flags = open_flags;
+    }
+
+    public Openable(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags,
+        int key_lo, int key_hi) {
+        super(style, x, y, orientation, gr_state);
+        this.open_flags = open_flags;
+        this.key_lo = key_lo;
+        this.key_hi = key_hi;
+    }
+
     public JSONLiteral encodeOpenable(JSONLiteral result) {
         result = super.encodeCommon(result);
         if (0 != packBits(open_flags)) {

--- a/src/main/java/org/made/neohabitat/Oracular.java
+++ b/src/main/java/org/made/neohabitat/Oracular.java
@@ -26,6 +26,11 @@ public abstract class Oracular extends HabitatMod {
 		this.live = live.value(0);
 	}
 
+	public Oracular(int style, int x, int y, int orientation, int gr_state, int live) {
+		super(style, x, y, orientation, gr_state);
+		this.live = live;
+	}
+
 	public JSONLiteral encodeOracular(JSONLiteral result) {
 		result = super.encodeCommon(result);
 		if (result.control().toRepository()) {

--- a/src/main/java/org/made/neohabitat/Polygonal.java
+++ b/src/main/java/org/made/neohabitat/Polygonal.java
@@ -35,7 +35,18 @@ public abstract class Polygonal extends HabitatMod {
         this.lower_right_x  = lower_right_x.value(0);
         this.height		    = height.value(0);
     }
-    
+
+    public Polygonal(int style, int x, int y, int orientation, int gr_state, int trapezoid_type, int upper_left_x,
+        int upper_right_x, int lower_left_x, int lower_right_x, int height) {
+        super(style, x, y, orientation, gr_state);
+        this.trapezoid_type = trapezoid_type;
+        this.upper_left_x	= upper_left_x;
+        this.upper_right_x	= upper_right_x;
+        this.lower_left_x   = lower_left_x;
+        this.lower_right_x  = lower_right_x;
+        this.height		    = height;
+    }
+
     public JSONLiteral encodePolygonal(JSONLiteral result) {
         result = super.encodeCommon(result);        
         result.addParameter("trapezoid_type", trapezoid_type);

--- a/src/main/java/org/made/neohabitat/Poster.java
+++ b/src/main/java/org/made/neohabitat/Poster.java
@@ -19,7 +19,7 @@ import org.elkoserver.json.JSONLiteral;
 public abstract class Poster extends HabitatMod {
 
 	/** The message to display on this sign */
-	private int ascii[];
+	protected int ascii[];
 	
 	public void setTextBytes(String text) {
 		for (int i = 0; i < text.length() && i < ascii.length; i++) {
@@ -37,6 +37,11 @@ public abstract class Poster extends HabitatMod {
 		} else {
 			System.arraycopy(ascii, 0, this.ascii, 0, Math.min(ascii.length, this.ascii.length));
 		}
+	}
+
+	public Poster(int style, int x, int y, int orientation, int gr_state, int[] ascii) {
+		super(style, x, y, orientation, gr_state);
+		this.ascii = ascii;
 	}
 
 	public JSONLiteral encodePoster(JSONLiteral result) {

--- a/src/main/java/org/made/neohabitat/Seating.java
+++ b/src/main/java/org/made/neohabitat/Seating.java
@@ -31,6 +31,10 @@ public abstract class Seating extends Openable {
 		super(style, x, y, orientation, gr_state, open_flags);
 	}
 
+	public Seating(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags) {
+		super(style, x, y, orientation, gr_state, open_flags);
+	}
+
 	public JSONLiteral encodeSeating(JSONLiteral result) {
 		result = super.encodeOpenable(result); 
 		if (result.control().toClient()) {

--- a/src/main/java/org/made/neohabitat/Switch.java
+++ b/src/main/java/org/made/neohabitat/Switch.java
@@ -27,7 +27,12 @@ public abstract class Switch extends HabitatMod {
         super(style, x, y, orientation, gr_state);
         this.on = on.value(FALSE);
     }
-    
+
+    public Switch(int style, int x, int y, int orientation, int gr_state, int on) {
+        super(style, x, y, orientation, gr_state);
+        this.on = on;
+    }
+
     /**
      * Change the state of a switch to OFF, and if it's a lighting source,
      * update the Region lighting level.

--- a/src/main/java/org/made/neohabitat/Walkable.java
+++ b/src/main/java/org/made/neohabitat/Walkable.java
@@ -24,12 +24,17 @@ public abstract class Walkable extends HabitatMod {
         super(style, x, y, orientation, gr_state);
         this.flat_type = flat_type;
     }
-    
+
     public Walkable(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
             OptInteger flat_type) {
         this(style, x, y, orientation, gr_state, flat_type.value(0));
     }
-    
+
+    public Walkable(int style, int x, int y, int orientation, int gr_state, int flat_type) {
+        super(style, x, y, orientation, gr_state);
+        this.flat_type = flat_type;
+    }
+
     public JSONLiteral encodeWalkable(JSONLiteral result) {
         result = super.encodeCommon(result);
         if (0 != flat_type) {

--- a/src/main/java/org/made/neohabitat/Weapon.java
+++ b/src/main/java/org/made/neohabitat/Weapon.java
@@ -34,6 +34,10 @@ public abstract class Weapon extends HabitatMod {
 		super(style, x, y, orientation, gr_state);
 	}
 
+	public Weapon(int style, int x, int y, int orientation, int gr_state) {
+		super(style, x, y, orientation, gr_state);
+	}
+
 	@JSONMethod
 	public void HELP(User from) {
 		generic_HELP(from);

--- a/src/main/java/org/made/neohabitat/mods/Atm.java
+++ b/src/main/java/org/made/neohabitat/mods/Atm.java
@@ -5,6 +5,7 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -15,7 +16,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class Atm extends HabitatMod {
+public class Atm extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_ATM;
@@ -48,6 +49,15 @@ public class Atm extends HabitatMod {
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
     public Atm(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
+    }
+
+    public Atm(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Atm(style, x, y, orientation, gr_state);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Avatar.java
+++ b/src/main/java/org/made/neohabitat/mods/Avatar.java
@@ -5,11 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.foundation.json.OptString;
 import org.elkoserver.server.context.User;
 import org.elkoserver.server.context.UserMod;
-import org.made.neohabitat.Container;
+import org.made.neohabitat.*;
 import org.made.neohabitat.mods.Door;
-import org.made.neohabitat.HabitatMod;
-import org.made.neohabitat.Magical;
-import org.made.neohabitat.Seating;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 
@@ -24,7 +21,7 @@ import org.elkoserver.json.JSONLiteral;
  *
  */
 
-public class Avatar extends Container implements UserMod {
+public class Avatar extends Container implements Copyable, UserMod {
     
     public static final int SIT_GROUND  = 132;
     public static final int SIT_CHAIR   = 133;
@@ -194,7 +191,38 @@ public class Avatar extends Container implements UserMod {
         this.turf = turf.value(DEFAULT_TURF);
         this.custom = custom;
     }
-    
+
+    public Avatar(int style, int x, int y, int orientation, int gr_state, boolean[] nitty_bits, String bodyType,
+        int stun_count, int bankBalance, int activity, int action, int health, int restrainer, int transition_type,
+        int from_orientation, int from_direction, String from_region, String to_region, int to_x, int to_y,
+        String turf, int[] custom) {
+        super(style, x, y, orientation, gr_state);
+        this.nitty_bits = nitty_bits;
+        this.bodyType = bodyType;
+        this.stun_count = stun_count;
+        this.bankBalance = bankBalance;
+        this.activity = activity;
+        this.action = action;
+        this.health = health;
+        this.restrainer = restrainer;
+        this.transition_type = transition_type;
+        this.from_orientation = from_orientation;
+        this.from_direction = from_direction;
+        this.from_region = from_region;
+        this.to_region = to_region;
+        this.to_x = to_x;
+        this.to_y = to_y;
+        this.turf = turf;
+        this.custom = custom;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Avatar(style, x, y, orientation, gr_state, nitty_bits, bodyType, stun_count, bankBalance, activity,
+            action, health, restrainer, transition_type, from_orientation, from_direction, from_region, to_region,
+            to_x, to_y, turf, custom);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Avatar.java
+++ b/src/main/java/org/made/neohabitat/mods/Avatar.java
@@ -21,7 +21,7 @@ import org.elkoserver.json.JSONLiteral;
  *
  */
 
-public class Avatar extends Container implements Copyable, UserMod {
+public class Avatar extends Container implements UserMod {
     
     public static final int SIT_GROUND  = 132;
     public static final int SIT_CHAIR   = 133;
@@ -214,13 +214,6 @@ public class Avatar extends Container implements Copyable, UserMod {
         this.to_y = to_y;
         this.turf = turf;
         this.custom = custom;
-    }
-
-    @Override
-    public HabitatMod copyThisMod() {
-        return new Avatar(style, x, y, orientation, gr_state, nitty_bits, bodyType, stun_count, bankBalance, activity,
-            action, health, restrainer, transition_type, from_orientation, from_direction, from_region, to_region,
-            to_x, to_y, turf, custom);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Bag.java
+++ b/src/main/java/org/made/neohabitat/mods/Bag.java
@@ -5,6 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 
 /**
@@ -16,7 +18,7 @@ import org.made.neohabitat.Openable;
  *
  */
 
-public class Bag extends Openable {
+public class Bag extends Openable implements Copyable {
     
     public int HabitatClass() {
         return CLASS_BAG;
@@ -51,7 +53,16 @@ public class Bag extends Openable {
             OptInteger open_flags, OptInteger key_lo, OptInteger key_hi) {
         super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
     }
-    
+
+    public Bag(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags, int key_lo, int key_hi) {
+        super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Bag(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeOpenable(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Bed.java
+++ b/src/main/java/org/made/neohabitat/mods/Bed.java
@@ -28,8 +28,8 @@ public class Bed extends Seating implements Copyable {
 
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "open_flags"})
     public Bed(OptInteger style, OptInteger x, OptInteger y,
-                 OptInteger orientation, OptInteger gr_state,
-                 OptInteger open_flags) {
+        OptInteger orientation, OptInteger gr_state,
+        OptInteger open_flags) {
         super(style, x, y, orientation, gr_state, open_flags);
     }
 

--- a/src/main/java/org/made/neohabitat/mods/Bed.java
+++ b/src/main/java/org/made/neohabitat/mods/Bed.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 import org.made.neohabitat.Seating;
 
@@ -14,7 +16,7 @@ import org.made.neohabitat.Seating;
  *
  * @author steve
  */
-public class Bed extends Seating {
+public class Bed extends Seating implements Copyable {
 
     public int		HabitatClass 	 () { return CLASS_BED; }
     public String	HabitatModName	 () { return "Bed"; }
@@ -29,6 +31,15 @@ public class Bed extends Seating {
                  OptInteger orientation, OptInteger gr_state,
                  OptInteger open_flags) {
         super(style, x, y, orientation, gr_state, open_flags);
+    }
+
+    public Bed(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags) {
+        super(style, x, y, orientation, gr_state, open_flags);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Bed(style, x, y, orientation, gr_state, open_flags);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Bottle.java
+++ b/src/main/java/org/made/neohabitat/mods/Bottle.java
@@ -5,6 +5,7 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -15,7 +16,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class Bottle extends HabitatMod {
+public class Bottle extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_BOTTLE;
@@ -52,6 +53,16 @@ public class Bottle extends HabitatMod {
         OptInteger gr_state, OptInteger filled) {
         super(style, x, y, orientation, gr_state);
         this.filled = filled.value(FALSE);
+    }
+
+    public Bottle(int style, int x, int y, int orientation, int gr_state, int filled) {
+        super(style, x, y, orientation, gr_state);
+        this.filled = filled;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Bottle(style, x, y, orientation, gr_state, filled);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Box.java
+++ b/src/main/java/org/made/neohabitat/mods/Box.java
@@ -5,6 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 
 /**
@@ -16,7 +18,7 @@ import org.made.neohabitat.Openable;
  *
  */
 
-public class Box extends Openable {
+public class Box extends Openable implements Copyable {
     
     public int HabitatClass() {
         return CLASS_BOX;
@@ -51,7 +53,16 @@ public class Box extends Openable {
             OptInteger open_flags, OptInteger key_lo, OptInteger key_hi) {
         super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
     }
-    
+
+    public Box(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags, int key_lo, int key_hi) {
+        super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Box(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeOpenable(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Building.java
+++ b/src/main/java/org/made/neohabitat/mods/Building.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -15,7 +16,7 @@ import org.made.neohabitat.HabitatMod;
  * @author randy
  *
  */
-public class Building extends HabitatMod {
+public class Building extends HabitatMod implements Copyable {
     
     public int HabitatClass() {
         return CLASS_BUILDING;
@@ -54,7 +55,17 @@ public class Building extends HabitatMod {
         super(style, x, y, orientation, gr_state);
         this.connection = connection;
     }
-    
+
+    public Building(int style, int x, int y, int orientation, int gr_state, String connection) {
+        super(style, x, y, orientation, gr_state);
+        this.connection = connection;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Building(style, x, y, orientation, gr_state, connection);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Bush.java
+++ b/src/main/java/org/made/neohabitat/mods/Bush.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -16,7 +17,7 @@ import org.made.neohabitat.HabitatMod;
  * @author randy
  *
  */
-public class Bush extends HabitatMod {
+public class Bush extends HabitatMod implements Copyable {
     
     public int HabitatClass() {
         return CLASS_BUSH;
@@ -50,7 +51,16 @@ public class Bush extends HabitatMod {
     public Bush(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-    
+
+    public Bush(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Bush(style, x, y, orientation, gr_state);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Chair.java
+++ b/src/main/java/org/made/neohabitat/mods/Chair.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 import org.made.neohabitat.Seating;
 
@@ -14,7 +16,7 @@ import org.made.neohabitat.Seating;
  *
  * @author steve
  */
-public class Chair extends Seating {
+public class Chair extends Seating implements Copyable {
 
     public int		HabitatClass 	 () { return CLASS_CHAIR; }
     public String	HabitatModName	 () { return "Chair"; }
@@ -26,9 +28,17 @@ public class Chair extends Seating {
 
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "open_flags"})
     public Chair(OptInteger style, OptInteger x, OptInteger y,
-                 OptInteger orientation, OptInteger gr_state,
-                 OptInteger open_flags) {
+        OptInteger orientation, OptInteger gr_state, OptInteger open_flags) {
         super(style, x, y, orientation, gr_state, open_flags);
+    }
+
+    public Chair(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags) {
+        super(style, x, y, orientation, gr_state, open_flags);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Chair(style, x, y, orientation, gr_state, open_flags);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Chest.java
+++ b/src/main/java/org/made/neohabitat/mods/Chest.java
@@ -5,6 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 
 /**
@@ -15,7 +17,7 @@ import org.made.neohabitat.Openable;
  *
  * @author steve
  */
-public class Chest extends Openable {
+public class Chest extends Openable implements Copyable {
 
     public int HabitatClass() {
         return CLASS_CHEST;
@@ -49,6 +51,15 @@ public class Chest extends Openable {
     public Chest(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
                  OptInteger open_flags, OptInteger key_lo, OptInteger key_hi) {
         super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+    }
+
+    public Chest(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags, int key_lo, int key_hi) {
+        super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Chest(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Club.java
+++ b/src/main/java/org/made/neohabitat/mods/Club.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Weapon;
 
 /**
@@ -13,7 +15,7 @@ import org.made.neohabitat.Weapon;
  *
  * @author steve
  */
-public class Club extends Weapon {
+public class Club extends Weapon implements Copyable {
 
     public int HabitatClass() {
         return CLASS_CLUB;
@@ -46,6 +48,15 @@ public class Club extends Weapon {
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
     public Club(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
+    }
+
+    public Club(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Club(style, x, y, orientation, gr_state);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Coke_machine.java
+++ b/src/main/java/org/made/neohabitat/mods/Coke_machine.java
@@ -6,6 +6,8 @@ import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
 import org.made.neohabitat.Coinop;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Massive;
 
 /**
@@ -16,7 +18,7 @@ import org.made.neohabitat.Massive;
  * @author randy
  *
  */
-public class Coke_machine extends Coinop {
+public class Coke_machine extends Coinop implements Copyable {
     
     public int HabitatClass() {
         return CLASS_COKE_MACHINE;
@@ -51,7 +53,16 @@ public class Coke_machine extends Coinop {
             OptInteger take) {
         super(style, x, y, orientation, gr_state, take);
     }
-    
+
+    public Coke_machine(int style, int x, int y, int orientation, int gr_state, int take) {
+        super(style, x, y, orientation, gr_state, take);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Coke_machine(style, x, y, orientation, gr_state, take);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCoinop(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Compass.java
+++ b/src/main/java/org/made/neohabitat/mods/Compass.java
@@ -5,6 +5,7 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 
@@ -16,7 +17,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class Compass extends HabitatMod {
+public class Compass extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_COMPASS;
@@ -50,6 +51,15 @@ public class Compass extends HabitatMod {
     public Compass(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
                    OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
+    }
+
+    public Compass(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Compass(style, x, y, orientation, gr_state);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Couch.java
+++ b/src/main/java/org/made/neohabitat/mods/Couch.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 import org.made.neohabitat.Seating;
 
@@ -14,7 +16,7 @@ import org.made.neohabitat.Seating;
  *
  * @author steve
  */
-public class Couch extends Seating {
+public class Couch extends Seating implements Copyable {
 
     public int		HabitatClass 	 () { return CLASS_COUCH; }
     public String	HabitatModName	 () { return "Couch"; }
@@ -26,9 +28,17 @@ public class Couch extends Seating {
 
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "open_flags"})
     public Couch(OptInteger style, OptInteger x, OptInteger y,
-               OptInteger orientation, OptInteger gr_state,
-               OptInteger open_flags) {
+        OptInteger orientation, OptInteger gr_state, OptInteger open_flags) {
         super(style, x, y, orientation, gr_state, open_flags);
+    }
+
+    public Couch(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags) {
+        super(style, x, y, orientation, gr_state, open_flags);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Couch(style, x, y, orientation, gr_state, open_flags);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Countertop.java
+++ b/src/main/java/org/made/neohabitat/mods/Countertop.java
@@ -5,6 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 
 /**
@@ -14,7 +16,7 @@ import org.made.neohabitat.Openable;
  *
  * @author steve
  */
-public class Countertop extends Openable {
+public class Countertop extends Openable implements Copyable {
 
     public int HabitatClass() {
         return CLASS_COUNTERTOP;
@@ -48,6 +50,15 @@ public class Countertop extends Openable {
     public Countertop(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
                  OptInteger open_flags) {
         super(style, x, y, orientation, gr_state, open_flags);
+    }
+
+    public Countertop(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags) {
+        super(style, x, y, orientation, gr_state, open_flags);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Countertop(style, x, y, orientation, gr_state, open_flags);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Display_case.java
+++ b/src/main/java/org/made/neohabitat/mods/Display_case.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 
 /**
@@ -14,7 +16,7 @@ import org.made.neohabitat.Openable;
  *
  * @author steve
  */
-public class Display_case extends Openable {
+public class Display_case extends Openable implements Copyable {
 
     public int HabitatClass() {
         return CLASS_DISPLAY_CASE;
@@ -46,8 +48,18 @@ public class Display_case extends Openable {
 
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "open_flags", "key_lo", "key_hi" })
     public Display_case(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-                 OptInteger open_flags, OptInteger key_lo, OptInteger key_hi) {
+        OptInteger open_flags, OptInteger key_lo, OptInteger key_hi) {
         super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+    }
+
+    public Display_case(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags, int key_lo,
+        int key_hi) {
+        super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Display_case(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Door.java
+++ b/src/main/java/org/made/neohabitat/mods/Door.java
@@ -5,6 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 
 /**
@@ -17,7 +19,7 @@ import org.made.neohabitat.Openable;
  * @author randy
  *
  */
-public class Door extends Openable {
+public class Door extends Openable implements Copyable {
     
     public int HabitatClass() {
         return CLASS_DOOR;
@@ -52,12 +54,23 @@ public class Door extends Openable {
     
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "open_flags", "key_lo", "key_hi", "connection" })
     public Door(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-            OptInteger open_flags, OptInteger key_lo, OptInteger key_hi,
-            String connection) {
+        OptInteger open_flags, OptInteger key_lo, OptInteger key_hi,
+        String connection) {
         super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
         this.connection = connection;
     }
-    
+
+    public Door(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags, int key_lo, int key_hi,
+        String connection) {
+        super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+        this.connection = connection;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Door(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi, connection);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeOpenable(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Dropbox.java
+++ b/src/main/java/org/made/neohabitat/mods/Dropbox.java
@@ -5,6 +5,7 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -14,7 +15,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class Dropbox extends HabitatMod {
+public class Dropbox extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_DROPBOX;
@@ -47,6 +48,15 @@ public class Dropbox extends HabitatMod {
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
     public Dropbox(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
+    }
+
+    public Dropbox(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Dropbox(style, x, y, orientation, gr_state);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Fence.java
+++ b/src/main/java/org/made/neohabitat/mods/Fence.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -16,7 +17,7 @@ import org.made.neohabitat.HabitatMod;
  * @author randy
  *
  */
-public class Fence extends HabitatMod {
+public class Fence extends HabitatMod implements Copyable {
     
     public int HabitatClass() {
         return CLASS_FENCE;
@@ -50,7 +51,16 @@ public class Fence extends HabitatMod {
     public Fence(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-    
+
+    public Fence(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Fence(style, x, y, orientation, gr_state);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Flag.java
+++ b/src/main/java/org/made/neohabitat/mods/Flag.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Massive;
 
 /**
@@ -16,7 +18,7 @@ import org.made.neohabitat.Massive;
  * @author matt
  *
  */
-public class Flag extends Massive {
+public class Flag extends Massive implements Copyable {
     
     public int HabitatClass() {
         return CLASS_FLAG;
@@ -48,10 +50,19 @@ public class Flag extends Massive {
     
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "mass" })
     public Flag(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-            OptInteger mass) {
+        OptInteger mass) {
         super(style, x, y, orientation, gr_state, mass);
     }
-    
+
+    public Flag(int style, int x, int y, int orientation, int gr_state, int mass) {
+        super(style, x, y, orientation, gr_state, mass);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Flag(style, x, y, orientation, gr_state, mass);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeMassive(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Flashlight.java
+++ b/src/main/java/org/made/neohabitat/mods/Flashlight.java
@@ -5,6 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Switch;
 
 /**
@@ -15,7 +17,7 @@ import org.made.neohabitat.Switch;
  * @author randy
  *
  */
-public class Flashlight extends Switch {
+public class Flashlight extends Switch implements Copyable {
     
     public int HabitatClass() {
         return CLASS_FLASHLIGHT;
@@ -50,7 +52,16 @@ public class Flashlight extends Switch {
             OptInteger on) {
         super(style, x, y, orientation, gr_state, on);
     }
-    
+
+    public Flashlight(int style, int x, int y, int orientation, int gr_state, int on) {
+        super(style, x, y, orientation, gr_state, on);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Flashlight(style, x, y, orientation, gr_state, on);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeLighting(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Flat.java
+++ b/src/main/java/org/made/neohabitat/mods/Flat.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 
@@ -15,7 +16,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class Flat extends HabitatMod {
+public class Flat extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_FLAT;
@@ -49,9 +50,19 @@ public class Flat extends HabitatMod {
 
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "flat_type" })
     public Flat(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-                OptInteger flat_type) {
+        OptInteger flat_type) {
         super(style, x, y, orientation, gr_state);
         this.flat_type = flat_type.value(0);
+    }
+
+    public Flat(int style, int x, int y, int orientation, int gr_state, int flat_type) {
+        super(style, x, y, orientation, gr_state);
+        this.flat_type = flat_type;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Flat(style, x, y, orientation, gr_state, flat_type);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Floor_lamp.java
+++ b/src/main/java/org/made/neohabitat/mods/Floor_lamp.java
@@ -5,6 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Switch;
 
 /**
@@ -14,7 +16,7 @@ import org.made.neohabitat.Switch;
  *
  * @author steve
  */
-public class Floor_lamp extends Switch {
+public class Floor_lamp extends Switch implements Copyable {
 
     public int HabitatClass() {
         return CLASS_FLOOR_LAMP;
@@ -48,6 +50,15 @@ public class Floor_lamp extends Switch {
     public Floor_lamp(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
                       OptInteger on) {
         super(style, x, y, orientation, gr_state, on);
+    }
+
+    public Floor_lamp(int style, int x, int y, int orientation, int gr_state, int on) {
+        super(style, x, y, orientation, gr_state, on);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Floor_lamp(style, x, y, orientation, gr_state, on);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Fortune_machine.java
+++ b/src/main/java/org/made/neohabitat/mods/Fortune_machine.java
@@ -6,6 +6,8 @@ import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
 import org.made.neohabitat.Coinop;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 
 /**
  * Habitat Fortune_machine Mod
@@ -14,7 +16,7 @@ import org.made.neohabitat.Coinop;
  *
  * @author steve
  */
-public class Fortune_machine extends Coinop {
+public class Fortune_machine extends Coinop implements Copyable {
 
     public int HabitatClass() {
         return CLASS_FORTUNE_MACHINE;
@@ -145,6 +147,15 @@ public class Fortune_machine extends Coinop {
     public Fortune_machine(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
         OptInteger gr_state, OptInteger take) {
         super(style, x, y, orientation, gr_state, take);
+    }
+
+    public Fortune_machine(int style, int x, int y, int orientation, int gr_state, int take) {
+        super(style, x, y, orientation, gr_state, take);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Fortune_machine(style, x, y, orientation, gr_state, take);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Fountain.java
+++ b/src/main/java/org/made/neohabitat/mods/Fountain.java
@@ -6,6 +6,8 @@ import org.elkoserver.foundation.json.OptString;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Oracular;
 
 /**
@@ -16,7 +18,7 @@ import org.made.neohabitat.Oracular;
  * @author randy
  *
  */
-public class Fountain extends Oracular {
+public class Fountain extends Oracular implements Copyable {
     
     public int HabitatClass() {
         return CLASS_FOUNTAIN;
@@ -51,7 +53,16 @@ public class Fountain extends Oracular {
             OptInteger live) {
         super(style, x, y, orientation, gr_state, live);
     }
-    
+
+    public Fountain(int style, int x, int y, int orientation, int gr_state, int live) {
+        super(style, x, y, orientation, gr_state, live);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Fountain(style, x, y, orientation, gr_state, live);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeOracular(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Garbage_can.java
+++ b/src/main/java/org/made/neohabitat/mods/Garbage_can.java
@@ -6,6 +6,7 @@ import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
 import org.made.neohabitat.Container;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 
@@ -17,7 +18,7 @@ import org.made.neohabitat.Openable;
  *
  * @author steve
  */
-public class Garbage_can extends Openable {
+public class Garbage_can extends Openable implements Copyable {
 
     public int HabitatClass() {
         return CLASS_GARBAGE_CAN;
@@ -52,6 +53,16 @@ public class Garbage_can extends Openable {
         OptInteger orientation, OptInteger gr_state, OptInteger open_flags,
         OptInteger key_hi, OptInteger key_lo) {
         super(style, x, y, orientation, gr_state, open_flags, key_hi, key_lo);
+    }
+
+    public Garbage_can(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags, int key_hi,
+        int key_lo) {
+        super(style, x, y, orientation, gr_state, open_flags, key_hi, key_lo);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Garbage_can(style, x, y, orientation, gr_state, open_flags, key_hi, key_lo);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Glue.java
+++ b/src/main/java/org/made/neohabitat/mods/Glue.java
@@ -5,6 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 
 /**
@@ -14,7 +16,7 @@ import org.made.neohabitat.Openable;
  *
  */
 
-public class Glue extends Openable {
+public class Glue extends Openable implements Copyable {
     
     public int HabitatClass() {
         return CLASS_GLUE;
@@ -50,10 +52,10 @@ public class Glue extends Openable {
     
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "open_flags", "key_lo", "key_hi", "x_offset_1", "y_offset_1", "x_offset_2", "y_offset_2",  "x_offset_3", "y_offset_3",  "x_offset_4", "y_offset_4",  "x_offset_5", "y_offset_5",  "x_offset_6", "y_offset_6"  })
     public Glue(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-            OptInteger open_flags, OptInteger key_lo, OptInteger key_hi,
-    	    OptInteger x_offset_1, OptInteger y_offset_1, OptInteger x_offset_2, OptInteger y_offset_2,
-    	    OptInteger x_offset_3, OptInteger y_offset_3, OptInteger x_offset_4, OptInteger y_offset_4,
-    	    OptInteger x_offset_5, OptInteger y_offset_5, OptInteger x_offset_6, OptInteger y_offset_6) {
+        OptInteger open_flags, OptInteger key_lo, OptInteger key_hi,
+        OptInteger x_offset_1, OptInteger y_offset_1, OptInteger x_offset_2, OptInteger y_offset_2,
+        OptInteger x_offset_3, OptInteger y_offset_3, OptInteger x_offset_4, OptInteger y_offset_4,
+        OptInteger x_offset_5, OptInteger y_offset_5, OptInteger x_offset_6, OptInteger y_offset_6) {
         super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
         this.x_offset_1 = x_offset_1.value(0);
         this.y_offset_1 = y_offset_1.value(0);
@@ -67,8 +69,33 @@ public class Glue extends Openable {
         this.y_offset_5 = y_offset_5.value(0);
         this.x_offset_6 = x_offset_6.value(0);
         this.y_offset_6 = y_offset_6.value(0);
-}
-    
+    }
+
+    public Glue(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags, int key_lo, int key_hi,
+        int x_offset_1, int y_offset_1, int x_offset_2, int y_offset_2, int x_offset_3, int y_offset_3,
+        int x_offset_4, int y_offset_4, int x_offset_5, int y_offset_5, int x_offset_6, int y_offset_6) {
+        super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+        this.x_offset_1 = x_offset_1;
+        this.y_offset_1 = y_offset_1;
+        this.x_offset_2 = x_offset_2;
+        this.y_offset_2 = y_offset_2;
+        this.x_offset_3 = x_offset_3;
+        this.y_offset_3 = y_offset_3;
+        this.x_offset_4 = x_offset_4;
+        this.y_offset_4 = y_offset_4;
+        this.x_offset_5 = x_offset_5;
+        this.y_offset_5 = y_offset_5;
+        this.x_offset_6 = x_offset_6;
+        this.y_offset_6 = y_offset_6;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Glue(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi, x_offset_1, y_offset_1,
+            x_offset_2, y_offset_2, x_offset_3, y_offset_3, x_offset_4, y_offset_4, x_offset_5, y_offset_5,
+            x_offset_6, y_offset_6);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeOpenable(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Ground.java
+++ b/src/main/java/org/made/neohabitat/mods/Ground.java
@@ -5,6 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Walkable;
 
 /**
@@ -18,7 +20,7 @@ import org.made.neohabitat.Walkable;
  *
  */
 
-public class Ground extends Walkable {
+public class Ground extends Walkable implements Copyable {
     
     public int HabitatClass() {
         return CLASS_GROUND;
@@ -53,7 +55,16 @@ public class Ground extends Walkable {
             OptInteger flat_type) {
         super(style, x, y, orientation, gr_state, flat_type.value(GROUND_FLAT));
     }
-    
+
+    public Ground(int style, int x, int y, int orientation, int gr_state, int flat_type) {
+        super(style, x, y, orientation, gr_state, flat_type);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Ground(style, x, y, orientation, gr_state, flat_type);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeWalkable(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Gun.java
+++ b/src/main/java/org/made/neohabitat/mods/Gun.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Weapon;
 
 /**
@@ -15,7 +17,7 @@ import org.made.neohabitat.Weapon;
  * 
  * @author steve
  */
-public class Gun extends Weapon {
+public class Gun extends Weapon implements Copyable {
     
     public int HabitatClass() {
         return CLASS_GUN;
@@ -49,7 +51,16 @@ public class Gun extends Weapon {
     public Gun(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-    
+
+    public Gun(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Gun(style, x, y, orientation, gr_state);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Head.java
+++ b/src/main/java/org/made/neohabitat/mods/Head.java
@@ -6,6 +6,7 @@ import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
 import org.made.neohabitat.Container;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -21,7 +22,7 @@ import org.made.neohabitat.HabitatMod;
  *
  */
 
-public class Head extends HabitatMod {
+public class Head extends HabitatMod implements Copyable {
     
     public int HabitatClass() {
         return CLASS_HEAD;
@@ -55,7 +56,16 @@ public class Head extends HabitatMod {
     public Head(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-    
+
+    public Head(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Head(style, x, y, orientation, gr_state);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Hot_tub.java
+++ b/src/main/java/org/made/neohabitat/mods/Hot_tub.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -16,7 +17,7 @@ import org.made.neohabitat.HabitatMod;
  * @author randy
  *
  */
-public class Hot_tub extends HabitatMod {
+public class Hot_tub extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_HOT_TUB;
@@ -49,6 +50,15 @@ public class Hot_tub extends HabitatMod {
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
     public Hot_tub(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
+    }
+
+    public Hot_tub(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Hot_tub(style, x, y, orientation, gr_state);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/House_cat.java
+++ b/src/main/java/org/made/neohabitat/mods/House_cat.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -14,7 +15,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class House_cat extends HabitatMod {
+public class House_cat extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_HOUSE_CAT;
@@ -47,6 +48,15 @@ public class House_cat extends HabitatMod {
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
     public House_cat(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
+    }
+
+    public House_cat(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new House_cat(style, x, y, orientation, gr_state);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Key.java
+++ b/src/main/java/org/made/neohabitat/mods/Key.java
@@ -5,6 +5,7 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -20,7 +21,7 @@ import org.made.neohabitat.HabitatMod;
  *
  */
 
-public class Key extends HabitatMod {
+public class Key extends HabitatMod implements Copyable {
     
     public int HabitatClass() {
         return CLASS_KEY;
@@ -68,7 +69,18 @@ public class Key extends HabitatMod {
         this.key_number_lo = key_number_lo.value(0);
         this.key_number_hi = key_number_hi.value(0);
     }
-    
+
+    public Key(int style, int x, int y, int orientation, int gr_state, int key_number_lo, int key_number_hi) {
+        super(style, x, y, orientation, gr_state);
+        this.key_number_lo = key_number_lo;
+        this.key_number_hi = key_number_hi;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Key(style, x, y, orientation, gr_state, key_number_lo, key_number_hi);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Knick_knack.java
+++ b/src/main/java/org/made/neohabitat/mods/Knick_knack.java
@@ -6,6 +6,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Magical;
 
 /**
@@ -18,7 +20,7 @@ import org.made.neohabitat.Magical;
  *
  */
 
-public class Knick_knack extends Magical {
+public class Knick_knack extends Magical implements Copyable {
     
     public int HabitatClass() {
         return CLASS_KNICK_KNACK;
@@ -69,7 +71,19 @@ public class Knick_knack extends Magical {
          * magical
          */
     }
-    
+
+    public Knick_knack(int style, int x, int y, int orientation, int gr_state, int magic_type, int charges,
+        int magic_data, int magic_data2, int magic_data3, int magic_data4, int magic_data5) {
+        super(style, x, y, orientation, gr_state, magic_type, charges, magic_data, magic_data2, magic_data3,
+                magic_data4, magic_data5);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Knick_knack(style, x, y, orientation, gr_state, magic_type, charges, magic_data, magic_data2,
+            magic_data3, magic_data4, magic_data5);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeMagical(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Knife.java
+++ b/src/main/java/org/made/neohabitat/mods/Knife.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Weapon;
 
 /**
@@ -14,7 +16,7 @@ import org.made.neohabitat.Weapon;
  * 
  * @author steve
  */
-public class Knife extends Weapon {
+public class Knife extends Weapon implements Copyable {
     
     public int HabitatClass() {
         return CLASS_KNIFE;
@@ -48,7 +50,16 @@ public class Knife extends Weapon {
     public Knife(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-    
+
+    public Knife(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Knife(style, x, y, orientation, gr_state);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Picture.java
+++ b/src/main/java/org/made/neohabitat/mods/Picture.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Massive;
 
 /**
@@ -14,7 +16,7 @@ import org.made.neohabitat.Massive;
  *
  * @author steve
  */
-public class Picture extends Massive {
+public class Picture extends Massive implements Copyable {
 
     public int HabitatClass() {
         return CLASS_PICTURE;
@@ -52,6 +54,16 @@ public class Picture extends Massive {
         OptInteger picture) {
         super(style, x, y, orientation, gr_state, mass);
         this.picture = picture.value(0);
+    }
+
+    public Picture(int style, int x, int y, int orientation, int gr_state, int mass, int picture) {
+        super(style, x, y, orientation, gr_state, mass);
+        this.picture = picture;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Picture(style, x, y, orientation, gr_state, mass, picture);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Plant.java
+++ b/src/main/java/org/made/neohabitat/mods/Plant.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Massive;
 
 /**
@@ -16,7 +18,7 @@ import org.made.neohabitat.Massive;
  * @author matt
  *
  */
-public class Plant extends Massive {
+public class Plant extends Massive implements Copyable {
     
     public int HabitatClass() {
         return CLASS_PLANT;
@@ -51,7 +53,16 @@ public class Plant extends Massive {
             OptInteger mass) {
         super(style, x, y, orientation, gr_state, mass);
     }
-    
+
+    public Plant(int style, int x, int y, int orientation, int gr_state, int mass) {
+        super(style, x, y, orientation, gr_state, mass);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Plant(style, x, y, orientation, gr_state, mass);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeMassive(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Plaque.java
+++ b/src/main/java/org/made/neohabitat/mods/Plaque.java
@@ -5,7 +5,9 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.Document;
+import org.made.neohabitat.HabitatMod;
 
 /**
  * Habitat Plaque Mod (attached to an Elko Item.)
@@ -15,7 +17,7 @@ import org.made.neohabitat.Document;
  * @author randy
  *
  */
-public class Plaque extends Document {
+public class Plaque extends Document implements Copyable {
     
     public int HabitatClass() {
         return CLASS_PLAQUE;
@@ -50,14 +52,23 @@ public class Plaque extends Document {
             int last_page, String pages[], String path) {
         super(style, x, y, orientation, gr_state, last_page, pages, path);
     }
-    
+
+    public Plaque(int style, int x, int y, int orientation, int gr_state, int last_page, String[] pages, String path) {
+        super(style, x, y, orientation, gr_state, last_page, pages, path);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Plaque(style, x, y, orientation, gr_state, last_page, pages, path);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeDocument(new JSONLiteral(HabitatModName(), control));
         result.finish();
         return result;
     }
-    
+
     @JSONMethod
     public void HELP(User from) {
         send_reply_msg(from,

--- a/src/main/java/org/made/neohabitat/mods/Pond.java
+++ b/src/main/java/org/made/neohabitat/mods/Pond.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -16,7 +17,7 @@ import org.made.neohabitat.HabitatMod;
  * @author matt
  *
  */
-public class Pond extends HabitatMod {
+public class Pond extends HabitatMod implements Copyable {
     
     public int HabitatClass() {
         return CLASS_POND;
@@ -50,7 +51,16 @@ public class Pond extends HabitatMod {
     public Pond(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-    
+
+    public Pond(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Pond(style, x, y, orientation, gr_state);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Region.java
+++ b/src/main/java/org/made/neohabitat/mods/Region.java
@@ -9,6 +9,7 @@ import org.elkoserver.server.context.ContextMod;
 import org.elkoserver.server.context.User;
 import org.made.neohabitat.Constants;
 import org.made.neohabitat.Container;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -25,7 +26,7 @@ import org.made.neohabitat.HabitatMod;
  *
  */
 
-public class Region extends Container implements ContextMod, Constants {
+public class Region extends Container implements Copyable, ContextMod, Constants {
     
     /** The default depth for a region. */
     public static final int DEFAULT_REGION_DEPTH = 32; // TODO What is the
@@ -86,10 +87,10 @@ public class Region extends Container implements ContextMod, Constants {
 
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "nitty_bits", "depth", "lighting",
         "town_dir", "port_dir", "max_avatars", "neighbors" })
-    Region(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-            OptInteger nitty_bits, OptInteger depth, OptInteger lighting, 
-            OptString town_dir, OptString port_dir, OptInteger max_avatars,
-            String[] neighbors) {
+    public Region(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
+        OptInteger nitty_bits, OptInteger depth, OptInteger lighting,
+        OptString town_dir, OptString port_dir, OptInteger max_avatars,
+        String[] neighbors) {
         super(style, x, y, orientation, gr_state);
         if (nitty_bits.value(-1) != -1) {
             this.nitty_bits = unpackBits(nitty_bits.value());
@@ -101,7 +102,25 @@ public class Region extends Container implements ContextMod, Constants {
         this.town_dir = town_dir.value("");
         this.port_dir = port_dir.value("");
     }
-    
+
+    public Region(int style, int x, int y, int orientation, int gr_state, boolean[] nitty_bits, int depth, int lighting,
+        String town_dir, String port_dir, int max_avatars, String[] neighbors) {
+        super(style, x, y, orientation, gr_state);
+        this.nitty_bits = nitty_bits;
+        this.depth = depth;
+        this.lighting = lighting;
+        this.max_avatars = max_avatars;
+        this.neighbors = neighbors;
+        this.town_dir = town_dir;
+        this.port_dir = port_dir;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Region(style, x, y, orientation, gr_state, nitty_bits, depth, lighting, town_dir, port_dir,
+            max_avatars, neighbors);
+    }
+
     @Override
     public void objectIsComplete() {
         this.noids[0] = this;

--- a/src/main/java/org/made/neohabitat/mods/Region.java
+++ b/src/main/java/org/made/neohabitat/mods/Region.java
@@ -26,7 +26,7 @@ import org.made.neohabitat.HabitatMod;
  *
  */
 
-public class Region extends Container implements Copyable, ContextMod, Constants {
+public class Region extends Container implements ContextMod, Constants {
     
     /** The default depth for a region. */
     public static final int DEFAULT_REGION_DEPTH = 32; // TODO What is the
@@ -113,12 +113,6 @@ public class Region extends Container implements Copyable, ContextMod, Constants
         this.neighbors = neighbors;
         this.town_dir = town_dir;
         this.port_dir = port_dir;
-    }
-
-    @Override
-    public HabitatMod copyThisMod() {
-        return new Region(style, x, y, orientation, gr_state, nitty_bits, depth, lighting, town_dir, port_dir,
-            max_avatars, neighbors);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Rock.java
+++ b/src/main/java/org/made/neohabitat/mods/Rock.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Massive;
 
 /**
@@ -16,7 +18,7 @@ import org.made.neohabitat.Massive;
  * @author randy
  *
  */
-public class Rock extends Massive {
+public class Rock extends Massive implements Copyable {
     
     public int HabitatClass() {
         return CLASS_ROCK;
@@ -48,10 +50,19 @@ public class Rock extends Massive {
     
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "mass" })
     public Rock(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-            OptInteger mass) {
+        OptInteger mass) {
         super(style, x, y, orientation, gr_state, mass);
     }
-    
+
+    public Rock(int style, int x, int y, int orientation, int gr_state, int mass) {
+        super(style, x, y, orientation, gr_state, mass);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Rock(style, x, y, orientation, gr_state, mass);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeMassive(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Roof.java
+++ b/src/main/java/org/made/neohabitat/mods/Roof.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -14,7 +15,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class Roof extends HabitatMod {
+public class Roof extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_ROOF;
@@ -50,10 +51,21 @@ public class Roof extends HabitatMod {
 
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "base", "pattern" })
     public Roof(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-    		OptInteger base, OptInteger pattern) {
+        OptInteger base, OptInteger pattern) {
         super(style, x, y, orientation, gr_state);
         this.base		= base.value(0);
         this.pattern	= pattern.value(0);
+    }
+
+    public Roof(int style, int x, int y, int orientation, int gr_state, int base, int pattern) {
+        super(style, x, y, orientation, gr_state);
+        this.base		= base;
+        this.pattern	= pattern;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Roof(style, x, y, orientation, gr_state, base, pattern);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Sex_changer.java
+++ b/src/main/java/org/made/neohabitat/mods/Sex_changer.java
@@ -6,6 +6,7 @@ import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
 
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -16,7 +17,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class Sex_changer extends HabitatMod {
+public class Sex_changer extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_SEX_CHANGER;
@@ -49,6 +50,15 @@ public class Sex_changer extends HabitatMod {
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
     public Sex_changer(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
+    }
+
+    public Sex_changer(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Sex_changer(style, x, y, orientation, gr_state);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Short_sign.java
+++ b/src/main/java/org/made/neohabitat/mods/Short_sign.java
@@ -5,6 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.foundation.json.OptString;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Poster;
 
 /**
@@ -15,7 +17,7 @@ import org.made.neohabitat.Poster;
  * @author randy
  *
  */
-public class Short_sign extends Poster {
+public class Short_sign extends Poster implements Copyable {
     
     public int HabitatClass() {
         return CLASS_SHORT_SIGN;
@@ -50,7 +52,16 @@ public class Short_sign extends Poster {
             OptString text, int[] ascii) {
         super(style, x, y, orientation, gr_state, text, ascii, 10);
     }
-    
+
+    public Short_sign(int style, int x, int y, int orientation, int gr_state, int[] ascii) {
+        super(style, x, y, orientation, gr_state, ascii);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Short_sign(style, x, y, orientation, gr_state, ascii);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodePoster(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Sign.java
+++ b/src/main/java/org/made/neohabitat/mods/Sign.java
@@ -5,6 +5,8 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.foundation.json.OptString;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Poster;
 
 /**
@@ -15,7 +17,7 @@ import org.made.neohabitat.Poster;
  * @author randy
  *
  */
-public class Sign extends Poster {
+public class Sign extends Poster implements Copyable {
     
     public int HabitatClass() {
         return CLASS_SIGN;
@@ -50,7 +52,16 @@ public class Sign extends Poster {
             OptString text, int[] ascii) {
         super(style, x, y, orientation, gr_state, text, ascii, 40);
     }
-    
+
+    public Sign(int style, int x, int y, int orientation, int gr_state, int[] ascii) {
+        super(style, x, y, orientation, gr_state, ascii);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Sign(style, x, y, orientation, gr_state, ascii);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodePoster(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Sky.java
+++ b/src/main/java/org/made/neohabitat/mods/Sky.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -16,7 +17,7 @@ import org.made.neohabitat.HabitatMod;
  * @author matt
  *
  */
-public class Sky extends HabitatMod {
+public class Sky extends HabitatMod implements Copyable {
     
     public int HabitatClass() {
         return CLASS_SKY;
@@ -50,7 +51,16 @@ public class Sky extends HabitatMod {
     public Sky(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-    
+
+    public Sky(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Sky(style, x, y, orientation, gr_state);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Spray_can.java
+++ b/src/main/java/org/made/neohabitat/mods/Spray_can.java
@@ -5,6 +5,7 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 
@@ -17,7 +18,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class Spray_can extends HabitatMod {
+public class Spray_can extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_SPRAY_CAN;
@@ -60,9 +61,19 @@ public class Spray_can extends HabitatMod {
 
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "charge" })
     public Spray_can(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
-                     OptInteger gr_state, OptInteger charge) {
+        OptInteger gr_state, OptInteger charge) {
         super(style, x, y, orientation, gr_state);
         this.charge = charge.value(10);
+    }
+
+    public Spray_can(int style, int x, int y, int orientation, int gr_state, int charge) {
+        super(style, x, y, orientation, gr_state);
+        this.charge = charge;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Spray_can(style, x, y, orientation, gr_state, charge);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Street.java
+++ b/src/main/java/org/made/neohabitat/mods/Street.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -14,7 +15,7 @@ import org.made.neohabitat.HabitatMod;
  * @author randy
  *
  */
-public class Street extends HabitatMod {
+public class Street extends HabitatMod implements Copyable {
     
     public int HabitatClass() {
         return CLASS_STREET;
@@ -54,7 +55,18 @@ public class Street extends HabitatMod {
         this.width  = width.value(0);
         this.height = height.value(0);
     }
-    
+
+    public Street(int style, int x, int y, int orientation, int gr_state, int width, int height) {
+        super(style, x, y, orientation, gr_state);
+        this.width  = width;
+        this.height = height;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Street(style, x, y, orientation, gr_state, width, height);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Streetlamp.java
+++ b/src/main/java/org/made/neohabitat/mods/Streetlamp.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -14,7 +15,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class Streetlamp extends HabitatMod {
+public class Streetlamp extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_STREETLAMP;
@@ -47,6 +48,15 @@ public class Streetlamp extends HabitatMod {
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
     public Streetlamp(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
+    }
+
+    public Streetlamp(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Streetlamp(style, x, y, orientation, gr_state);
     }
 
     @Override

--- a/src/main/java/org/made/neohabitat/mods/Stun_gun.java
+++ b/src/main/java/org/made/neohabitat/mods/Stun_gun.java
@@ -5,6 +5,7 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 
@@ -16,7 +17,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class Stun_gun extends HabitatMod {
+public class Stun_gun extends HabitatMod implements Copyable {
 
 	public int HabitatClass() {
 		return CLASS_STUN_GUN;
@@ -48,8 +49,17 @@ public class Stun_gun extends HabitatMod {
 
 	@JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
 	public Stun_gun(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
-					 OptInteger gr_state) {
+		OptInteger gr_state) {
 		super(style, x, y, orientation, gr_state);
+	}
+
+	public Stun_gun(int style, int x, int y, int orientation, int gr_state) {
+		super(style, x, y, orientation, gr_state);
+	}
+
+	@Override
+	public HabitatMod copyThisMod() {
+		return new Stun_gun(style, x, y, orientation, gr_state);
 	}
 
 	@Override

--- a/src/main/java/org/made/neohabitat/mods/Super_trapezoid.java
+++ b/src/main/java/org/made/neohabitat/mods/Super_trapezoid.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Polygonal;
 
 /**
@@ -15,7 +17,7 @@ import org.made.neohabitat.Polygonal;
  * @author randy
  *
  */
-public class Super_trapezoid extends Polygonal {
+public class Super_trapezoid extends Polygonal implements Copyable {
     
     public int HabitatClass() {
         return CLASS_SUPER_TRAPEZOID;
@@ -52,15 +54,30 @@ public class Super_trapezoid extends Polygonal {
 
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "trapezoid_type",  "upper_left_x", "upper_right_x", "lower_left_x", "lower_right_x",  "height", "pattern_x_size", "pattern_y_size", "pattern"})    
     public Super_trapezoid(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-            OptInteger trapezoid_type, OptInteger upper_left_x,  OptInteger upper_right_x,
-            OptInteger lower_left_x,   OptInteger lower_right_x, OptInteger height,
-            OptInteger pattern_x_size, OptInteger pattern_y_size, int[] pattern) {
+        OptInteger trapezoid_type, OptInteger upper_left_x,  OptInteger upper_right_x,
+        OptInteger lower_left_x,   OptInteger lower_right_x, OptInteger height,
+        OptInteger pattern_x_size, OptInteger pattern_y_size, int[] pattern) {
         super(style, x, y, orientation, gr_state, trapezoid_type, upper_left_x, upper_right_x, lower_left_x, lower_right_x, height);
         this.pattern_x_size = pattern_x_size.value(4);
         this.pattern_y_size = pattern_y_size.value(8);
         this.pattern = pattern;
     }
-    
+
+    public Super_trapezoid(int style, int x, int y, int orientation, int gr_state, int trapezoid_type,
+        int upper_left_x, int upper_right_x, int lower_left_x, int lower_right_x, int height, int pattern_x_size,
+        int pattern_y_size, int[] pattern) {
+        super(style, x, y, orientation, gr_state, trapezoid_type, upper_left_x, upper_right_x, lower_left_x, lower_right_x, height);
+        this.pattern_x_size = pattern_x_size;
+        this.pattern_y_size = pattern_y_size;
+        this.pattern = pattern;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Super_trapezoid(style, x, y, orientation, gr_state, trapezoid_type, upper_left_x, upper_right_x,
+            lower_left_x, lower_right_x, height, pattern_x_size, pattern_y_size, pattern);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodePolygonal(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Table.java
+++ b/src/main/java/org/made/neohabitat/mods/Table.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Openable;
 
 /**
@@ -15,7 +17,7 @@ import org.made.neohabitat.Openable;
  *
  */
 
-public class Table extends Openable {
+public class Table extends Openable implements Copyable {
     
     public int HabitatClass() {
         return CLASS_TABLE;
@@ -50,7 +52,16 @@ public class Table extends Openable {
             OptInteger open_flags, OptInteger key_lo, OptInteger key_hi) {
         super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
     }
-    
+
+    public Table(int style, int x, int y, int orientation, int gr_state, boolean[] open_flags, int key_lo, int key_hi) {
+        super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Table(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeOpenable(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Table.java
+++ b/src/main/java/org/made/neohabitat/mods/Table.java
@@ -49,7 +49,7 @@ public class Table extends Openable implements Copyable {
     
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "open_flags", "key_lo", "key_hi" })
     public Table(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-            OptInteger open_flags, OptInteger key_lo, OptInteger key_hi) {
+        OptInteger open_flags, OptInteger key_lo, OptInteger key_hi) {
         super(style, x, y, orientation, gr_state, open_flags, key_lo, key_hi);
     }
 

--- a/src/main/java/org/made/neohabitat/mods/Teleport.java
+++ b/src/main/java/org/made/neohabitat/mods/Teleport.java
@@ -11,6 +11,7 @@ import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
 import org.made.neohabitat.Coinop;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Massive;
 
@@ -22,7 +23,7 @@ import org.made.neohabitat.Massive;
  * @author randy
  *
  */
-public class Teleport extends Coinop {
+public class Teleport extends Coinop implements Copyable {
     
     public int HabitatClass() {
         return CLASS_TELEPORT;
@@ -64,12 +65,23 @@ public class Teleport extends Coinop {
     
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "activeState", "take", "address"})
     public Teleport(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-            OptInteger activeState,  OptInteger take, String address) {
+		OptInteger activeState,  OptInteger take, String address) {
         super(style, x, y, orientation, gr_state, take);
-        this.activeState	= activeState.value(PORT_READY);
-        this.address		= address;
+        this.activeState = activeState.value(PORT_READY);
+        this.address = address;
     }
-    
+
+	public Teleport(int style, int x, int y, int orientation, int gr_state, int activeState, int take, String address) {
+		super(style, x, y, orientation, gr_state, take);
+		this.activeState = activeState;
+		this.address = address;
+	}
+
+	@Override
+	public HabitatMod copyThisMod() {
+		return new Teleport(style, x, y, orientation, gr_state, activeState, take, address);
+	}
+
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCoinop(new JSONLiteral(HabitatModName(), control));
         result.addParameter("activeState", activeState);

--- a/src/main/java/org/made/neohabitat/mods/Tokens.java
+++ b/src/main/java/org/made/neohabitat/mods/Tokens.java
@@ -7,6 +7,7 @@ import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.BasicObject;
 import org.elkoserver.server.context.Item;
 import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -18,7 +19,7 @@ import org.made.neohabitat.HabitatMod;
  * @author Randy
  *
  */
-public class Tokens extends HabitatMod {
+public class Tokens extends HabitatMod implements Copyable {
     
     public int HabitatClass() {
         return CLASS_TOKENS;
@@ -82,7 +83,12 @@ public class Tokens extends HabitatMod {
         this.denom_lo = denom_lo;
         this.denom_hi = denom_hi;
     }
-    
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Tokens(style, x, y, orientation, gr_state, denom_lo, denom_hi);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Trapezoid.java
+++ b/src/main/java/org/made/neohabitat/mods/Trapezoid.java
@@ -4,6 +4,8 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
 import org.made.neohabitat.Polygonal;
 
 /**
@@ -15,7 +17,7 @@ import org.made.neohabitat.Polygonal;
  * @author randy
  *
  */
-public class Trapezoid extends Polygonal {
+public class Trapezoid extends Polygonal implements Copyable {
     
     public int HabitatClass() {
         return CLASS_TRAPEZOID;
@@ -48,11 +50,21 @@ public class Trapezoid extends Polygonal {
     
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "trapezoid_type",  "upper_left_x", "upper_right_x", "lower_left_x", "lower_right_x",  "height"})
     public Trapezoid(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
-            OptInteger trapezoid_type, OptInteger upper_left_x,  OptInteger upper_right_x,
-            OptInteger lower_left_x,   OptInteger lower_right_x, OptInteger height) {
+        OptInteger trapezoid_type, OptInteger upper_left_x,  OptInteger upper_right_x,
+        OptInteger lower_left_x,   OptInteger lower_right_x, OptInteger height) {
         super(style, x, y, orientation, gr_state, trapezoid_type, upper_left_x, upper_right_x, lower_left_x, lower_right_x, height);
     }
-    
+
+    public Trapezoid(int style, int x, int y, int orientation, int gr_state, int trapezoid_type, int upper_left_x,
+        int upper_right_x, int lower_left_x, int lower_right_x, int height) {
+        super(style, x, y, orientation, gr_state, trapezoid_type, upper_left_x, upper_right_x, lower_left_x, lower_right_x, height);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Trapezoid(style, x, y, orientation, gr_state, trapezoid_type, upper_left_x, upper_right_x, lower_left_x, lower_right_x, height);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodePolygonal(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Tree.java
+++ b/src/main/java/org/made/neohabitat/mods/Tree.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -16,7 +17,7 @@ import org.made.neohabitat.HabitatMod;
  * @author randy
  *
  */
-public class Tree extends HabitatMod {
+public class Tree extends HabitatMod implements Copyable {
     
     public int HabitatClass() {
         return CLASS_TREE;
@@ -50,7 +51,16 @@ public class Tree extends HabitatMod {
     public Tree(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-    
+
+    public Tree(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Tree(style, x, y, orientation, gr_state);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Wall.java
+++ b/src/main/java/org/made/neohabitat/mods/Wall.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -17,7 +18,7 @@ import org.made.neohabitat.HabitatMod;
  * @author randy
  *
  */
-public class Wall extends HabitatMod {
+public class Wall extends HabitatMod implements Copyable {
     
     public int HabitatClass() {
         return CLASS_WALL;
@@ -51,7 +52,16 @@ public class Wall extends HabitatMod {
     public Wall(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
     }
-    
+
+    public Wall(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Wall(style, x, y, orientation, gr_state);
+    }
+
     @Override
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));

--- a/src/main/java/org/made/neohabitat/mods/Window.java
+++ b/src/main/java/org/made/neohabitat/mods/Window.java
@@ -4,6 +4,7 @@ import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
+import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
 /**
@@ -14,7 +15,7 @@ import org.made.neohabitat.HabitatMod;
  *
  * @author steve
  */
-public class Window extends HabitatMod {
+public class Window extends HabitatMod implements Copyable {
 
     public int HabitatClass() {
         return CLASS_WINDOW;
@@ -47,6 +48,15 @@ public class Window extends HabitatMod {
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state" })
     public Window(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state) {
         super(style, x, y, orientation, gr_state);
+    }
+
+    public Window(int style, int x, int y, int orientation, int gr_state) {
+        super(style, x, y, orientation, gr_state);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Window(style, x, y, orientation, gr_state);
     }
 
     @Override


### PR DESCRIPTION
To enable the creation of Vendo, we need to ensure that all of our HabitatMods can be cleanly copied.  This PR accomplishes this by specifying explicit constructors (non-OptString,OptInteger,etc.) on each class and abstract class as well as providing a new interface, Copyable:

```
public interface Copyable {
    HabitatMod copyThisMod();
}
```

This interface has been implemented across all current HabitatMods.

Finally, I've set the WEAPONS_FREE bit off all of our current Back4t regions as well as fixed a bug where lighting was clamped to 1 by the Bridge (the ```||``` operator will return the default value if the initial value is 0 or undefined, we want it to only do so if the value is undefined).

Let me know what you think and thanks for the consideration!