### PR TITLE
Adds Escape_device class

### DIFF
--- a/bridge/Habitat2ElkoBridge.js
+++ b/bridge/Habitat2ElkoBridge.js
@@ -860,6 +860,11 @@ var encodeState = {
 			buf.add(state.display_item	|| 0);
 			return buf;
 		},
+		Escape_device: function(state, container, buf) {
+			buf = this.common(state, container, buf);
+			buf.add(state.charge || 0);
+			return buf;
+		},
 		Atm:			function (state, container, buf) { return (this.common  (state, container, buf)); },
 		Bag: 			function (state, container, buf) { return (this.openable(state, container, buf)); },
 		Bed:			function (state, container, buf) { return (this.common  (state, container, buf)); },

--- a/bridge/hcode.js
+++ b/bridge/hcode.js
@@ -820,6 +820,11 @@ this.translate = {
 			toClient: function(o, b) {
 				b.add(o.err);
 			}
+		},
+		BUGOUT: {
+			toClient: function(o, b) {
+				b.add(o.err);
+			}
 		}
 };
 
@@ -1126,6 +1131,16 @@ this.Vendo_front	= {
 			0:{ op:"HELP" },
 			4:{ op:"VEND" },
 			5:{ op:"VSELECT" }
+		}
+};
+
+this.Escape_device = {
+		clientMessages: {
+			0:{ op:"HELP" },
+			1:{ op:"GET" },
+			2:{ op:"PUT" },
+			3:{ op:"THROW" },
+			4:{ op:"BUGOUT" }
 		}
 };
 

--- a/db/classes-habitat.json
+++ b/db/classes-habitat.json
@@ -330,6 +330,11 @@
 			"type": "class",
 			"tag": "Book",
 			"name": "org.made.neohabitat.mods.Book"
+		},
+		{
+			"type": "class",
+			"tag": "Escape_device",
+			"name": "org.made.neohabitat.mods.Escape_device"
 		}
 	]
 }

--- a/regionator/mod_index.yml
+++ b/regionator/mod_index.yml
@@ -58,6 +58,9 @@ Display_case:
 Door:
   <<: *openable
 
+Escape_device:
+  8: charge
+
 Flag:
   <<: *massive
 

--- a/src/main/java/org/made/neohabitat/mods/Escape_device.java
+++ b/src/main/java/org/made/neohabitat/mods/Escape_device.java
@@ -1,0 +1,166 @@
+package org.made.neohabitat.mods;
+
+import org.elkoserver.foundation.json.JSONMethod;
+import org.elkoserver.foundation.json.OptBoolean;
+import org.elkoserver.foundation.json.OptInteger;
+import org.elkoserver.json.EncodeControl;
+import org.elkoserver.json.JSONLiteral;
+import org.elkoserver.server.context.User;
+
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
+
+
+/**
+ * Habitat Escape Device Mod
+ *
+ * The Escape Device mod, when activated upon an Avatar, will teleport
+ * that avatar back to their turf, up to the number of available
+ * charges.
+ *
+ * @author steve
+ */
+public class Escape_device extends HabitatMod implements Copyable {
+
+    public int HabitatClass() {
+        return CLASS_ESCAPE_DEV;
+    }
+
+    public String HabitatModName() {
+        return "Escape_device";
+    }
+
+    public int capacity() {
+        return 0;
+    }
+
+    public int pc_state_bytes() {
+        return 1;
+    }
+
+    public boolean known() {
+        return true;
+    }
+
+    public boolean opaque_container() {
+        return false;
+    }
+
+    public boolean filler() {
+        return false;
+    }
+
+    private int charge = 3;
+
+    @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "restricted", "charge" })
+    public Escape_device(OptInteger style, OptInteger x, OptInteger y,
+        OptInteger orientation, OptInteger gr_state, OptBoolean restricted,
+        OptInteger charge) {
+        super(style, x, y, orientation, gr_state, restricted);
+        this.charge = charge.value(5);
+    }
+
+    public Escape_device(int style, int x, int y, int orientation, int gr_state,
+        boolean restricted, int charge) {
+        super(style, x, y, orientation, gr_state, restricted);
+        this.charge = charge;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Escape_device(style, x, y, orientation, gr_state, restricted, charge);
+    }
+
+    @Override
+    public JSONLiteral encode(EncodeControl control) {
+        JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));
+        result.addParameter("charge", charge);
+        result.finish();
+        return result;
+    }
+
+    @JSONMethod
+    public void BUGOUT(User from) {
+        Avatar avatar = avatar(from);
+        if (holding(avatar, this) && charge > 0) {
+            if (avatar.turf.equals(current_region().object().ref())) {
+                object_say(from, noid, "You're already home.");
+                send_reply_error(from);
+            } else {
+                avatar.x = 80;
+                avatar.y = 132;
+                avatar.inc_record(HS$escapes);
+                avatar.markAsChanged();
+                send_reply_success(from);
+                send_neighbor_msg(from, avatar.noid, "BUGOUT$");
+                charge--;
+                gen_flags[MODIFIED] = true;
+                checkpoint_object(this);
+                avatar.change_regions(avatar.turf, 0, 1);
+            }
+        } else {
+            object_say(from, noid, "Its charge is all used up.");
+            send_reply_error(from);
+        }
+    }
+
+    @JSONMethod
+    public void HELP(User from) {
+        if (charge > 0) {
+            send_reply_msg(from,
+                String.format("Choose DO to activate.  Available charge: %d units.", charge));
+        } else {
+            send_reply_msg(from, "This device has run out of charge.");
+        }
+    }
+
+    /**
+     * Verb (Generic): Pick this item up.
+     *
+     * @param from
+     *            User representing the connection making the request.
+     */
+    @JSONMethod
+    public void GET(User from) {
+        generic_GET(from);
+    }
+
+    /**
+     * Verb (Generic): Put this item into some container or on the ground.
+     *
+     * @param from
+     *            User representing the connection making the request.
+     * @param containerNoid
+     *            The Habitat Noid for the target container THE_REGION is
+     *            default.
+     * @param x
+     *            If THE_REGION is the new container, the horizontal position.
+     *            Otherwise ignored.
+     * @param y
+     *            If THE_REGION: the vertical position, otherwise the target
+     *            container slot (e.g. HANDS/HEAD or other.)
+     * @param orientation
+     *            The new orientation for the object being PUT.
+     */
+    @JSONMethod({ "containerNoid", "x", "y", "orientation" })
+    public void PUT(User from, OptInteger containerNoid, OptInteger x, OptInteger y, OptInteger orientation) {
+        generic_PUT(from, containerNoid.value(THE_REGION), x.value(avatar(from).x), y.value(avatar(from).y),
+            orientation.value(avatar(from).orientation));
+    }
+
+    /**
+     * Verb (Generic): Throw this across the Region
+     *
+     * @param from
+     *            User representing the connection making the request.
+     * @param x
+     *            Destination horizontal position
+     * @param y
+     *            Destination vertical position (lower 7 bits)
+     */
+    @JSONMethod({ "target", "x", "y" })
+    public void THROW(User from, int target, int x, int y) {
+        generic_THROW(from, target, x, y);
+    }
+
+}


### PR DESCRIPTION
We all need a little escape from time to time, especially if you're in the Back 40. As such, this PR adds the ```Escape_device``` class alongside necessary Regionator scripting to allow its conversion from RDL.

This class has been tested using multiple C64 clients:

![screen shot 2017-05-06 at 11 01 18 pm](https://cloud.githubusercontent.com/assets/15283/25778529/4c9e95ae-32b5-11e7-8a29-e66d689b8e79.png)
![screen shot 2017-05-06 at 11 20 09 pm](https://cloud.githubusercontent.com/assets/15283/25778531/5361a278-32b5-11e7-8571-1017750b1035.png)
![screen shot 2017-05-06 at 11 25 02 pm](https://cloud.githubusercontent.com/assets/15283/25778532/582a6e52-32b5-11e7-9cac-c36036683a4e.png)
![screen shot 2017-05-06 at 11 35 11 pm](https://cloud.githubusercontent.com/assets/15283/25778533/5b26236c-32b5-11e7-904c-0a5fb79736a7.png)

Let me know what you think and thanks!