### PR TITLE
Corrects !ASTROESC!177 to right arrow ("")

### DIFF
--- a/db/Popustop/Popustop.hall1.line125.json
+++ b/db/Popustop/Popustop.hall1.line125.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line129", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line141.json
+++ b/db/Popustop/Popustop.hall1.line141.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall2.line145", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line176.json
+++ b/db/Popustop/Popustop.hall1.line176.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line225.json
+++ b/db/Popustop/Popustop.hall1.line225.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line229", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line241.json
+++ b/db/Popustop/Popustop.hall1.line241.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall2.line245", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line25.json
+++ b/db/Popustop/Popustop.hall1.line25.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line29", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line276.json
+++ b/db/Popustop/Popustop.hall1.line276.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line325.json
+++ b/db/Popustop/Popustop.hall1.line325.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line329", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line341.json
+++ b/db/Popustop/Popustop.hall1.line341.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall2.line345", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line376.json
+++ b/db/Popustop/Popustop.hall1.line376.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line41.json
+++ b/db/Popustop/Popustop.hall1.line41.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall2.line45", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line425.json
+++ b/db/Popustop/Popustop.hall1.line425.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line429", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line441.json
+++ b/db/Popustop/Popustop.hall1.line441.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall2.line445", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line476.json
+++ b/db/Popustop/Popustop.hall1.line476.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line525.json
+++ b/db/Popustop/Popustop.hall1.line525.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line529", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line541.json
+++ b/db/Popustop/Popustop.hall1.line541.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall2.line545", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line576.json
+++ b/db/Popustop/Popustop.hall1.line576.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line625.json
+++ b/db/Popustop/Popustop.hall1.line625.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line629", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line641.json
+++ b/db/Popustop/Popustop.hall1.line641.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall2.line645", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line676.json
+++ b/db/Popustop/Popustop.hall1.line676.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line725.json
+++ b/db/Popustop/Popustop.hall1.line725.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line729", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line741.json
+++ b/db/Popustop/Popustop.hall1.line741.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall2.line745", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line76.json
+++ b/db/Popustop/Popustop.hall1.line76.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line776.json
+++ b/db/Popustop/Popustop.hall1.line776.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line825.json
+++ b/db/Popustop/Popustop.hall1.line825.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line829", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line841.json
+++ b/db/Popustop/Popustop.hall1.line841.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall2.line845", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line876.json
+++ b/db/Popustop/Popustop.hall1.line876.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall11000.line1025.json
+++ b/db/Popustop/Popustop.hall11000.line1025.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall21000.line1029", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall11000.line1041.json
+++ b/db/Popustop/Popustop.hall11000.line1041.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall21000.line1045", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall11000.line1076.json
+++ b/db/Popustop/Popustop.hall11000.line1076.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall11000.line925.json
+++ b/db/Popustop/Popustop.hall11000.line925.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall21000.line929", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall11000.line941.json
+++ b/db/Popustop/Popustop.hall11000.line941.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall21000.line945", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall11000.line976.json
+++ b/db/Popustop/Popustop.hall11000.line976.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line129.json
+++ b/db/Popustop/Popustop.hall2.line129.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line133", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line145.json
+++ b/db/Popustop/Popustop.hall2.line145.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall3.line149", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line180.json
+++ b/db/Popustop/Popustop.hall2.line180.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line176", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line229.json
+++ b/db/Popustop/Popustop.hall2.line229.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line233", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line245.json
+++ b/db/Popustop/Popustop.hall2.line245.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall3.line249", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line280.json
+++ b/db/Popustop/Popustop.hall2.line280.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line276", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line29.json
+++ b/db/Popustop/Popustop.hall2.line29.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line33", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line329.json
+++ b/db/Popustop/Popustop.hall2.line329.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line333", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line345.json
+++ b/db/Popustop/Popustop.hall2.line345.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall3.line349", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line380.json
+++ b/db/Popustop/Popustop.hall2.line380.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line376", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line429.json
+++ b/db/Popustop/Popustop.hall2.line429.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line433", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line445.json
+++ b/db/Popustop/Popustop.hall2.line445.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall3.line449", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line45.json
+++ b/db/Popustop/Popustop.hall2.line45.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall3.line49", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line480.json
+++ b/db/Popustop/Popustop.hall2.line480.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line476", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line529.json
+++ b/db/Popustop/Popustop.hall2.line529.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line533", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line545.json
+++ b/db/Popustop/Popustop.hall2.line545.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall3.line549", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line580.json
+++ b/db/Popustop/Popustop.hall2.line580.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line576", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line629.json
+++ b/db/Popustop/Popustop.hall2.line629.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line633", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line645.json
+++ b/db/Popustop/Popustop.hall2.line645.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall3.line649", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line680.json
+++ b/db/Popustop/Popustop.hall2.line680.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line676", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line729.json
+++ b/db/Popustop/Popustop.hall2.line729.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line733", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line745.json
+++ b/db/Popustop/Popustop.hall2.line745.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall3.line749", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line780.json
+++ b/db/Popustop/Popustop.hall2.line780.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line776", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line80.json
+++ b/db/Popustop/Popustop.hall2.line80.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line76", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line829.json
+++ b/db/Popustop/Popustop.hall2.line829.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line833", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line845.json
+++ b/db/Popustop/Popustop.hall2.line845.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall3.line849", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line880.json
+++ b/db/Popustop/Popustop.hall2.line880.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line876", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall21000.line1029.json
+++ b/db/Popustop/Popustop.hall21000.line1029.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall31000.line1033", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall21000.line1045.json
+++ b/db/Popustop/Popustop.hall21000.line1045.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall31000.line1049", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall21000.line1080.json
+++ b/db/Popustop/Popustop.hall21000.line1080.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall11000.line1076", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall21000.line929.json
+++ b/db/Popustop/Popustop.hall21000.line929.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall31000.line933", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall21000.line945.json
+++ b/db/Popustop/Popustop.hall21000.line945.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall31000.line949", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall21000.line980.json
+++ b/db/Popustop/Popustop.hall21000.line980.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall11000.line976", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line133.json
+++ b/db/Popustop/Popustop.hall3.line133.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line137", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line149.json
+++ b/db/Popustop/Popustop.hall3.line149.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall4.line153", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line184.json
+++ b/db/Popustop/Popustop.hall3.line184.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line180", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line233.json
+++ b/db/Popustop/Popustop.hall3.line233.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line237", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line249.json
+++ b/db/Popustop/Popustop.hall3.line249.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall4.line253", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line284.json
+++ b/db/Popustop/Popustop.hall3.line284.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line280", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line33.json
+++ b/db/Popustop/Popustop.hall3.line33.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line37", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line333.json
+++ b/db/Popustop/Popustop.hall3.line333.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line337", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line349.json
+++ b/db/Popustop/Popustop.hall3.line349.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall4.line353", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line384.json
+++ b/db/Popustop/Popustop.hall3.line384.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line380", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line433.json
+++ b/db/Popustop/Popustop.hall3.line433.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line437", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line449.json
+++ b/db/Popustop/Popustop.hall3.line449.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall4.line453", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line484.json
+++ b/db/Popustop/Popustop.hall3.line484.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line480", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line49.json
+++ b/db/Popustop/Popustop.hall3.line49.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall4.line53", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line533.json
+++ b/db/Popustop/Popustop.hall3.line533.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line537", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line549.json
+++ b/db/Popustop/Popustop.hall3.line549.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall4.line553", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line584.json
+++ b/db/Popustop/Popustop.hall3.line584.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line580", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line633.json
+++ b/db/Popustop/Popustop.hall3.line633.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line637", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line649.json
+++ b/db/Popustop/Popustop.hall3.line649.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall4.line653", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line684.json
+++ b/db/Popustop/Popustop.hall3.line684.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line680", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line733.json
+++ b/db/Popustop/Popustop.hall3.line733.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line737", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line749.json
+++ b/db/Popustop/Popustop.hall3.line749.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall4.line753", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line784.json
+++ b/db/Popustop/Popustop.hall3.line784.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line780", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line833.json
+++ b/db/Popustop/Popustop.hall3.line833.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line837", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line84.json
+++ b/db/Popustop/Popustop.hall3.line84.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line80", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line849.json
+++ b/db/Popustop/Popustop.hall3.line849.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall4.line853", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line884.json
+++ b/db/Popustop/Popustop.hall3.line884.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line880", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall31000.line1033.json
+++ b/db/Popustop/Popustop.hall31000.line1033.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall41000.line1037", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall31000.line1049.json
+++ b/db/Popustop/Popustop.hall31000.line1049.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall41000.line1053", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall31000.line1084.json
+++ b/db/Popustop/Popustop.hall31000.line1084.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall21000.line1080", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall31000.line933.json
+++ b/db/Popustop/Popustop.hall31000.line933.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall41000.line937", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall31000.line949.json
+++ b/db/Popustop/Popustop.hall31000.line949.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-Popustop.hall41000.line953", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall31000.line984.json
+++ b/db/Popustop/Popustop.hall31000.line984.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall21000.line980", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line137.json
+++ b/db/Popustop/Popustop.hall4.line137.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-144.elby.line156", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line153.json
+++ b/db/Popustop/Popustop.hall4.line153.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-144.elby.line154", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line188.json
+++ b/db/Popustop/Popustop.hall4.line188.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line184", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line237.json
+++ b/db/Popustop/Popustop.hall4.line237.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-152.elby.line256", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line253.json
+++ b/db/Popustop/Popustop.hall4.line253.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-152.elby.line254", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line288.json
+++ b/db/Popustop/Popustop.hall4.line288.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line284", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line337.json
+++ b/db/Popustop/Popustop.hall4.line337.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-160.elby.line356", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line353.json
+++ b/db/Popustop/Popustop.hall4.line353.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-160.elby.line354", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line37.json
+++ b/db/Popustop/Popustop.hall4.line37.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-136.elby.line56", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line388.json
+++ b/db/Popustop/Popustop.hall4.line388.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line384", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line437.json
+++ b/db/Popustop/Popustop.hall4.line437.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-168.elby.line456", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line453.json
+++ b/db/Popustop/Popustop.hall4.line453.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-168.elby.line454", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line488.json
+++ b/db/Popustop/Popustop.hall4.line488.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line484", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line53.json
+++ b/db/Popustop/Popustop.hall4.line53.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-136.elby.line54", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line537.json
+++ b/db/Popustop/Popustop.hall4.line537.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-184.elby.line556", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line553.json
+++ b/db/Popustop/Popustop.hall4.line553.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-184.elby.line554", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line588.json
+++ b/db/Popustop/Popustop.hall4.line588.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line584", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line637.json
+++ b/db/Popustop/Popustop.hall4.line637.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-192.elby.line656", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line653.json
+++ b/db/Popustop/Popustop.hall4.line653.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-192.elby.line654", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line688.json
+++ b/db/Popustop/Popustop.hall4.line688.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line684", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line737.json
+++ b/db/Popustop/Popustop.hall4.line737.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-200.elby.line756", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line753.json
+++ b/db/Popustop/Popustop.hall4.line753.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-200.elby.line754", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line788.json
+++ b/db/Popustop/Popustop.hall4.line788.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line784", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line837.json
+++ b/db/Popustop/Popustop.hall4.line837.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-216.elby.line856", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line853.json
+++ b/db/Popustop/Popustop.hall4.line853.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-216.elby.line854", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line88.json
+++ b/db/Popustop/Popustop.hall4.line88.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line84", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line888.json
+++ b/db/Popustop/Popustop.hall4.line888.json
@@ -3,7 +3,7 @@
     "capacity": 6, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line884", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall41000.line1037.json
+++ b/db/Popustop/Popustop.hall41000.line1037.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-232.elby1000.line1056", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall41000.line1053.json
+++ b/db/Popustop/Popustop.hall41000.line1053.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-232.elby1000.line1054", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall41000.line1088.json
+++ b/db/Popustop/Popustop.hall41000.line1088.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall31000.line1084", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall41000.line937.json
+++ b/db/Popustop/Popustop.hall41000.line937.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-224.elby1000.line956", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall41000.line953.json
+++ b/db/Popustop/Popustop.hall41000.line953.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "context-224.elby1000.line954", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall41000.line988.json
+++ b/db/Popustop/Popustop.hall41000.line988.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\\DEL", 
         "neighbors": [
           "", 
           "context-Popustop.hall31000.line984", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\\DEL", 
         "type": "Region"
       }
     ], 


### PR DESCRIPTION
An older version of Astroturf did not correctly translate escaped octal ASCII table offsets and this bug is reflected in some of the converted Popustop regions.

This escape notation was only used for characters at octal 177, so this PR translates them to the corresponding PETSCII rune, right arrow, which Neohabitat represents by the empty string: ""