### PR TITLE
Opens Tivolli's interior

### DIFF
--- a/db/new_Downtown/Downtown_5b.json
+++ b/db/new_Downtown/Downtown_5b.json
@@ -116,7 +116,7 @@
         "gr_state": 1,		
         "type": "Door", 
         "orientation": 236,
-		    "connection": "context-Downtown_5a"
+        "connection": "context-Downtown_5a"
       }
     ], 
     "type": "item", 

--- a/db/new_Downtown/Downtown_5b.json
+++ b/db/new_Downtown/Downtown_5b.json
@@ -112,10 +112,11 @@
       {
         "y": 33, 
         "x": 8, 
-        "open_flags": 2,		
+        "open_flags": 3,
+        "gr_state": 1,		
         "type": "Door", 
         "orientation": 236,
-		"connection": "context-Downtown_5a"
+		    "connection": "context-Downtown_5a"
       }
     ], 
     "type": "item", 


### PR DESCRIPTION
Looks like Tivolli's is open too:

![screen shot 2017-02-23 at 10 57 37 pm](https://cloud.githubusercontent.com/assets/15283/23293565/b07c92ce-fa1b-11e6-8c8c-072f60af63ed.png)
