### PR TITLE
Simplifies Paper logic and fixes several bugs

### DIFF
--- a/db/Backroom/context-steve2.json
+++ b/db/Backroom/context-steve2.json
@@ -73,6 +73,7 @@
         "type": "Paper",
         "x": 16,
         "y": 130,
+        "gr_state": 1,
         "orientation": 16,
         "text_path": "text-popmap"
       }


### PR DESCRIPTION
This PR simplifies Paper's ```text_path``` determination logic and DB lookup logic significantly; it also changes the gr_state of the Paper object in the steve2 region to properly reflect the current state.

Let me know what you think and thanks!