### PR TITLE
Adds container log tailing utility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ RUN yum -y install \
 # Installs Node dependencies.
 RUN npm install -g supervisor
 
+# Adds a container log tailing utility.
+RUN printf '#!/bin/bash\ncat /proc/$(pgrep java)/fd/{1,2} /proc/$(pgrep -f node)/fd/{1,2}' > /usr/bin/habitail && chmod a+x /usr/bin/habitail
+
 # Builds the Neohabitat project.
 WORKDIR /neohabitat
 RUN rm -rf lib && npm install && ./build


### PR DESCRIPTION
It's useful to tail -f any container logs from within its execution environment, so this PR adds a little utility which will do so.