### PR TITLE
Opened the Hall of Records, added the Book of Records.

### DIFF
--- a/db/new_Downtown/Downtown_5h.json
+++ b/db/new_Downtown/Downtown_5h.json
@@ -56,7 +56,8 @@
       {
         "y": 33, 
         "x": 8, 
-        "open_flags": 0, 
+        "open_flags": 3, 
+		"gr_state": 1,
         "type": "Door",
         "connection": "context-Downtown_5i",		
         "orientation": 220

--- a/db/new_Downtown/Downtown_5i.json
+++ b/db/new_Downtown/Downtown_5i.json
@@ -7,7 +7,7 @@
     "mods": [
       {
         "town_dir": "", 
-        "port_dir": "", 
+        "port_dir": "}", 
         "type": "Region",
         "orientation": 1,
         "neighbors": [
@@ -206,5 +206,23 @@
     "type": "item", 
     "name": "Picture", 
     "in": "context-Downtown_5i"
+  },
+  {
+	"type": "item",
+	"ref": "item-bookofrecords",
+	"name": "Book of Records",
+	"in": "context-Downtown_5i",
+	"mods": [
+		{
+			"type": "Book",
+			"title": "The Great Book of Records",
+			"x": 72,
+			"y": 71,			
+			"last_page": 16,
+			"style": 1,
+			"restricted": 1,
+			"path": "text-bookofrecords"
+		}
+	]
   }
 ]

--- a/db/new_Downtown/Downtown_5i.json
+++ b/db/new_Downtown/Downtown_5i.json
@@ -220,7 +220,7 @@
 			"y": 71,			
 			"last_page": 16,
 			"style": 1,
-			"restricted": 1,
+			"restricted": true,
 			"path": "text-bookofrecords"
 		}
 	]


### PR DESCRIPTION
Downtown_5i contains a property called "restricted" which is not implemented yet, this region will not compile properly until that property is added. To compile this region before-hand, remove the "restricted" property.

The book of records has been added and placed over the podium. Since it must be held to be read, it is not encased in Glue. Once restricted functionality is added, it will not be possible to remove this item from the room.