### PR TITLE
Plaza Fountain

### DIFF
--- a/db/new_Downtown/Downtown_5f.json
+++ b/db/new_Downtown/Downtown_5f.json
@@ -56,7 +56,8 @@
         "y": 158, 
         "x": 20,
         "type": "Flag", 
-        "orientation": 72
+        "orientation": 72,
+		"mass": 1
       }
     ], 
     "type": "item", 


### PR DESCRIPTION
- Added mass = 1 to the flag in the Plaza Fountain region to ensure newbies don't accidentally make off with the goodies