### PR TITLE
Corrects crash issues when paper removed from pocket

### DIFF
--- a/src/main/java/org/made/neohabitat/mods/Paper.java
+++ b/src/main/java/org/made/neohabitat/mods/Paper.java
@@ -9,6 +9,7 @@ import org.elkoserver.server.context.Item;
 import org.elkoserver.server.context.User;
 
 import org.elkoserver.util.ArgRunnable;
+import org.made.neohabitat.Constants;
 import org.made.neohabitat.Copyable;
 import org.made.neohabitat.HabitatMod;
 
@@ -265,7 +266,7 @@ public class Paper extends HabitatMod implements Copyable {
                 }*/
                 announce_it = true;
             }
-            send_neighbor_msg(from, noid, "GET$", "target", noid, "how", how);
+            send_neighbor_msg(from, avatar.noid, "GET$", "target", noid, "how", how);
         } else {
             success = false;
         }
@@ -283,7 +284,34 @@ public class Paper extends HabitatMod implements Copyable {
 
     @JSONMethod
     public void PSENDMAIL(User from) {
-        illegal(from, this.HabitatModName() + ".PSENDMAIL");
+        Avatar avatar = avatar(from);
+        boolean success;
+        Paper paperInHands = null;
+        HabitatMod inHands = avatar.contents(HANDS);
+
+        if (holding(avatar, this)) {
+            if (inHands instanceof Paper) {
+                paperInHands = (Paper) inHands;
+                success = paperInHands.send_mail_message(from);
+            } else {
+                success = false;
+            }
+        } else {
+            success = false;
+        }
+
+        if (success) {
+            send_reply_success(from);
+            send_goaway_msg(paperInHands.noid);
+            destroy_object(paperInHands);
+            avatar.inc_record(Constants.HS$mail_send_count);
+        } else {
+            send_reply_error(from);
+        }
+    }
+
+    private boolean send_mail_message(User from) {
+        return true;
     }
 
     /**

--- a/src/main/java/org/made/neohabitat/mods/Paper.java
+++ b/src/main/java/org/made/neohabitat/mods/Paper.java
@@ -284,30 +284,7 @@ public class Paper extends HabitatMod implements Copyable {
 
     @JSONMethod
     public void PSENDMAIL(User from) {
-        Avatar avatar = avatar(from);
-        boolean success;
-        Paper paperInHands = null;
-        HabitatMod inHands = avatar.contents(HANDS);
-
-        if (holding(avatar, this)) {
-            if (inHands instanceof Paper) {
-                paperInHands = (Paper) inHands;
-                success = paperInHands.send_mail_message(from);
-            } else {
-                success = false;
-            }
-        } else {
-            success = false;
-        }
-
-        if (success) {
-            send_reply_success(from);
-            send_goaway_msg(paperInHands.noid);
-            destroy_object(paperInHands);
-            avatar.inc_record(Constants.HS$mail_send_count);
-        } else {
-            send_reply_error(from);
-        }
+        illegal(from, this.HabitatModName() + ".PSENDMAIL");
     }
 
     private boolean send_mail_message(User from) {


### PR DESCRIPTION
A client crash currently occurs when an Avatar removes a 'baby Paper' from their pocket. This is because the ```GET$``` operation is broadcasted from the incorrect noid, which should be the noid of the Avatar. This PR corrects this issue.