### PR TITLE
Creates new Elevator class, refactors common teleporting code into Teleporter abstract class

### DIFF
--- a/bridge/Habitat2ElkoBridge.js
+++ b/bridge/Habitat2ElkoBridge.js
@@ -865,6 +865,11 @@ var encodeState = {
 			buf.add(state.charge || 0);
 			return buf;
 		},
+		Elevator: function(state, container, buf) {
+			buf = this.common(state, container, buf);
+			buf.add(state.activeState || 0);
+			return buf;
+		},
 		Atm:			function (state, container, buf) { return (this.common  (state, container, buf)); },
 		Bag: 			function (state, container, buf) { return (this.openable(state, container, buf)); },
 		Bed:			function (state, container, buf) { return (this.common  (state, container, buf)); },

--- a/bridge/hcode.js
+++ b/bridge/hcode.js
@@ -414,6 +414,7 @@ this.CLASSES 			= {
 		"Drugs":	25, 25:"Drugs",
 		"Escape_device":26, 26:"Escape_device",
 		"Fake_gun":	27, 27:"Fake_gun",
+		"Elevator": 28, 28:"Elevator",
 		"Flag":		29, 29:"Flag",
 		"Flashlight":30, 30:"Flashlight",
 		"Frisbee":	31, 31:"Frisbee",
@@ -1141,6 +1142,13 @@ this.Escape_device = {
 			2:{ op:"PUT" },
 			3:{ op:"THROW" },
 			4:{ op:"BUGOUT" }
+		}
+};
+
+this.Elevator = {
+		clientMessages: {
+			0:{ op:"HELP" },
+			5:{ op:"ZAPTO" }
 		}
 };
 

--- a/db/Backroom/context-library.json
+++ b/db/Backroom/context-library.json
@@ -10,7 +10,7 @@
 			"port_dir": "",
 			"type": "Region",
 			"nitty_bits": 2,
-			"neighbors": ["", "context-table", "context-test", ""]
+			"neighbors": ["context-steve1", "context-table", "context-test", ""]
 		}
 	]
 },

--- a/db/Backroom/context-steve1.json
+++ b/db/Backroom/context-steve1.json
@@ -1,0 +1,66 @@
+[
+  {
+    "type": "context",
+    "ref": "context-steve1",
+    "capacity": 6,
+    "name": "Welcome to Steve: Floor 1",
+    "mods": [
+      {
+        "town_dir": "",
+        "port_dir": "missing",
+        "type": "Region",
+        "nitty_bits": 2,
+        "neighbors": [ 
+          "context-library",
+          "context-library",
+          "context-library",
+          "context-library"
+        ]
+      }
+    ]
+  },
+  {
+    "ref": "item-steve1.wall", 
+    "mods": [
+      {
+        "y": 0,
+        "x": 0,
+        "style": 5,
+        "type": "Wall",
+        "orientation": 148
+      }
+    ],
+    "type": "item",
+    "name": "Wall",
+    "in": "context-steve1"
+  },
+  {
+    "ref": "item-steve1.ground", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-steve1"
+  }, 
+  {
+    "type": "item",
+    "ref": "item-steve1.elevator",
+    "name": "Elevator - Steve 1",
+    "in": "context-steve1",
+    "mods": [
+      {
+        "type": "Elevator",
+        "x": 60,
+        "y": 26,
+        "address": "steve-1"
+      }
+    ]
+  }
+]

--- a/db/Backroom/context-steve2.json
+++ b/db/Backroom/context-steve2.json
@@ -1,0 +1,66 @@
+[ 
+  {
+    "type": "context",
+    "ref": "context-steve2",
+    "capacity": 6,
+    "name": "Welcome to Steve: Floor 2",
+    "mods": [
+      {
+        "town_dir": "",
+        "port_dir": "missing",
+        "type": "Region",
+        "nitty_bits": 2,
+        "neighbors": [ 
+          "context-library",
+          "context-library",
+          "context-library",
+          "context-library"
+        ]
+      }
+    ]
+  },
+  {
+    "ref": "item-steve2.wall", 
+    "mods": [
+      {
+        "y": 0,
+        "x": 0,
+        "style": 5,
+        "type": "Wall",
+        "orientation": 148
+      }
+    ],
+    "type": "item",
+    "name": "Wall",
+    "in": "context-steve2"
+  },
+  {
+    "ref": "item-steve2.ground", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-steve2"
+  },
+  {
+    "type": "item",
+    "ref": "item-steve2.elevator",
+    "name": "Elevator - Steve 2",
+    "in": "context-steve2",
+    "mods": [
+      {
+        "type": "Elevator",
+        "x": 60,
+        "y": 26,
+        "address": "steve-2"
+      }
+    ]
+  }
+]

--- a/db/classes-habitat.json
+++ b/db/classes-habitat.json
@@ -335,6 +335,11 @@
 			"type": "class",
 			"tag": "Escape_device",
 			"name": "org.made.neohabitat.mods.Escape_device"
+		},
+		{
+			"type": "class",
+			"tag": "Elevator",
+			"name": "org.made.neohabitat.mods.Elevator"
 		}
 	]
 }

--- a/db/dumpTeleportEntries.js
+++ b/db/dumpTeleportEntries.js
@@ -22,6 +22,8 @@ var lookForTeleportEntries = function (o) {
 		if (mod.type === "Teleport") {
 			console.log("\"" + squish(mod.address) + "\":\"" + o.in + "\",");
 			lookForAliases(mod, o.in);
+		} else if (mod.type === "Elevator") {
+			console.log("\"" + "otis-" + squish(mod.address) + "\":\"" + o.in + "\",");
 		}
 		if (o.type === "context") {
 			lookForAliases(o, o.ref);

--- a/regionator/mod_index.yml
+++ b/regionator/mod_index.yml
@@ -27,6 +27,9 @@ polygonal: &polygonal
   12: lower_right_x
   13: height
 
+teleporter: &teleporter
+  8: activeState
+
 toggle: &toggle
   8: "on"
 
@@ -57,6 +60,9 @@ Display_case:
 
 Door:
   <<: *openable
+
+Elevator:
+  <<: *teleporter
 
 Escape_device:
   8: charge
@@ -129,7 +135,7 @@ Table:
   <<: *openable
 
 Teleport:
-  8: activeState
+  <<: *teleporter
 
 Tokens:
   8: denom_lo

--- a/src/main/java/org/made/neohabitat/Teleporter.java
+++ b/src/main/java/org/made/neohabitat/Teleporter.java
@@ -1,0 +1,112 @@
+package org.made.neohabitat;
+
+import java.util.Map;
+
+import org.elkoserver.foundation.json.OptBoolean;
+import org.elkoserver.foundation.json.OptInteger;
+import org.elkoserver.json.EncodeControl;
+import org.elkoserver.json.JSONLiteral;
+import org.elkoserver.server.context.User;
+
+import org.made.neohabitat.mods.Avatar;
+
+
+/**
+ * Encapsulates logic common to classes which perform Avatar teleportation,
+ * e.g. Teleport and Elevator.
+ */
+public abstract class Teleporter extends Coinop {
+
+    public static final int TELEPORT_COST = 10;
+    public static final int PORT_READY    = 0;
+    public static final int PORT_ACTIVE   = 1;
+
+    /** The (de)active state of the teleport [server + client]  was 'state' in struct_teleport */
+    protected int activeState = PORT_READY;
+
+    /** The teleport address of this teleport [server only] */
+    protected String address = "";
+
+    public Teleporter(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
+        OptInteger gr_state, OptBoolean restricted, OptInteger activeState, OptInteger take, String address) {
+        super(style, x, y, orientation, gr_state, restricted, take);
+        setTeleportState(activeState.value(PORT_READY), address);
+    }
+
+    public Teleporter(int style, int x, int y, int orientation, int gr_state,
+        boolean restricted, int activeState, int take, String address) {
+        super(style, x, y, orientation, gr_state, restricted, take);
+        setTeleportState(activeState, address);
+    }
+
+    public JSONLiteral encodeTeleporter(JSONLiteral result, EncodeControl control) {
+        super.encodeCoinop(result);
+        result.addParameter("activeState", activeState);
+        if (control.toRepository()) {
+            result.addParameter("address", address);
+        }
+        return result;
+    }
+
+    protected void setTeleportState(int activeState, String address) {
+        this.activeState = activeState;
+        this.address = address;
+    }
+
+    protected void activate_teleporter(User from, String destination, int x, int y) {
+        if (destination == null) {
+            object_say(from,
+                (HabitatClass() == CLASS_TELEPORT) ?
+                    "There is no such place.  Please check the area code and address and try again." :
+                    "There is no such floor.  Please check the number and try again.");
+        } else if (destination.equals(context().ref())) {
+            object_say(from, "Malfunction! You may not teleport to the same location.");
+        } else {
+            Avatar avatar = avatar(from);
+            if (adjacent(avatar) &&
+                (activeState == PORT_ACTIVE || HabitatClass() == CLASS_ELEVATOR)) {
+                // Moved arrival positioning logic to avatar.objectIsComplete
+                send_reply_success(from);
+                avatar.inc_record(HS$teleports);
+                goto_new_region(avatar, destination, EAST, TELEPORT_ENTRY, x, y);
+                send_neighbor_msg(from, noid, "ZAPTO$");
+                if (HabitatClass() == CLASS_TELEPORT) {
+                    activeState			= PORT_READY;
+                    gr_state			= PORT_READY;
+                    gen_flags[MODIFIED]	= true;
+                    send_neighbor_fiddle_msg(from, THE_REGION, noid, C64_GR_STATE_OFFSET, PORT_READY);
+                }
+                return;
+            }
+        }
+        send_reply_error(from);
+    }
+
+    protected void activate_teleporter(User from, String destination) {
+        activate_teleporter(from, destination, 0, 0);
+    }
+
+    public String lookupTeleportDestination(String key) {
+        @SuppressWarnings("unchecked")
+        Map<String, String> directory = (Map<String, String>) context().getStaticObject("teleports");
+        return (String) directory.get(squish(key));
+    }
+
+    protected String squish(String value) {
+        return value.toLowerCase().replaceAll("\\s","");
+    }
+
+    protected String area_code(String value) {
+        value = squish(value);
+        int mark = value.indexOf('-');
+        if (mark == -1) {
+            return "pop-";
+        }
+        return value.substring(0, mark + 1);
+    }
+
+    protected String area_code() {
+        return area_code(address);
+    }
+
+}

--- a/src/main/java/org/made/neohabitat/mods/Elevator.java
+++ b/src/main/java/org/made/neohabitat/mods/Elevator.java
@@ -1,0 +1,90 @@
+package org.made.neohabitat.mods;
+
+import org.elkoserver.foundation.json.JSONMethod;
+import org.elkoserver.foundation.json.OptBoolean;
+import org.elkoserver.foundation.json.OptInteger;
+import org.elkoserver.json.EncodeControl;
+import org.elkoserver.json.JSONLiteral;
+import org.elkoserver.server.context.User;
+
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
+import org.made.neohabitat.Teleporter;
+
+
+/**
+ * Habitat Elevator Mod (attached to an Elko Item.)
+ *
+ * Teleports an Avatar to another Elevator, prefixed by "otis-" and the Elevator's
+ * area code.
+ *
+ * @author steve
+ */
+public class Elevator extends Teleporter implements Copyable {
+
+    public int HabitatClass() {
+        return CLASS_ELEVATOR;
+    }
+
+    public String HabitatModName() {
+        return "Elevator";
+    }
+
+    public int capacity() {
+        return 0;
+    }
+
+    public int pc_state_bytes() {
+        return 1;
+    };
+
+    public boolean known() {
+        return true;
+    }
+
+    public boolean opaque_container() {
+        return false;
+    }
+
+    public boolean filler() {
+        return false;
+    }
+
+    @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "restricted", "activeState", "take", "address"})
+    public Elevator(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
+        OptInteger gr_state, OptBoolean restricted, OptInteger activeState,  OptInteger take,
+        String address) {
+        super(style, x, y, orientation, gr_state, restricted, activeState, take, address);
+    }
+
+    public Elevator(int style, int x, int y, int orientation, int gr_state, boolean restricted,
+        int activeState, int take, String address) {
+        super(style, x, y, orientation, gr_state, restricted, activeState, take, address);
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Elevator(style, x, y, orientation, gr_state, restricted, activeState, take, address);
+    }
+
+    public JSONLiteral encode(EncodeControl control) {
+        JSONLiteral result = super.encodeTeleporter(
+            new JSONLiteral(HabitatModName(), control), control);
+        result.finish();
+        return result;
+    }
+
+    @JSONMethod({"port_number"})
+    public void ZAPTO(User from, String port_number) {
+        String elevator_destination = "otis-" + area_code() + squish(port_number.toLowerCase());
+        activate_teleporter(from, lookupTeleportDestination(elevator_destination));
+    }
+
+    @Override
+    @JSONMethod
+    public void HELP(User from) {
+        send_reply_msg(from, "ELEVATOR: stand in elevator and type desired floor followed by RETURN.");
+        object_say(from, "This is elevator \"" + address.trim() + "\"");
+    }
+
+}

--- a/src/main/java/org/made/neohabitat/mods/Teleport.java
+++ b/src/main/java/org/made/neohabitat/mods/Teleport.java
@@ -6,7 +6,11 @@ import org.elkoserver.foundation.json.OptInteger;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
-import org.made.neohabitat.*;
+
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
+import org.made.neohabitat.Teleporter;
+
 
 /**
  * Habitat Teleport Mod (attached to an Elko Item.)
@@ -48,24 +52,24 @@ public class Teleport extends Teleporter implements Copyable {
     
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "restricted", "activeState", "take", "address"})
     public Teleport(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
-	    OptInteger gr_state, OptBoolean restricted, OptInteger activeState,  OptInteger take,
-		String address) {
+        OptInteger gr_state, OptBoolean restricted, OptInteger activeState,  OptInteger take,
+        String address) {
         super(style, x, y, orientation, gr_state, restricted, activeState, take, address);
     }
 
-	public Teleport(int style, int x, int y, int orientation, int gr_state, boolean restricted,
-		int activeState, int take, String address) {
-		super(style, x, y, orientation, gr_state, restricted, activeState, take, address);
-	}
+    public Teleport(int style, int x, int y, int orientation, int gr_state, boolean restricted,
+        int activeState, int take, String address) {
+        super(style, x, y, orientation, gr_state, restricted, activeState, take, address);
+    }
 
-	@Override
-	public HabitatMod copyThisMod() {
-		return new Teleport(style, x, y, orientation, gr_state, restricted, activeState, take, address);
-	}
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Teleport(style, x, y, orientation, gr_state, restricted, activeState, take, address);
+    }
 
     public JSONLiteral encode(EncodeControl control) {
         JSONLiteral result = super.encodeTeleporter(
-			new JSONLiteral(HabitatModName(), control), control);
+            new JSONLiteral(HabitatModName(), control), control);
         result.finish();
         return result;
     }
@@ -73,43 +77,43 @@ public class Teleport extends Teleporter implements Copyable {
     @Override
     @JSONMethod
     public void HELP(User from) {
-    	send_reply_msg(from, "TELEPORT: PUT $" + TELEPORT_COST + " here to activate, point at booth and type desired destination address followed by RETURN.");
-    	object_say(from, "This is TelePort \"" + address.trim() + "\"");
+        send_reply_msg(from,
+            "TELEPORT: PUT $" + TELEPORT_COST + " here to activate, point at booth and type desired destination address followed by RETURN.");
+        object_say(from, "This is TelePort \"" + address.trim() + "\"");
     }
 
     @JSONMethod
     public void PAY(User from) {
-    	int success = FALSE;
-    	if (activeState == PORT_READY) {
-    		Avatar	avatar = (Avatar) from.getMod(Avatar.class);
-    		success = Tokens.spend(from, TELEPORT_COST, Tokens.CLIENT_DESTROYS_TOKEN);		
-    		if (success == TRUE) {
-    			addToTake(TELEPORT_COST);
-    			activeState			= PORT_ACTIVE;
-    			gr_state			= PORT_ACTIVE;
-    			gen_flags[MODIFIED]	= true;
-    			send_fiddle_msg(THE_REGION, noid, C64_GR_STATE_OFFSET, PORT_ACTIVE);            
-        		send_neighbor_msg(from, noid, "PAID$", "payer", avatar.noid, "amount_lo", TELEPORT_COST, "amount_hi", 0);
-    		} else {
-        		object_say(from,  "You don't have enough money.  Teleportation costs $" +  TELEPORT_COST +  ".");    			
-    		}
-    	}
-    	this.send_reply_msg(from, noid, "err", success, "amount_lo", TELEPORT_COST, "amount_hi", 0);
+        int success = FALSE;
+        if (activeState == PORT_READY) {
+            Avatar	avatar = (Avatar) from.getMod(Avatar.class);
+            success = Tokens.spend(from, TELEPORT_COST, Tokens.CLIENT_DESTROYS_TOKEN);
+            if (success == TRUE) {
+                addToTake(TELEPORT_COST);
+                activeState			= PORT_ACTIVE;
+                gr_state			= PORT_ACTIVE;
+                gen_flags[MODIFIED]	= true;
+                send_fiddle_msg(THE_REGION, noid, C64_GR_STATE_OFFSET, PORT_ACTIVE);
+                send_neighbor_msg(from, noid, "PAID$", "payer", avatar.noid, "amount_lo", TELEPORT_COST, "amount_hi", 0);
+            } else {
+                object_say(from,  "You don't have enough money.  Teleportation costs $" +  TELEPORT_COST +  ".");
+            }
+        }
+        this.send_reply_msg(from, noid, "err", success, "amount_lo", TELEPORT_COST, "amount_hi", 0);
     }
     
     @JSONMethod({"port_number"})
     public void ZAPTO(User from, String port_number) {
-    	Avatar avatar = avatar(from);
-    	port_number = squish(port_number);
-    	if (port_number.equals("home")) {
-    		activate_teleporter(from, avatar.turf, 72, 130);
-    		return;
-    	}
-    	if (port_number.indexOf('-') == -1) {
-    		port_number = area_code() + port_number;
-    	}
-    	activate_teleporter(from, lookupTeleportDestination(port_number));
+        Avatar avatar = avatar(from);
+        port_number = squish(port_number);
+        if (port_number.equals("home")) {
+            activate_teleporter(from, avatar.turf, 72, 130);
+            return;
+        }
+        if (port_number.indexOf('-') == -1) {
+            port_number = area_code() + port_number;
+        }
+        activate_teleporter(from, lookupTeleportDestination(port_number));
     }
-
 
 }

--- a/src/main/java/org/made/neohabitat/mods/Teleport.java
+++ b/src/main/java/org/made/neohabitat/mods/Teleport.java
@@ -1,20 +1,12 @@
 package org.made.neohabitat.mods;
 
-import java.util.Map;
-
-import javax.print.attribute.standard.Destination;
-
 import org.elkoserver.foundation.json.JSONMethod;
 import org.elkoserver.foundation.json.OptBoolean;
 import org.elkoserver.foundation.json.OptInteger;
-import org.elkoserver.foundation.json.OptString;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.User;
-import org.made.neohabitat.Coinop;
-import org.made.neohabitat.Copyable;
-import org.made.neohabitat.HabitatMod;
-import org.made.neohabitat.Massive;
+import org.made.neohabitat.*;
 
 /**
  * Habitat Teleport Mod (attached to an Elko Item.)
@@ -24,7 +16,7 @@ import org.made.neohabitat.Massive;
  * @author randy
  *
  */
-public class Teleport extends Coinop implements Copyable {
+public class Teleport extends Teleporter implements Copyable {
     
     public int HabitatClass() {
         return CLASS_TELEPORT;
@@ -54,31 +46,16 @@ public class Teleport extends Coinop implements Copyable {
         return false;
     }
     
-    static final int TELEPORT_COST		= 10;
-    static final int PORT_READY			= 0;
-    static final int PORT_ACTIVE		= 1;
-    
-    /** The (de)active state of the teleport [server + client]  was 'state' in struct_teleport */
-    private int 	activeState = PORT_READY;
-    
-    /** The teleport address of this teleport [server only] */
-    private String	address		= "";
-    
     @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "restricted", "activeState", "take", "address"})
-    public Teleport(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state, OptBoolean restricted,
-		OptInteger activeState,  OptInteger take, String address) {
-        super(style, x, y, orientation, gr_state, restricted, take);
-        setTeleportState(activeState.value(PORT_READY), address);
+    public Teleport(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation,
+	    OptInteger gr_state, OptBoolean restricted, OptInteger activeState,  OptInteger take,
+		String address) {
+        super(style, x, y, orientation, gr_state, restricted, activeState, take, address);
     }
 
-	public Teleport(int style, int x, int y, int orientation, int gr_state, boolean restricted, int activeState, int take, String address) {
-		super(style, x, y, orientation, gr_state, restricted, take);
-		setTeleportState(activeState, address);
-	}
-	
-	protected void setTeleportState(int activeState, String address) {
-		this.activeState = activeState;
-		this.address = address;
+	public Teleport(int style, int x, int y, int orientation, int gr_state, boolean restricted,
+		int activeState, int take, String address) {
+		super(style, x, y, orientation, gr_state, restricted, activeState, take, address);
 	}
 
 	@Override
@@ -87,11 +64,8 @@ public class Teleport extends Coinop implements Copyable {
 	}
 
     public JSONLiteral encode(EncodeControl control) {
-        JSONLiteral result = super.encodeCoinop(new JSONLiteral(HabitatModName(), control));
-        result.addParameter("activeState", activeState);
-        if (control.toRepository()) {
-        	result.addParameter("address", address);
-        }
+        JSONLiteral result = super.encodeTeleporter(
+			new JSONLiteral(HabitatModName(), control), control);
         result.finish();
         return result;
     }
@@ -123,7 +97,7 @@ public class Teleport extends Coinop implements Copyable {
     	this.send_reply_msg(from, noid, "err", success, "amount_lo", TELEPORT_COST, "amount_hi", 0);
     }
     
-    @JSONMethod ({"port_number"})
+    @JSONMethod({"port_number"})
     public void ZAPTO(User from, String port_number) {
     	Avatar avatar = avatar(from);
     	port_number = squish(port_number);
@@ -135,63 +109,6 @@ public class Teleport extends Coinop implements Copyable {
     		port_number = area_code() + port_number;
     	}
     	activate_teleporter(from, lookupTeleportDestination(port_number));
-    }
-
-    private void activate_teleporter(User from, String destination, int x, int y) {
-    	if (destination == null) {
-    		object_say(from,
-    				(HabitatClass() == CLASS_TELEPORT) ?
-    				"There is no such place.  Please check the area code and address and try again." :
-    				"There is no such floor.  Please check the number and try again.");
-    	} else if (destination.equals(context().ref())) {
-    			object_say(from, "Malfunction! You may not teleport to the same location.");
-    	} else {
-    		Avatar avatar = avatar(from);
-    		if (adjacent(avatar) && 
-    				(activeState == PORT_ACTIVE || HabitatClass() == CLASS_ELEVATOR)) {
-    			// Moved arrival positioning logic to avatar.objectIsComplete
-    			send_reply_success(from);
-                avatar.inc_record(HS$teleports);
-    			goto_new_region(avatar, destination, EAST, TELEPORT_ENTRY, x, y);
-    			send_neighbor_msg(from, noid, "ZAPTO$");
-    			if (HabitatClass() == CLASS_TELEPORT) {
-    				activeState			= PORT_READY;
-    				gr_state			= PORT_READY;
-    				gen_flags[MODIFIED]	= true;
-    				send_neighbor_fiddle_msg(from, THE_REGION, noid, C64_GR_STATE_OFFSET, PORT_READY);            
-    			}
-    			return;
-    		}
-    	}
-    	send_reply_error(from);
-    }
-    
-    private void activate_teleporter(User from, String destination) {
-    	activate_teleporter(from, destination, 0, 0);
-    }
-    
-    public String lookupTeleportDestination(String key) {
-    	@SuppressWarnings("unchecked")
-    	Map<String, String> directory = (Map<String, String>) context().getStaticObject("teleports");
-    	return (String) directory.get(squish(key));
-    }
-
-   
-    private String squish(String value) {
-    	return value.toLowerCase().replaceAll("\\s","");
-    }
-    
-    private String area_code(String value) {
-    	value = squish(value);
-    	int mark = value.indexOf('-');
-    	if (mark == -1) {
-    		return "pop-";
-    	}
-    	return value.substring(0, mark + 1);
-    }
-    
-    private String area_code() {
-    	return area_code(address);
     }
 
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/15283/25784869/5a618470-3329-11e7-9a4c-58f0673c22b6.png)

Elevators are great and I enjoy riding them frequently. It follows then that the grand poetry of the elevator should return to Neohabitat once again:

![screen shot 2017-05-07 at 1 13 54 pm](https://cloud.githubusercontent.com/assets/15283/25784825/a4bf1010-3328-11e7-9b2b-9408cf75f465.png)
![screen shot 2017-05-07 at 1 14 59 pm](https://cloud.githubusercontent.com/assets/15283/25784826/a7473fa6-3328-11e7-8a84-068235afa9df.png)
![screen shot 2017-05-07 at 1 07 11 pm](https://cloud.githubusercontent.com/assets/15283/25784830/ad4f38fe-3328-11e7-972a-f60772c50cdf.png)
![screen shot 2017-05-07 at 1 10 23 pm](https://cloud.githubusercontent.com/assets/15283/25784833/af0e7060-3328-11e7-8cf9-666adeab68a7.png)

Notes
------

**Refactor of common teleport logic into Teleporter abstract class**

As it turns out, the **Teleport** and **Elevator** class share a fair bit of common logic, so I've pulled the important bits into a common abstract class, **Teleporter**, from which they now derive.

I've tested both the **Elevator** and **Teleport** classes to work properly after this refactor, both in single and multiple C64 arrangements.

**'otis-' prefix**

The PL/1 source builds the teleport destination string by prepending the prefix ```otis-``` before the area code and floor number:

https://github.com/Museum-of-Art-and-Digital-Entertainment/habitat/blob/master/sources/stratus/Classes/class_elevator.pl1#L55

As such, I've added in support for prepending this prefix before all Elevator address IDs when dumping the static teleport table:

https://github.com/frandallfarmer/neohabitat/compare/master...ssalevan:master#diff-e2904f3df3f637009b5376e358a4ea0bR25

Let me know what you think and thanks!