### PR TITLE
Enables automated Spine deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,10 @@ script:
 
 after_success:
   # Pushes the Docker image.
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
-      if [[ "$SPINE_DEPLOY" == true ]]; then
-        docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+  - if [ "${TRAVIS_BRANCH}" == "master" ]; then
+      if [[ "${SPINE_DEPLOY}" == true ]]; then
+        cd ${TRAVIS_BUILD_DIR}
+        docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}";
         docker push ${DOCKER_USERNAME}/neohabitat;
 
         curl -o ./spinecli.tgz https://bin.equinox.io/c/jSZ5ZhbDXZ9/spine-cli-stable-linux-amd64.tgz && tar xvzf spinecli.tgz;

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,15 @@ script:
 
   # Executes functional tests:
   - cd test && node Telko.js -f chip
+
+after_success:
+  # Pushes the Docker image.
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+      if [[ "$SPINE_DEPLOY" == true ]]; then
+        docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+        docker push ${DOCKER_USERNAME}/neohabitat;
+
+        curl -o ./spinecli.tgz https://bin.equinox.io/c/jSZ5ZhbDXZ9/spine-cli-stable-linux-amd64.tgz && tar xvzf spinecli.tgz;
+        ./spine deploy;
+      fi
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ script:
   - cd test && node Telko.js -f chip
 
 after_success:
-  # Pushes the Docker image.
+  # Pushes the Docker image then deploys it to Spine.
   - if [ "${TRAVIS_BRANCH}" == "master" ]; then
       if [[ "${SPINE_DEPLOY}" == true ]]; then
-        cd ${TRAVIS_BUILD_DIR}
+        cd ${TRAVIS_BUILD_DIR};
         docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}";
         docker push ${DOCKER_USERNAME}/neohabitat;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,6 @@ after_success:
         docker push ${DOCKER_USERNAME}/neohabitat;
 
         curl -o ./spinecli.tgz https://bin.equinox.io/c/jSZ5ZhbDXZ9/spine-cli-stable-linux-amd64.tgz && tar xvzf spinecli.tgz;
-        ./spine deploy;
+        ./spine cluster deploy neohabitat;
       fi
     fi

--- a/Backbone
+++ b/Backbone
@@ -2,9 +2,20 @@
 clusters:
   - neohabitatmongo:
       image: mongo
-      tag: "3.4"
+      tag: "3.4.1"
       ports:
         - port: 27017
+
+  - neohabitatmariadb:
+      image: mariadb
+      environment:
+        MYSQL_ROOT_PASSWORD: "{{ vault.mysql_root_password }}"
+        MYSQL_DATABASE: qlink
+        MYSQL_USER: spine
+        MYSQL_PASSWORD: spine
+      ports:
+        - port: 3306
+
   - neohabitat:
       image: philcollins/neohabitat
       environment:
@@ -14,12 +25,11 @@ clusters:
         NEOHABITAT_SHOULD_ENABLE_DEBUGGER: "false"
       synapses:
         - resource: neohabitatmongo
-          protocol: tcp
           port: 27017
-          remote_port: 27017
       ports:
         - port: 1337
         - port: 9000
+
   - neohabitatslackin:
       image: chk1/slackin
       environment:
@@ -27,52 +37,36 @@ clusters:
         SLACK_TOKEN: "{{ vault.slack_token }}"
       ports:
         - port: 3000
+
   - neohabitatqlink:
       image: philcollins/qlink
       environment:
         QLINK_DB_HOST: 127.0.0.1
         QLINK_DB_JDBC_URI: jdbc:mysql://127.0.0.1:3306/qlink
-        QLINK_DB_USERNAME: mysos
-        QLINK_DB_PASSWORD: "{{ synapse.neohabitatmysql.admin_password }}"
+        QLINK_DB_USERNAME: spine
+        QLINK_DB_PASSWORD: spine
         QLINK_HABITAT_HOST: 127.0.0.1
         QLINK_SHOULD_CREATE_DB: true
         QLINK_SHOULD_PING: true
       synapses:
         - resource: neohabitat
-          protocol: tcp
           port: 1337
-          remote_port: 1337
-        - resource: neohabitatmysql
-          type: database
+        - resource: neohabitatmariadb
+          port: 3306
       ports:
         - port: 5190
 
-databases:
-  - neohabitatmysql
-
 balancers:
+  - neohabitat:
+      synapses:
+        - resource: neohabitatqlink
+          port: 5190
+        - resource: neohabitat
+          port: 1337
+
   - join-neohabitat:
       enable_ssl: false
       synapses:
         - resource: neohabitatslackin
           protocol: http
           remote_port: 3000
-  - neohabitat:
-      enable_ssl: false
-      synapses:
-        - resource: neohabitatqlink
-          protocol: tcp
-          port: 5190
-          remote_port: 5190
-        - resource: neohabitat
-          protocol: tcp
-          port: 1337
-          remote_port: 1337
-        - resource: neohabitat
-          protocol: tcp
-          port: 9000
-          remote_port: 9000
-        - resource: neohabitat
-          protocol: tcp
-          port: 1898
-          remote_port: 1898

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To connect to the Neohabitat server, you'll need to install a C64 emulator and d
 Download the latest Windows Vice emulator from the above link then make the following configuration changes:
 
 - Go to **Settings –> RS232 Settings**:
-  - Set **RS232 Device 1** to the following: **34.198.66.157:5190**
+  - Set **RS232 Device 1** to the following: **52.87.109.252:5190**
 - Go to **Settings –> Cart I/O Settings –> RS232 Userport settings**:
   - Enable **RS232 Userport** and **Userport Device RS232 Device 1**
   - Set **Userport baud rate** to the following: **1200**
@@ -58,7 +58,7 @@ alias c64='/Applications/x64.app/Contents/MacOS/x64 -rsuser -rsuserbaud 1200 -rs
 ```
 
 - Launch Vice via the above alias then go to **Settings -> Resource Inspector**
-- Under **Peripherals -> RS232**, set **Device 1** to the following: ```|nc 34.198.66.157 5190```
+- Under **Peripherals -> RS232**, set **Device 1** to the following: ```|nc neohabitat.demo.spi.ne 5190```
 - Under **Peripherals -> RS232**, set **Device 1 Baud Rate** to the following: ```1200```
 - Save these new settings via **Settings -> Save current Settings**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - "27017:27017"
   neohabitat:
     build: .
+    image: philcollins/neohabitat
     privileged: true
     volumes:
       - .:/neohabitat


### PR DESCRIPTION
Every time we successfully build on Travis, we should support automated deploys to the Spine demo environment; this way, we can continuously test new code.

I've also added changes to the documentation to point to the new, permanent Neohabitat load balancer and will be announcing this in-channel shortly.