### PR TITLE
Opens QuizShows interior

### DIFF
--- a/db/new_Downtown/Downtown_7c.json
+++ b/db/new_Downtown/Downtown_7c.json
@@ -60,8 +60,9 @@
         "x": 8,
         "y": 33,
         "orientation": 172,
-        "open_flags": 0,
-        "connection": "context-test"
+        "open_flags": 3,
+        "gr_state": 1,
+        "connection": "context-Downtown_8c"
       }
     ]
   },


### PR DESCRIPTION
The QuizShows interior is working, so we should open a door to it:

![screen shot 2017-02-23 at 10 48 24 pm](https://cloud.githubusercontent.com/assets/15283/23293295/33d9f258-fa1a-11e6-8cc3-37ca6169366b.png)
