### PR TITLE
Reverts DB Makefile change, cordons off Kelly's back room

### DIFF
--- a/Backbone
+++ b/Backbone
@@ -11,7 +11,7 @@ clusters:
         NEOHABITAT_DEFAULT_CONTEXT: context-Downtown_5f
         NEOHABITAT_MONGO_HOST: 127.0.0.1:27017
         NEOHABITAT_SCHEMA_DIR: db
-        NEOHABITAT_SHOULD_ENABLE_DEBUGGER: "false"
+        NEOHABITAT_SHOULD_ENABLE_DEBUGGER: "true"
       synapses:
         - resource: neohabitatmongo
           protocol: tcp
@@ -72,3 +72,7 @@ balancers:
           protocol: tcp
           port: 9000
           remote_port: 9000
+        - resource: neohabitat
+          protocol: tcp
+          port: 1898
+          remote_port: 1898

--- a/Backbone
+++ b/Backbone
@@ -76,3 +76,7 @@ balancers:
           protocol: tcp
           port: 1898
           remote_port: 1898
+        - resource: neohabitatmongo
+          protocol: tcp
+          port: 27017
+          remote_port: 27017

--- a/db/Makefile
+++ b/db/Makefile
@@ -22,52 +22,21 @@ DBINIT_SCRIPT = ./dbinit.sh
 
 NEOHABITAT_MONGO_HOST ?= "127.0.0.1"
 
-clean: nuke all help
-
-help:
-	@echo ""
-	@echo "Valid 'make' targets are 'teleports', 'regions', 'all', 'clean', or JSONFILENAME.o . Default is 'clean'"
-	@echo "Mongo output is in .errs"
-	@echo ""
-
-regions:
-	@echo "Building Regions, Avatars, and Objects"
-	@rm -f $(DBINIT_SCRIPT)
-	@echo '#!/bin/bash' > $(DBINIT_SCRIPT)
-	@cp dbinitpre.js $(DBINIT_SCRIPT)
-	@$(foreach F,$(MONGODB_OBJECTS), echo "eupdate(" >> $(DBINIT_SCRIPT); cat $F >> $(DBINIT_SCRIPT); echo ")" >>$(DBINIT_SCRIPT);)
-	@cat dbinitpost.js >> $(DBINIT_SCRIPT)
-	@cat $(DBINIT_SCRIPT) | mongo $(NEOHABITAT_MONGO_HOST)/elko --verbose --shell mongohelper.js >>.errs 2>&1
-
-teleports:
-	@echo "Building Teleport Directory"
-	@rm -f $(TELEPORTDB)
-	@echo '{ "ref" : "teleports", "type" : "map", "map" : {' > $(TELEPORTDB)
-	@$(foreach F,$(MONGODB_OBJECTS), node dumpTeleportEntries.js < $(F) >> $(TELEPORTDB);)
-	@echo ' " End Of Directory": "eod" } }' >> $(TELEPORTDB)
-	@cp dbinitpre.js $(DBINIT_SCRIPT)
-	@echo "eupdate(" >> $(DBINIT_SCRIPT); cat $(TELEPORTDB) >> $(DBINIT_SCRIPT); echo ")" >>$(DBINIT_SCRIPT)
-	@cat dbinitpost.js >> $(DBINIT_SCRIPT)
-	@cat $(DBINIT_SCRIPT) | mongo $(NEOHABITAT_MONGO_HOST)/elko --verbose --shell mongohelper.js >> .errs 2>&1
-
-%.o: %.json
-	@echo "Updating" $*.json "in the database"
-	@cp dbinitpre.js $(DBINIT_SCRIPT)
-	@echo "eupdate(" >> $(DBINIT_SCRIPT); cat $*.json >> $(DBINIT_SCRIPT); echo ")" >>$(DBINIT_SCRIPT)
-	@cat dbinitpost.js >> $(DBINIT_SCRIPT)
-	@cat $(DBINIT_SCRIPT) | mongo $(NEOHABITAT_MONGO_HOST)/elko --verbose --shell mongohelper.js >> .errs 2>&1
-	@tail -3 .errs
-
-nuke:
-	@echo "Nuking database"
-	@rm -f  $(DATABASE_OBJECTS) .errs	
-	@echo 'db.odb.remove({});' | mongo $(NEOHABITAT_MONGO_HOST)/elko --verbose --shell mongohelper.js >> .errs 2>&1
-
-all: teleports regions
-
+# Make the database setup stuff
+db:
+	rm -f  $(DATABASE_OBJECTS)
+	echo '{ "ref" : "teleports", "type" : "map", "map" : {' > $(TELEPORTDB)
+	$(foreach F,$(MONGODB_OBJECTS), node dumpTeleportEntries.js < $(F) >> $(TELEPORTDB);)
+	echo ' " End Of Directory": "eod" } }' >> $(TELEPORTDB)
+	rm -f $(DBINIT_SCRIPT)
+	echo '#!/bin/bash' > $(DBINIT_SCRIPT)
+	echo 'mongo $(NEOHABITAT_MONGO_HOST)/elko --verbose --shell mongohelper.js <<ENDINITS' >> $(DBINIT_SCRIPT)
+	cat dbinitpre.js >> $(DBINIT_SCRIPT)
+	$(foreach F,$(MONGODB_OBJECTS), echo "eupdate(" >> $(DBINIT_SCRIPT); cat $F >> $(DBINIT_SCRIPT); echo ")" >>$(DBINIT_SCRIPT);)
+	cat dbinitpost.js >> $(DBINIT_SCRIPT)
+	echo 'ENDINITS' >> $(DBINIT_SCRIPT)
+	chmod +x $(DBINIT_SCRIPT)
+	$(DBINIT_SCRIPT)
+	
 deletables:
 	$(foreach F,$(MONGODB_OBJECTS), if grep -q "deletable" $(F); then grep -v "deletable" <$(F) > tmp; mv tmp $(F); fi;)
-
-
-
-

--- a/db/new_Downtown/Downtown_5k.json
+++ b/db/new_Downtown/Downtown_5k.json
@@ -12,7 +12,7 @@
         "orientation": 1,   
         "neighbors": [
           "",
-          "context-Downtown_5l",
+          "",
           "context-Downtown_5j",
           ""
         ], 

--- a/db/new_Downtown/Downtown_5k.json
+++ b/db/new_Downtown/Downtown_5k.json
@@ -12,7 +12,7 @@
         "orientation": 1,   
         "neighbors": [
           "",
-          "",
+          "context-Downtown_5l",
           "context-Downtown_5j",
           ""
         ], 

--- a/run
+++ b/run
@@ -75,7 +75,7 @@ fi
 
 if [ "${SHOULD_UPDATE_SCHEMA}" == true ]; then
   cd ${GIT_BASE_DIR}/${SCHEMA_DIR}
-  retry 60 "make clean"
+  retry 60 "make db"
   cd ..
 fi
 

--- a/src/main/java/org/made/neohabitat/mods/Sex_changer.java
+++ b/src/main/java/org/made/neohabitat/mods/Sex_changer.java
@@ -75,12 +75,16 @@ public class Sex_changer extends HabitatMod implements Copyable {
 
     public void sex_changer_SEXCHANGE(User from, Avatar sexChangingAvatar) {
         if (adjacent(sexChangingAvatar)) {
+            trace_msg("Avatar %s is adjacent to sex changer: %s", sexChangingAvatar.object().ref(), object().ref());
             if (test_bit(sexChangingAvatar.orientation, 8)) {
+                trace_msg("Bit 8 is set on sex changing Avatar %s; clearing it", sexChangingAvatar.object().ref());
                 sexChangingAvatar.orientation = clear_bit(sexChangingAvatar.orientation, 8);
             } else {
+                trace_msg("Bit 8 is cleared on sex changing Avatar %s; setting it", sexChangingAvatar.object().ref());
                 sexChangingAvatar.orientation = set_bit(sexChangingAvatar.orientation, 8);
             }
         }
+        trace_msg("New sex-changed Avatar orientation: %d", sexChangingAvatar.orientation);
         sexChangingAvatar.gen_flags[MODIFIED] = true;
         sexChangingAvatar.checkpoint_object(sexChangingAvatar);
         send_neighbor_msg(from, noid, "SEXCHANGE$",

--- a/src/main/java/org/made/neohabitat/mods/Sex_changer.java
+++ b/src/main/java/org/made/neohabitat/mods/Sex_changer.java
@@ -83,12 +83,13 @@ public class Sex_changer extends HabitatMod implements Copyable {
                 trace_msg("Bit 8 is cleared on sex changing Avatar %s; setting it", sexChangingAvatar.object().ref());
                 sexChangingAvatar.orientation = set_bit(sexChangingAvatar.orientation, 8);
             }
+            send_neighbor_msg(from, noid, "SEXCHANGE$",
+                "AVATAR_NOID", sexChangingAvatar.noid);
         }
         trace_msg("New sex-changed Avatar orientation: %d", sexChangingAvatar.orientation);
         sexChangingAvatar.gen_flags[MODIFIED] = true;
         sexChangingAvatar.checkpoint_object(sexChangingAvatar);
-        send_neighbor_msg(from, noid, "SEXCHANGE$",
-            "AVATAR_NOID", sexChangingAvatar.noid);
+
         send_reply_success(from);
     }
 

--- a/src/main/java/org/made/neohabitat/mods/Sex_changer.java
+++ b/src/main/java/org/made/neohabitat/mods/Sex_changer.java
@@ -82,7 +82,7 @@ public class Sex_changer extends HabitatMod implements Copyable {
             }
         }
         sexChangingAvatar.gen_flags[MODIFIED] = true;
-        checkpoint_object(sexChangingAvatar);
+        sexChangingAvatar.checkpoint_object(sexChangingAvatar);
         send_neighbor_msg(from, noid, "SEXCHANGE$",
             "AVATAR_NOID", sexChangingAvatar.noid);
         send_reply_success(from);

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -74,7 +74,7 @@ npm install --no-bin-links
 
 # Installs Neohabitat MongoDB schema and models.
 cd /neohabitat/db
-make clean
+make db
 
 # Clones the QuantumLink Reloaded codebase.
 cd /neohabitat


### PR DESCRIPTION
To ensure stable provisioning for our GDC demo, this PR temporarily reverts the DB Makefile to its original integrated behavior and also cordons off Kelly's back room.

It also makes a few minor changes to Sex_changer to ensure better trace logging and closer compliance to the original PL/1.