### PR TITLE
Updates README to point to new Habitat client

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ alias c64='/Applications/x64.app/Contents/MacOS/x64 -rsuser -rsuserbaud 1200 -rs
 
 Client software can be downloaded here:
 
-- [QuantumLink (with Habitat support)](https://s3.amazonaws.com/ssalevan/neohabitat/QuantumLink.d64)
-- [Club Caribe disk A (a.k.a. side 3)](https://s3.amazonaws.com/ssalevan/neohabitat/club-caribe-a.d64)
-- [Club Caribe disk B (a.k.a. Imagery)](https://s3.amazonaws.com/ssalevan/neohabitat/club-caribe-b.d64)
+- [QuantumLink (with Habitat support)](http://cloud.cbm8bit.com/brataccas/QLink-Habitat.d64)
+- [Habitat disk A (a.k.a. side 3)](http://cloud.cbm8bit.com/brataccas/Habitat-A.d64)
+- [Habitat disk B (a.k.a. Imagery)](https://s3.amazonaws.com/ssalevan/neohabitat/Habitat-B.d64)
+
+Major thanks to Gary Lake-Schaal who rebuilt the Habitat client from the original 1985 source!
 
 **NOTE:** Make a backup of QuantumLink.d64, as it gets modified with your account information and a link to the Club Caribe game disk.
 


### PR DESCRIPTION
@glake1 successfully built the original Habitat client from source, which is a huge and awesome step for the project:

![image](https://cloud.githubusercontent.com/assets/15283/25066418/996284e6-21d9-11e7-9b70-a6300b941888.png)
![image](https://cloud.githubusercontent.com/assets/15283/25066422/aa05162e-21d9-11e7-98c7-2de10c25071e.png)

This PR updates our docs to point to this new client instead of the original Club Caribe client.