### PR TITLE
Adds Book class

### DIFF
--- a/bridge/Habitat2ElkoBridge.js
+++ b/bridge/Habitat2ElkoBridge.js
@@ -703,7 +703,7 @@ var encodeState = {
 		},
 		document:  function (state, container, buf) {
 			buf = this.common(state, container, buf);
-			buf.add(state.last_page		|| 1);
+			buf.add(state.last_page		|| 0);
 			return buf;
 		},
 		magical: function (state, container, buf) {
@@ -899,7 +899,8 @@ var encodeState = {
 		Sex_changer:  function (state, container, buf) { return (this.common  (state, container, buf)); },
 		Dropbox:  function (state, container, buf) { return (this.common  (state, container, buf)); },
 		Garbage_can: function (state, container, buf) { return (this.openable(state, container, buf)); },
-		Display_case: function (state, container, buf) { return (this.openable(state, container, buf)); }
+		Display_case: function (state, container, buf) { return (this.openable(state, container, buf)); },
+		Book:		function (state, container, buf) { return (this.document(state, container, buf)); }
 };
 
 function habitatEncodeElkoModState (state, container, buf) {

--- a/bridge/hcode.js
+++ b/bridge/hcode.js
@@ -1056,6 +1056,16 @@ this.Display_case	= {
 		}
 };
 
+this.Book = {
+		clientMessages: {
+			0:{ op:"HELP" },
+			1:{ op:"GET" },
+			2:{ op:"PUT" },
+			3:{ op:"THROW" },
+			4:{ op:"READ" }
+		}
+};
+
 this.magical	= {
 		clientMessages: {
 			0:{ op:"HELP" },

--- a/db/Makefile
+++ b/db/Makefile
@@ -28,7 +28,7 @@ DBINIT_SCRIPT = ./dbinit.sh
 
 NEOHABITAT_MONGO_HOST ?= "127.0.0.1"
 
-clean: nuke all help
+clean: nuke all
 
 help:
 	@echo ""
@@ -39,7 +39,7 @@ help:
 book:
 	@echo "Regenerating Book of Records"
 	@rm -f $(DBINIT_SCRIPT) $(BOOKOFRECORDS)
-	@node ../tools/generateBookOfRecords.js --book=$(BOOKOFRECORDS)
+	@node ../tools/generateBookOfRecords.js --book=$(BOOKOFRECORDS) --mongo=$(NEOHABITAT_MONGO_HOST)/elko
 	@echo '#!/bin/bash' > $(DBINIT_SCRIPT)
 	@cp dbinitpre.js $(DBINIT_SCRIPT)
 	@$(foreach F,$(BOOKOFRECORDS), echo "eupdate(" >> $(DBINIT_SCRIPT); cat $F >> $(DBINIT_SCRIPT); echo ")" >>$(DBINIT_SCRIPT);)

--- a/db/classes-habitat.json
+++ b/db/classes-habitat.json
@@ -310,6 +310,11 @@
 			"type": "class",
 			"tag": "Display_case",
 			"name": "org.made.neohabitat.mods.Display_case"
+		},
+		{
+			"type": "class",
+			"tag": "Book",
+			"name": "org.made.neohabitat.mods.Book"
 		}
 	]
 }

--- a/src/main/java/org/made/neohabitat/Document.java
+++ b/src/main/java/org/made/neohabitat/Document.java
@@ -129,7 +129,7 @@ public abstract class Document extends HabitatMod {
         from.send(msg);
     }
     
-    private String getTextPage(String path, int page_to_read) {
+    protected String getTextPage(String path, int page_to_read) {
         return pages[Math.max(Math.min(page_to_read, last_page), 1) - 1];
     }
     

--- a/src/main/java/org/made/neohabitat/mods/Book.java
+++ b/src/main/java/org/made/neohabitat/mods/Book.java
@@ -1,0 +1,161 @@
+package org.made.neohabitat.mods;
+
+import org.elkoserver.foundation.json.JSONMethod;
+import org.elkoserver.foundation.json.OptInteger;
+import org.elkoserver.foundation.json.OptString;
+import org.elkoserver.json.EncodeControl;
+import org.elkoserver.json.JSONLiteral;
+import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.Document;
+import org.made.neohabitat.HabitatMod;
+
+
+/**
+ * Habitat Book Mod (attached to an Elko Item.)
+ *
+ * This is a portable, READ-only text document with a title. Responds to HELP messages.
+ *
+ * @author steve
+ */
+public class Book extends Document implements Copyable {
+
+    public int HabitatClass() {
+        return CLASS_BOOK;
+    }
+
+    public String HabitatModName() {
+        return "Book";
+    }
+
+    public int capacity() {
+        return 0;
+    }
+
+    public int pc_state_bytes() {
+        return 1;
+    };
+
+    public boolean known() {
+        return true;
+    }
+
+    public boolean opaque_container() {
+        return false;
+    }
+
+    public boolean filler() {
+        return false;
+    }
+
+    private String title;
+
+    @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "last_page", "pages", "path", "title" })
+    public Book(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state,
+        int last_page, String pages[], OptString path, OptString title) {
+        super(style, x, y, orientation, gr_state, last_page, pages, path);
+        this.title = title.value("");
+    }
+
+    public Book(int style, int x, int y, int orientation, int gr_state, int last_page, String[] pages, String path,
+        String title) {
+        super(style, x, y, orientation, gr_state, last_page, pages, path);
+        this.title = title;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Book(style, x, y, orientation, gr_state, last_page, pages, path, title);
+    }
+
+    @Override
+    public JSONLiteral encode(EncodeControl control) {
+        JSONLiteral result = super.encodeDocument(new JSONLiteral(HabitatModName(), control));
+        if (control.toRepository()) {
+            result.addParameter("title", title);
+        }
+        result.finish();
+        return result;
+    }
+
+    @JSONMethod({ "page" })
+    public void READ(User from, OptInteger page) {
+        int page_to_read = page.value(0);
+        if (page_to_read == 254) { // aka -1: BACK pressed on UI.
+            page_to_read = Math.max(1, next_page - 2);
+        } else if (page_to_read == 0) {
+            page_to_read = next_page;
+        }
+        if (page_to_read > last_page) {
+            page_to_read = 1;
+        }
+        if (holding(avatar(from), this)) {
+            next_page = page_to_read + 1;
+            show_text_page(from, path, page_to_read, next_page);
+        } else {
+            String textPage = getTextPage(path, page_to_read);
+            send_reply_msg(from, textPage.substring(0, 16));
+        }
+    }
+
+    /**
+     * Verb (Generic): Pick this item up.
+     *
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod
+    public void GET(User from) {
+        generic_GET(from);
+    }
+
+    /**
+     * Verb (Generic): Put this item into some container or on the ground.
+     *
+     * @param from
+     *            User representing the connection making the request.
+     * @param containerNoid
+     *            The Habitat Noid for the target container THE_REGION is
+     *            default.
+     * @param x
+     *            If THE_REGION is the new container, the horizontal position.
+     *            Otherwise ignored.
+     * @param y
+     *            If THE_REGION: the vertical position, otherwise the target
+     *            container slot (e.g. HANDS/HEAD or other.)
+     * @param orientation
+     *            The new orientation for the object being PUT.
+     */
+    @JSONMethod({ "containerNoid", "x", "y", "orientation" })
+    public void PUT(User from, OptInteger containerNoid, OptInteger x, OptInteger y, OptInteger orientation) {
+        generic_PUT(from, containerNoid.value(THE_REGION), x.value(avatar(from).x), y.value(avatar(from).y),
+                orientation.value(avatar(from).orientation));
+    }
+
+    /**
+     * Verb (Generic): Throw this across the Region
+     *
+     * @param from
+     *            User representing the connection making the request.
+     * @param x
+     *            Destination horizontal position
+     * @param y
+     *            Destination vertical position (lower 7 bits)
+     */
+    @JSONMethod({ "target", "x", "y" })
+    public void THROW(User from, int target, int x, int y) {
+        generic_THROW(from, target, x, y);
+    }
+
+    @JSONMethod
+    public void HELP(User from) {
+        send_reply_msg(from, "BOOK: DO while holding to read the book.");
+        if (title.length() == 0) {
+            object_say(from, noid, "This book is untitled.");
+        } else {
+            object_say(from, noid, String.format("This book is '%s'.", title.trim()));
+        }
+    }
+
+}
+


### PR DESCRIPTION
Books are pretty cool all things told and I enjoy reading them often. That's why we should bring the Book class back to Habitat, which is what this PR aims to accomplish:

![screen shot 2017-04-07 at 11 54 42 pm](https://cloud.githubusercontent.com/assets/15283/24826598/af172f08-1bee-11e7-8d77-c6197008c194.png)

Books are like other Document mods, except they respond to GET/PUT/THROW, can only be read if an avatar is holding it, and they can have a title, which is shown when a HELP action is executed upon it.

**PLEASE NOTE**: It looks like we currently bound a document's state.last_page to 1, which caused some issues with the current page mechanism.  I've bound it to 0 instead; please let me know if this is undesirable.

Finally, I've made a few changes to enable successful Docker Compose builds of the Book of Records.

Let me know what you think and thanks!