### PR TITLE
Corrects make db issues

### DIFF
--- a/Backbone
+++ b/Backbone
@@ -11,6 +11,7 @@ clusters:
         NEOHABITAT_DEFAULT_CONTEXT: context-Downtown_5f
         NEOHABITAT_MONGO_HOST: 127.0.0.1:27017
         NEOHABITAT_SCHEMA_DIR: db
+        NEOHABITAT_SHOULD_ENABLE_DEBUGGER: "false"
       synapses:
         - resource: neohabitatmongo
           protocol: tcp

--- a/run
+++ b/run
@@ -74,7 +74,7 @@ if [ "${SHOULD_ENABLE_DEBUGGER}" == true ]; then
 fi
 
 if [ "${SHOULD_UPDATE_SCHEMA}" == true ]; then
-  cd ${GIT_BASE_DIR}/${NEOHABITAT_SCHEMA_DIR}
+  cd ${GIT_BASE_DIR}/${SCHEMA_DIR}
   retry 60 "make db"
   cd ..
 fi


### PR DESCRIPTION
A recent change to the run script broke ```make db``` execution when starting Neohabitat via the ```run``` script.  This PR corrects this issue while also disabling the debugger in production environments.