### PR TITLE
Corrects !ASTROESC!177 to right arrow ASCII rune ('\u007f')

### DIFF
--- a/astroturf/popustop/afront3.json
+++ b/astroturf/popustop/afront3.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_1)s",
     "mods": [

--- a/astroturf/popustop/basement.json
+++ b/astroturf/popustop/basement.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "Basement",
     "mods": [

--- a/astroturf/popustop/bboard.json
+++ b/astroturf/popustop/bboard.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(region_name)s",
     "mods": [

--- a/astroturf/popustop/elby.json
+++ b/astroturf/popustop/elby.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s", 
-    "capacity": 6, 
+    "capacity": 64, 
     "type": "context", 
     "name": "%(arg_8)s", 
     "mods": [

--- a/astroturf/popustop/elevator1.json
+++ b/astroturf/popustop/elevator1.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_3)s:%(arg_1)s",
     "mods": [

--- a/astroturf/popustop/hall1.json
+++ b/astroturf/popustop/hall1.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_5)s",
     "mods": [

--- a/astroturf/popustop/hall2.json
+++ b/astroturf/popustop/hall2.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_5)s",
     "mods": [

--- a/astroturf/popustop/hall3.json
+++ b/astroturf/popustop/hall3.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_5)s",
     "mods": [

--- a/astroturf/popustop/hall4.json
+++ b/astroturf/popustop/hall4.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_5)s",
     "mods": [

--- a/astroturf/popustop/lobby.json
+++ b/astroturf/popustop/lobby.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_3)s:%(arg_1)s",
     "mods": [

--- a/astroturf/popustop/roof.json
+++ b/astroturf/popustop/roof.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "Roof",
     "mods": [

--- a/astroturf/popustop/stairs.json
+++ b/astroturf/popustop/stairs.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_3)s:%(arg_1)s",
     "mods": [

--- a/astroturf/popustop/turf1.json
+++ b/astroturf/popustop/turf1.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_1)s #%(arg_2)s",
     "mods": [

--- a/astroturf/popustop/turf10.json
+++ b/astroturf/popustop/turf10.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_1)s #%(arg_2)s",
     "mods": [

--- a/astroturf/popustop/turf2.json
+++ b/astroturf/popustop/turf2.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_1)s #%(arg_2)s",
     "mods": [

--- a/astroturf/popustop/turf3.json
+++ b/astroturf/popustop/turf3.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_1)s #%(arg_2)s",
     "mods": [

--- a/astroturf/popustop/turf4.json
+++ b/astroturf/popustop/turf4.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_1)s #%(arg_2)s",
     "mods": [

--- a/astroturf/popustop/turf5.json
+++ b/astroturf/popustop/turf5.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_1)s #%(arg_2)s",
     "mods": [

--- a/astroturf/popustop/turf6.json
+++ b/astroturf/popustop/turf6.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_1)s #%(arg_2)s",
     "mods": [

--- a/astroturf/popustop/turf7.json
+++ b/astroturf/popustop/turf7.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_1)s #%(arg_2)s",
     "mods": [

--- a/astroturf/popustop/turf8.json
+++ b/astroturf/popustop/turf8.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_1)s #%(arg_2)s",
     "mods": [

--- a/astroturf/popustop/turf9.json
+++ b/astroturf/popustop/turf9.json
@@ -1,7 +1,7 @@
 [
   {
     "ref": "context-%(region_ref)s",
-    "capacity": 6,
+    "capacity": 64,
     "type": "context",
     "name": "%(arg_1)s #%(arg_2)s",
     "mods": [

--- a/db/Popustop/136.elby.line54.json
+++ b/db/Popustop/136.elby.line54.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/136.elby.line56.json
+++ b/db/Popustop/136.elby.line56.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/144.elby.line154.json
+++ b/db/Popustop/144.elby.line154.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/144.elby.line156.json
+++ b/db/Popustop/144.elby.line156.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/152.elby.line254.json
+++ b/db/Popustop/152.elby.line254.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/152.elby.line256.json
+++ b/db/Popustop/152.elby.line256.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/160.elby.line354.json
+++ b/db/Popustop/160.elby.line354.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/160.elby.line356.json
+++ b/db/Popustop/160.elby.line356.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/168.elby.line454.json
+++ b/db/Popustop/168.elby.line454.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/168.elby.line456.json
+++ b/db/Popustop/168.elby.line456.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/184.elby.line554.json
+++ b/db/Popustop/184.elby.line554.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/184.elby.line556.json
+++ b/db/Popustop/184.elby.line556.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/192.elby.line654.json
+++ b/db/Popustop/192.elby.line654.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/192.elby.line656.json
+++ b/db/Popustop/192.elby.line656.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/200.elby.line754.json
+++ b/db/Popustop/200.elby.line754.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/200.elby.line756.json
+++ b/db/Popustop/200.elby.line756.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/216.elby.line854.json
+++ b/db/Popustop/216.elby.line854.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/216.elby.line856.json
+++ b/db/Popustop/216.elby.line856.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.100.json
+++ b/db/Popustop/Popustop.100.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1000.json
+++ b/db/Popustop/Popustop.1000.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1001.json
+++ b/db/Popustop/Popustop.1001.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1002.json
+++ b/db/Popustop/Popustop.1002.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1003.json
+++ b/db/Popustop/Popustop.1003.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1004.json
+++ b/db/Popustop/Popustop.1004.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1005.json
+++ b/db/Popustop/Popustop.1005.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1006.json
+++ b/db/Popustop/Popustop.1006.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1007.json
+++ b/db/Popustop/Popustop.1007.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1008.json
+++ b/db/Popustop/Popustop.1008.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1009.json
+++ b/db/Popustop/Popustop.1009.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.101.json
+++ b/db/Popustop/Popustop.101.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1010.json
+++ b/db/Popustop/Popustop.1010.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1011.json
+++ b/db/Popustop/Popustop.1011.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1012.json
+++ b/db/Popustop/Popustop.1012.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1013.json
+++ b/db/Popustop/Popustop.1013.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1014.json
+++ b/db/Popustop/Popustop.1014.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1015.json
+++ b/db/Popustop/Popustop.1015.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1016.json
+++ b/db/Popustop/Popustop.1016.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1017.json
+++ b/db/Popustop/Popustop.1017.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1018.json
+++ b/db/Popustop/Popustop.1018.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1019.json
+++ b/db/Popustop/Popustop.1019.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.102.json
+++ b/db/Popustop/Popustop.102.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1020.json
+++ b/db/Popustop/Popustop.1020.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1021.json
+++ b/db/Popustop/Popustop.1021.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1022.json
+++ b/db/Popustop/Popustop.1022.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1023.json
+++ b/db/Popustop/Popustop.1023.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1024.json
+++ b/db/Popustop/Popustop.1024.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1025.json
+++ b/db/Popustop/Popustop.1025.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1026.json
+++ b/db/Popustop/Popustop.1026.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1027.json
+++ b/db/Popustop/Popustop.1027.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1028.json
+++ b/db/Popustop/Popustop.1028.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1029.json
+++ b/db/Popustop/Popustop.1029.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.103.json
+++ b/db/Popustop/Popustop.103.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1030.json
+++ b/db/Popustop/Popustop.1030.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1031.json
+++ b/db/Popustop/Popustop.1031.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1032.json
+++ b/db/Popustop/Popustop.1032.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1033.json
+++ b/db/Popustop/Popustop.1033.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1034.json
+++ b/db/Popustop/Popustop.1034.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1035.json
+++ b/db/Popustop/Popustop.1035.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1036.json
+++ b/db/Popustop/Popustop.1036.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1037.json
+++ b/db/Popustop/Popustop.1037.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1038.json
+++ b/db/Popustop/Popustop.1038.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1039.json
+++ b/db/Popustop/Popustop.1039.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.104.json
+++ b/db/Popustop/Popustop.104.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1040.json
+++ b/db/Popustop/Popustop.1040.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1041.json
+++ b/db/Popustop/Popustop.1041.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1042.json
+++ b/db/Popustop/Popustop.1042.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1043.json
+++ b/db/Popustop/Popustop.1043.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1044.json
+++ b/db/Popustop/Popustop.1044.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1045.json
+++ b/db/Popustop/Popustop.1045.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1046.json
+++ b/db/Popustop/Popustop.1046.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1047.json
+++ b/db/Popustop/Popustop.1047.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1048.json
+++ b/db/Popustop/Popustop.1048.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1049.json
+++ b/db/Popustop/Popustop.1049.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.105.json
+++ b/db/Popustop/Popustop.105.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1050.json
+++ b/db/Popustop/Popustop.1050.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1051.json
+++ b/db/Popustop/Popustop.1051.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1052.json
+++ b/db/Popustop/Popustop.1052.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1053.json
+++ b/db/Popustop/Popustop.1053.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1054.json
+++ b/db/Popustop/Popustop.1054.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1055.json
+++ b/db/Popustop/Popustop.1055.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1056.json
+++ b/db/Popustop/Popustop.1056.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1057.json
+++ b/db/Popustop/Popustop.1057.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1058.json
+++ b/db/Popustop/Popustop.1058.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1059.json
+++ b/db/Popustop/Popustop.1059.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.106.json
+++ b/db/Popustop/Popustop.106.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1060.json
+++ b/db/Popustop/Popustop.1060.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1061.json
+++ b/db/Popustop/Popustop.1061.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1062.json
+++ b/db/Popustop/Popustop.1062.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1063.json
+++ b/db/Popustop/Popustop.1063.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1064.json
+++ b/db/Popustop/Popustop.1064.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1065.json
+++ b/db/Popustop/Popustop.1065.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1066.json
+++ b/db/Popustop/Popustop.1066.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1067.json
+++ b/db/Popustop/Popustop.1067.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1068.json
+++ b/db/Popustop/Popustop.1068.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1069.json
+++ b/db/Popustop/Popustop.1069.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.107.json
+++ b/db/Popustop/Popustop.107.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1070.json
+++ b/db/Popustop/Popustop.1070.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1071.json
+++ b/db/Popustop/Popustop.1071.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.108.json
+++ b/db/Popustop/Popustop.108.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.109.json
+++ b/db/Popustop/Popustop.109.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.110.json
+++ b/db/Popustop/Popustop.110.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1100.json
+++ b/db/Popustop/Popustop.1100.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1101.json
+++ b/db/Popustop/Popustop.1101.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1102.json
+++ b/db/Popustop/Popustop.1102.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1103.json
+++ b/db/Popustop/Popustop.1103.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1104.json
+++ b/db/Popustop/Popustop.1104.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1105.json
+++ b/db/Popustop/Popustop.1105.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1106.json
+++ b/db/Popustop/Popustop.1106.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1107.json
+++ b/db/Popustop/Popustop.1107.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1108.json
+++ b/db/Popustop/Popustop.1108.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1109.json
+++ b/db/Popustop/Popustop.1109.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.111.json
+++ b/db/Popustop/Popustop.111.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1110.json
+++ b/db/Popustop/Popustop.1110.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1111.json
+++ b/db/Popustop/Popustop.1111.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1112.json
+++ b/db/Popustop/Popustop.1112.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1113.json
+++ b/db/Popustop/Popustop.1113.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1114.json
+++ b/db/Popustop/Popustop.1114.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1115.json
+++ b/db/Popustop/Popustop.1115.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1116.json
+++ b/db/Popustop/Popustop.1116.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1117.json
+++ b/db/Popustop/Popustop.1117.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1118.json
+++ b/db/Popustop/Popustop.1118.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1119.json
+++ b/db/Popustop/Popustop.1119.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.112.json
+++ b/db/Popustop/Popustop.112.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1120.json
+++ b/db/Popustop/Popustop.1120.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1121.json
+++ b/db/Popustop/Popustop.1121.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1122.json
+++ b/db/Popustop/Popustop.1122.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1123.json
+++ b/db/Popustop/Popustop.1123.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1124.json
+++ b/db/Popustop/Popustop.1124.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1125.json
+++ b/db/Popustop/Popustop.1125.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1126.json
+++ b/db/Popustop/Popustop.1126.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1127.json
+++ b/db/Popustop/Popustop.1127.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1128.json
+++ b/db/Popustop/Popustop.1128.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1129.json
+++ b/db/Popustop/Popustop.1129.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.113.json
+++ b/db/Popustop/Popustop.113.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1130.json
+++ b/db/Popustop/Popustop.1130.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1131.json
+++ b/db/Popustop/Popustop.1131.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1132.json
+++ b/db/Popustop/Popustop.1132.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1133.json
+++ b/db/Popustop/Popustop.1133.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1134.json
+++ b/db/Popustop/Popustop.1134.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1135.json
+++ b/db/Popustop/Popustop.1135.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1136.json
+++ b/db/Popustop/Popustop.1136.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1137.json
+++ b/db/Popustop/Popustop.1137.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1138.json
+++ b/db/Popustop/Popustop.1138.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1139.json
+++ b/db/Popustop/Popustop.1139.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.114.json
+++ b/db/Popustop/Popustop.114.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1140.json
+++ b/db/Popustop/Popustop.1140.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1141.json
+++ b/db/Popustop/Popustop.1141.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1142.json
+++ b/db/Popustop/Popustop.1142.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1143.json
+++ b/db/Popustop/Popustop.1143.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1144.json
+++ b/db/Popustop/Popustop.1144.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1145.json
+++ b/db/Popustop/Popustop.1145.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1146.json
+++ b/db/Popustop/Popustop.1146.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1147.json
+++ b/db/Popustop/Popustop.1147.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1148.json
+++ b/db/Popustop/Popustop.1148.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1149.json
+++ b/db/Popustop/Popustop.1149.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.115.json
+++ b/db/Popustop/Popustop.115.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1150.json
+++ b/db/Popustop/Popustop.1150.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1151.json
+++ b/db/Popustop/Popustop.1151.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1152.json
+++ b/db/Popustop/Popustop.1152.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1153.json
+++ b/db/Popustop/Popustop.1153.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1154.json
+++ b/db/Popustop/Popustop.1154.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1155.json
+++ b/db/Popustop/Popustop.1155.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1156.json
+++ b/db/Popustop/Popustop.1156.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1157.json
+++ b/db/Popustop/Popustop.1157.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1158.json
+++ b/db/Popustop/Popustop.1158.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1159.json
+++ b/db/Popustop/Popustop.1159.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.116.json
+++ b/db/Popustop/Popustop.116.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1160.json
+++ b/db/Popustop/Popustop.1160.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1161.json
+++ b/db/Popustop/Popustop.1161.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1162.json
+++ b/db/Popustop/Popustop.1162.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1163.json
+++ b/db/Popustop/Popustop.1163.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1164.json
+++ b/db/Popustop/Popustop.1164.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1165.json
+++ b/db/Popustop/Popustop.1165.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1166.json
+++ b/db/Popustop/Popustop.1166.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1167.json
+++ b/db/Popustop/Popustop.1167.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1168.json
+++ b/db/Popustop/Popustop.1168.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1169.json
+++ b/db/Popustop/Popustop.1169.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.117.json
+++ b/db/Popustop/Popustop.117.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1170.json
+++ b/db/Popustop/Popustop.1170.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.1171.json
+++ b/db/Popustop/Popustop.1171.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.118.json
+++ b/db/Popustop/Popustop.118.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.119.json
+++ b/db/Popustop/Popustop.119.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.120.json
+++ b/db/Popustop/Popustop.120.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.121.json
+++ b/db/Popustop/Popustop.121.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.122.json
+++ b/db/Popustop/Popustop.122.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.123.json
+++ b/db/Popustop/Popustop.123.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.124.json
+++ b/db/Popustop/Popustop.124.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.125.json
+++ b/db/Popustop/Popustop.125.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.126.json
+++ b/db/Popustop/Popustop.126.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.127.json
+++ b/db/Popustop/Popustop.127.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.128.json
+++ b/db/Popustop/Popustop.128.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.129.json
+++ b/db/Popustop/Popustop.129.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.130.json
+++ b/db/Popustop/Popustop.130.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.131.json
+++ b/db/Popustop/Popustop.131.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.132.json
+++ b/db/Popustop/Popustop.132.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.133.json
+++ b/db/Popustop/Popustop.133.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.134.json
+++ b/db/Popustop/Popustop.134.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.135.json
+++ b/db/Popustop/Popustop.135.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.136.json
+++ b/db/Popustop/Popustop.136.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.137.json
+++ b/db/Popustop/Popustop.137.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.138.json
+++ b/db/Popustop/Popustop.138.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.139.json
+++ b/db/Popustop/Popustop.139.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.140.json
+++ b/db/Popustop/Popustop.140.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.141.json
+++ b/db/Popustop/Popustop.141.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.142.json
+++ b/db/Popustop/Popustop.142.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.143.json
+++ b/db/Popustop/Popustop.143.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.144.json
+++ b/db/Popustop/Popustop.144.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.145.json
+++ b/db/Popustop/Popustop.145.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.146.json
+++ b/db/Popustop/Popustop.146.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.147.json
+++ b/db/Popustop/Popustop.147.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.148.json
+++ b/db/Popustop/Popustop.148.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.149.json
+++ b/db/Popustop/Popustop.149.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.150.json
+++ b/db/Popustop/Popustop.150.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.151.json
+++ b/db/Popustop/Popustop.151.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.152.json
+++ b/db/Popustop/Popustop.152.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.153.json
+++ b/db/Popustop/Popustop.153.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.154.json
+++ b/db/Popustop/Popustop.154.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.155.json
+++ b/db/Popustop/Popustop.155.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.156.json
+++ b/db/Popustop/Popustop.156.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.157.json
+++ b/db/Popustop/Popustop.157.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.158.json
+++ b/db/Popustop/Popustop.158.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.159.json
+++ b/db/Popustop/Popustop.159.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.160.json
+++ b/db/Popustop/Popustop.160.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.161.json
+++ b/db/Popustop/Popustop.161.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.162.json
+++ b/db/Popustop/Popustop.162.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.163.json
+++ b/db/Popustop/Popustop.163.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.164.json
+++ b/db/Popustop/Popustop.164.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.165.json
+++ b/db/Popustop/Popustop.165.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.167.json
+++ b/db/Popustop/Popustop.167.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.168.json
+++ b/db/Popustop/Popustop.168.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.169.json
+++ b/db/Popustop/Popustop.169.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.170.json
+++ b/db/Popustop/Popustop.170.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.171.json
+++ b/db/Popustop/Popustop.171.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.200.json
+++ b/db/Popustop/Popustop.200.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.201.json
+++ b/db/Popustop/Popustop.201.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.202.json
+++ b/db/Popustop/Popustop.202.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.203.json
+++ b/db/Popustop/Popustop.203.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.204.json
+++ b/db/Popustop/Popustop.204.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.205.json
+++ b/db/Popustop/Popustop.205.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.206.json
+++ b/db/Popustop/Popustop.206.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.207.json
+++ b/db/Popustop/Popustop.207.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.208.json
+++ b/db/Popustop/Popustop.208.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.209.json
+++ b/db/Popustop/Popustop.209.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.210.json
+++ b/db/Popustop/Popustop.210.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.211.json
+++ b/db/Popustop/Popustop.211.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.212.json
+++ b/db/Popustop/Popustop.212.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.213.json
+++ b/db/Popustop/Popustop.213.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.214.json
+++ b/db/Popustop/Popustop.214.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.215.json
+++ b/db/Popustop/Popustop.215.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.216.json
+++ b/db/Popustop/Popustop.216.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.217.json
+++ b/db/Popustop/Popustop.217.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.218.json
+++ b/db/Popustop/Popustop.218.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.219.json
+++ b/db/Popustop/Popustop.219.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.220.json
+++ b/db/Popustop/Popustop.220.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.221.json
+++ b/db/Popustop/Popustop.221.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.222.json
+++ b/db/Popustop/Popustop.222.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.223.json
+++ b/db/Popustop/Popustop.223.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.224.json
+++ b/db/Popustop/Popustop.224.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.225.json
+++ b/db/Popustop/Popustop.225.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.226.json
+++ b/db/Popustop/Popustop.226.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.227.json
+++ b/db/Popustop/Popustop.227.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.228.json
+++ b/db/Popustop/Popustop.228.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.229.json
+++ b/db/Popustop/Popustop.229.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.230.json
+++ b/db/Popustop/Popustop.230.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.231.json
+++ b/db/Popustop/Popustop.231.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.232.json
+++ b/db/Popustop/Popustop.232.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.233.json
+++ b/db/Popustop/Popustop.233.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.234.json
+++ b/db/Popustop/Popustop.234.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.235.json
+++ b/db/Popustop/Popustop.235.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.236.json
+++ b/db/Popustop/Popustop.236.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.237.json
+++ b/db/Popustop/Popustop.237.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.238.json
+++ b/db/Popustop/Popustop.238.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.239.json
+++ b/db/Popustop/Popustop.239.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.240.json
+++ b/db/Popustop/Popustop.240.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.241.json
+++ b/db/Popustop/Popustop.241.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.242.json
+++ b/db/Popustop/Popustop.242.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.243.json
+++ b/db/Popustop/Popustop.243.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.244.json
+++ b/db/Popustop/Popustop.244.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.245.json
+++ b/db/Popustop/Popustop.245.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.246.json
+++ b/db/Popustop/Popustop.246.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.247.json
+++ b/db/Popustop/Popustop.247.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.248.json
+++ b/db/Popustop/Popustop.248.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.249.json
+++ b/db/Popustop/Popustop.249.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.250.json
+++ b/db/Popustop/Popustop.250.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.251.json
+++ b/db/Popustop/Popustop.251.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.252.json
+++ b/db/Popustop/Popustop.252.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.253.json
+++ b/db/Popustop/Popustop.253.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.254.json
+++ b/db/Popustop/Popustop.254.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.255.json
+++ b/db/Popustop/Popustop.255.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.256.json
+++ b/db/Popustop/Popustop.256.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.257.json
+++ b/db/Popustop/Popustop.257.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.258.json
+++ b/db/Popustop/Popustop.258.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.259.json
+++ b/db/Popustop/Popustop.259.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.260.json
+++ b/db/Popustop/Popustop.260.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.261.json
+++ b/db/Popustop/Popustop.261.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.262.json
+++ b/db/Popustop/Popustop.262.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.263.json
+++ b/db/Popustop/Popustop.263.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.264.json
+++ b/db/Popustop/Popustop.264.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.265.json
+++ b/db/Popustop/Popustop.265.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.266.json
+++ b/db/Popustop/Popustop.266.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.267.json
+++ b/db/Popustop/Popustop.267.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.268.json
+++ b/db/Popustop/Popustop.268.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.269.json
+++ b/db/Popustop/Popustop.269.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.270.json
+++ b/db/Popustop/Popustop.270.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.271.json
+++ b/db/Popustop/Popustop.271.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.300.json
+++ b/db/Popustop/Popustop.300.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.301.json
+++ b/db/Popustop/Popustop.301.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.302.json
+++ b/db/Popustop/Popustop.302.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.303.json
+++ b/db/Popustop/Popustop.303.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.304.json
+++ b/db/Popustop/Popustop.304.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.305.json
+++ b/db/Popustop/Popustop.305.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.306.json
+++ b/db/Popustop/Popustop.306.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.307.json
+++ b/db/Popustop/Popustop.307.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.308.json
+++ b/db/Popustop/Popustop.308.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.309.json
+++ b/db/Popustop/Popustop.309.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.310.json
+++ b/db/Popustop/Popustop.310.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.311.json
+++ b/db/Popustop/Popustop.311.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.312.json
+++ b/db/Popustop/Popustop.312.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.313.json
+++ b/db/Popustop/Popustop.313.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.314.json
+++ b/db/Popustop/Popustop.314.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.315.json
+++ b/db/Popustop/Popustop.315.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.316.json
+++ b/db/Popustop/Popustop.316.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.317.json
+++ b/db/Popustop/Popustop.317.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.318.json
+++ b/db/Popustop/Popustop.318.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.319.json
+++ b/db/Popustop/Popustop.319.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.320.json
+++ b/db/Popustop/Popustop.320.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.321.json
+++ b/db/Popustop/Popustop.321.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.322.json
+++ b/db/Popustop/Popustop.322.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.323.json
+++ b/db/Popustop/Popustop.323.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.324.json
+++ b/db/Popustop/Popustop.324.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.325.json
+++ b/db/Popustop/Popustop.325.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.326.json
+++ b/db/Popustop/Popustop.326.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.327.json
+++ b/db/Popustop/Popustop.327.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.328.json
+++ b/db/Popustop/Popustop.328.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.329.json
+++ b/db/Popustop/Popustop.329.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.330.json
+++ b/db/Popustop/Popustop.330.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.331.json
+++ b/db/Popustop/Popustop.331.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.332.json
+++ b/db/Popustop/Popustop.332.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.333.json
+++ b/db/Popustop/Popustop.333.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.334.json
+++ b/db/Popustop/Popustop.334.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.335.json
+++ b/db/Popustop/Popustop.335.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.336.json
+++ b/db/Popustop/Popustop.336.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.337.json
+++ b/db/Popustop/Popustop.337.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.338.json
+++ b/db/Popustop/Popustop.338.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.339.json
+++ b/db/Popustop/Popustop.339.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.340.json
+++ b/db/Popustop/Popustop.340.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.341.json
+++ b/db/Popustop/Popustop.341.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.342.json
+++ b/db/Popustop/Popustop.342.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.343.json
+++ b/db/Popustop/Popustop.343.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.344.json
+++ b/db/Popustop/Popustop.344.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.345.json
+++ b/db/Popustop/Popustop.345.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.346.json
+++ b/db/Popustop/Popustop.346.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.347.json
+++ b/db/Popustop/Popustop.347.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.348.json
+++ b/db/Popustop/Popustop.348.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.349.json
+++ b/db/Popustop/Popustop.349.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.350.json
+++ b/db/Popustop/Popustop.350.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.351.json
+++ b/db/Popustop/Popustop.351.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.352.json
+++ b/db/Popustop/Popustop.352.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.353.json
+++ b/db/Popustop/Popustop.353.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.354.json
+++ b/db/Popustop/Popustop.354.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.355.json
+++ b/db/Popustop/Popustop.355.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.356.json
+++ b/db/Popustop/Popustop.356.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.357.json
+++ b/db/Popustop/Popustop.357.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.358.json
+++ b/db/Popustop/Popustop.358.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.359.json
+++ b/db/Popustop/Popustop.359.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.360.json
+++ b/db/Popustop/Popustop.360.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.361.json
+++ b/db/Popustop/Popustop.361.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.362.json
+++ b/db/Popustop/Popustop.362.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.363.json
+++ b/db/Popustop/Popustop.363.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.364.json
+++ b/db/Popustop/Popustop.364.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.365.json
+++ b/db/Popustop/Popustop.365.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.366.json
+++ b/db/Popustop/Popustop.366.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.367.json
+++ b/db/Popustop/Popustop.367.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.368.json
+++ b/db/Popustop/Popustop.368.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.369.json
+++ b/db/Popustop/Popustop.369.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.370.json
+++ b/db/Popustop/Popustop.370.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.371.json
+++ b/db/Popustop/Popustop.371.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.400.json
+++ b/db/Popustop/Popustop.400.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.401.json
+++ b/db/Popustop/Popustop.401.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.402.json
+++ b/db/Popustop/Popustop.402.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.403.json
+++ b/db/Popustop/Popustop.403.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.404.json
+++ b/db/Popustop/Popustop.404.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.405.json
+++ b/db/Popustop/Popustop.405.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.406.json
+++ b/db/Popustop/Popustop.406.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.407.json
+++ b/db/Popustop/Popustop.407.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.408.json
+++ b/db/Popustop/Popustop.408.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.409.json
+++ b/db/Popustop/Popustop.409.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.410.json
+++ b/db/Popustop/Popustop.410.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.411.json
+++ b/db/Popustop/Popustop.411.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.412.json
+++ b/db/Popustop/Popustop.412.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.413.json
+++ b/db/Popustop/Popustop.413.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.414.json
+++ b/db/Popustop/Popustop.414.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.415.json
+++ b/db/Popustop/Popustop.415.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.416.json
+++ b/db/Popustop/Popustop.416.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.417.json
+++ b/db/Popustop/Popustop.417.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.418.json
+++ b/db/Popustop/Popustop.418.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.419.json
+++ b/db/Popustop/Popustop.419.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.420.json
+++ b/db/Popustop/Popustop.420.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.421.json
+++ b/db/Popustop/Popustop.421.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.422.json
+++ b/db/Popustop/Popustop.422.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.423.json
+++ b/db/Popustop/Popustop.423.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.424.json
+++ b/db/Popustop/Popustop.424.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.425.json
+++ b/db/Popustop/Popustop.425.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.426.json
+++ b/db/Popustop/Popustop.426.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.427.json
+++ b/db/Popustop/Popustop.427.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.428.json
+++ b/db/Popustop/Popustop.428.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.429.json
+++ b/db/Popustop/Popustop.429.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.430.json
+++ b/db/Popustop/Popustop.430.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.431.json
+++ b/db/Popustop/Popustop.431.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.432.json
+++ b/db/Popustop/Popustop.432.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.433.json
+++ b/db/Popustop/Popustop.433.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.434.json
+++ b/db/Popustop/Popustop.434.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.435.json
+++ b/db/Popustop/Popustop.435.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.436.json
+++ b/db/Popustop/Popustop.436.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.437.json
+++ b/db/Popustop/Popustop.437.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.438.json
+++ b/db/Popustop/Popustop.438.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.439.json
+++ b/db/Popustop/Popustop.439.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.440.json
+++ b/db/Popustop/Popustop.440.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.441.json
+++ b/db/Popustop/Popustop.441.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.442.json
+++ b/db/Popustop/Popustop.442.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.443.json
+++ b/db/Popustop/Popustop.443.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.444.json
+++ b/db/Popustop/Popustop.444.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.445.json
+++ b/db/Popustop/Popustop.445.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.446.json
+++ b/db/Popustop/Popustop.446.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.447.json
+++ b/db/Popustop/Popustop.447.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.448.json
+++ b/db/Popustop/Popustop.448.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.449.json
+++ b/db/Popustop/Popustop.449.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.450.json
+++ b/db/Popustop/Popustop.450.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.451.json
+++ b/db/Popustop/Popustop.451.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.452.json
+++ b/db/Popustop/Popustop.452.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.453.json
+++ b/db/Popustop/Popustop.453.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.454.json
+++ b/db/Popustop/Popustop.454.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.455.json
+++ b/db/Popustop/Popustop.455.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.456.json
+++ b/db/Popustop/Popustop.456.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.457.json
+++ b/db/Popustop/Popustop.457.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.458.json
+++ b/db/Popustop/Popustop.458.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.459.json
+++ b/db/Popustop/Popustop.459.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.460.json
+++ b/db/Popustop/Popustop.460.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.461.json
+++ b/db/Popustop/Popustop.461.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.462.json
+++ b/db/Popustop/Popustop.462.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.463.json
+++ b/db/Popustop/Popustop.463.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.464.json
+++ b/db/Popustop/Popustop.464.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.465.json
+++ b/db/Popustop/Popustop.465.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.466.json
+++ b/db/Popustop/Popustop.466.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.467.json
+++ b/db/Popustop/Popustop.467.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.468.json
+++ b/db/Popustop/Popustop.468.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.469.json
+++ b/db/Popustop/Popustop.469.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.470.json
+++ b/db/Popustop/Popustop.470.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.471.json
+++ b/db/Popustop/Popustop.471.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.500.json
+++ b/db/Popustop/Popustop.500.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.501.json
+++ b/db/Popustop/Popustop.501.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.502.json
+++ b/db/Popustop/Popustop.502.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.503.json
+++ b/db/Popustop/Popustop.503.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.504.json
+++ b/db/Popustop/Popustop.504.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.505.json
+++ b/db/Popustop/Popustop.505.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.506.json
+++ b/db/Popustop/Popustop.506.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.507.json
+++ b/db/Popustop/Popustop.507.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.508.json
+++ b/db/Popustop/Popustop.508.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.509.json
+++ b/db/Popustop/Popustop.509.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.510.json
+++ b/db/Popustop/Popustop.510.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.511.json
+++ b/db/Popustop/Popustop.511.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.512.json
+++ b/db/Popustop/Popustop.512.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.513.json
+++ b/db/Popustop/Popustop.513.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.514.json
+++ b/db/Popustop/Popustop.514.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.515.json
+++ b/db/Popustop/Popustop.515.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.516.json
+++ b/db/Popustop/Popustop.516.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.517.json
+++ b/db/Popustop/Popustop.517.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.518.json
+++ b/db/Popustop/Popustop.518.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.519.json
+++ b/db/Popustop/Popustop.519.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.520.json
+++ b/db/Popustop/Popustop.520.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.521.json
+++ b/db/Popustop/Popustop.521.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.522.json
+++ b/db/Popustop/Popustop.522.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.523.json
+++ b/db/Popustop/Popustop.523.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.524.json
+++ b/db/Popustop/Popustop.524.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.525.json
+++ b/db/Popustop/Popustop.525.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.526.json
+++ b/db/Popustop/Popustop.526.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.527.json
+++ b/db/Popustop/Popustop.527.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.528.json
+++ b/db/Popustop/Popustop.528.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.529.json
+++ b/db/Popustop/Popustop.529.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.530.json
+++ b/db/Popustop/Popustop.530.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.531.json
+++ b/db/Popustop/Popustop.531.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.532.json
+++ b/db/Popustop/Popustop.532.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.533.json
+++ b/db/Popustop/Popustop.533.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.534.json
+++ b/db/Popustop/Popustop.534.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.535.json
+++ b/db/Popustop/Popustop.535.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.536.json
+++ b/db/Popustop/Popustop.536.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.537.json
+++ b/db/Popustop/Popustop.537.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.538.json
+++ b/db/Popustop/Popustop.538.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.539.json
+++ b/db/Popustop/Popustop.539.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.540.json
+++ b/db/Popustop/Popustop.540.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.541.json
+++ b/db/Popustop/Popustop.541.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.542.json
+++ b/db/Popustop/Popustop.542.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.543.json
+++ b/db/Popustop/Popustop.543.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.544.json
+++ b/db/Popustop/Popustop.544.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.545.json
+++ b/db/Popustop/Popustop.545.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.546.json
+++ b/db/Popustop/Popustop.546.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.547.json
+++ b/db/Popustop/Popustop.547.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.548.json
+++ b/db/Popustop/Popustop.548.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.549.json
+++ b/db/Popustop/Popustop.549.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.550.json
+++ b/db/Popustop/Popustop.550.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.551.json
+++ b/db/Popustop/Popustop.551.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.552.json
+++ b/db/Popustop/Popustop.552.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.553.json
+++ b/db/Popustop/Popustop.553.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.554.json
+++ b/db/Popustop/Popustop.554.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.555.json
+++ b/db/Popustop/Popustop.555.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.556.json
+++ b/db/Popustop/Popustop.556.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.557.json
+++ b/db/Popustop/Popustop.557.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.558.json
+++ b/db/Popustop/Popustop.558.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.559.json
+++ b/db/Popustop/Popustop.559.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.560.json
+++ b/db/Popustop/Popustop.560.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.561.json
+++ b/db/Popustop/Popustop.561.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.562.json
+++ b/db/Popustop/Popustop.562.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.563.json
+++ b/db/Popustop/Popustop.563.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.564.json
+++ b/db/Popustop/Popustop.564.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.565.json
+++ b/db/Popustop/Popustop.565.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.566.json
+++ b/db/Popustop/Popustop.566.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.567.json
+++ b/db/Popustop/Popustop.567.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.568.json
+++ b/db/Popustop/Popustop.568.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.569.json
+++ b/db/Popustop/Popustop.569.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.570.json
+++ b/db/Popustop/Popustop.570.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.571.json
+++ b/db/Popustop/Popustop.571.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.600.json
+++ b/db/Popustop/Popustop.600.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.601.json
+++ b/db/Popustop/Popustop.601.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.602.json
+++ b/db/Popustop/Popustop.602.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.603.json
+++ b/db/Popustop/Popustop.603.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.604.json
+++ b/db/Popustop/Popustop.604.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.605.json
+++ b/db/Popustop/Popustop.605.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.606.json
+++ b/db/Popustop/Popustop.606.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.607.json
+++ b/db/Popustop/Popustop.607.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.608.json
+++ b/db/Popustop/Popustop.608.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.609.json
+++ b/db/Popustop/Popustop.609.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.610.json
+++ b/db/Popustop/Popustop.610.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.611.json
+++ b/db/Popustop/Popustop.611.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.612.json
+++ b/db/Popustop/Popustop.612.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.613.json
+++ b/db/Popustop/Popustop.613.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.614.json
+++ b/db/Popustop/Popustop.614.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.615.json
+++ b/db/Popustop/Popustop.615.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.616.json
+++ b/db/Popustop/Popustop.616.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.617.json
+++ b/db/Popustop/Popustop.617.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.618.json
+++ b/db/Popustop/Popustop.618.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.619.json
+++ b/db/Popustop/Popustop.619.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.620.json
+++ b/db/Popustop/Popustop.620.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.621.json
+++ b/db/Popustop/Popustop.621.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.622.json
+++ b/db/Popustop/Popustop.622.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.623.json
+++ b/db/Popustop/Popustop.623.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.624.json
+++ b/db/Popustop/Popustop.624.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.625.json
+++ b/db/Popustop/Popustop.625.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.626.json
+++ b/db/Popustop/Popustop.626.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.627.json
+++ b/db/Popustop/Popustop.627.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.628.json
+++ b/db/Popustop/Popustop.628.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.629.json
+++ b/db/Popustop/Popustop.629.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.630.json
+++ b/db/Popustop/Popustop.630.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.631.json
+++ b/db/Popustop/Popustop.631.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.632.json
+++ b/db/Popustop/Popustop.632.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.633.json
+++ b/db/Popustop/Popustop.633.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.634.json
+++ b/db/Popustop/Popustop.634.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.635.json
+++ b/db/Popustop/Popustop.635.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.636.json
+++ b/db/Popustop/Popustop.636.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.637.json
+++ b/db/Popustop/Popustop.637.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.638.json
+++ b/db/Popustop/Popustop.638.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.639.json
+++ b/db/Popustop/Popustop.639.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.640.json
+++ b/db/Popustop/Popustop.640.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.641.json
+++ b/db/Popustop/Popustop.641.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.642.json
+++ b/db/Popustop/Popustop.642.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.643.json
+++ b/db/Popustop/Popustop.643.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.644.json
+++ b/db/Popustop/Popustop.644.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.645.json
+++ b/db/Popustop/Popustop.645.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.646.json
+++ b/db/Popustop/Popustop.646.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.647.json
+++ b/db/Popustop/Popustop.647.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.648.json
+++ b/db/Popustop/Popustop.648.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.649.json
+++ b/db/Popustop/Popustop.649.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.650.json
+++ b/db/Popustop/Popustop.650.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.651.json
+++ b/db/Popustop/Popustop.651.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.652.json
+++ b/db/Popustop/Popustop.652.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.653.json
+++ b/db/Popustop/Popustop.653.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.654.json
+++ b/db/Popustop/Popustop.654.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.655.json
+++ b/db/Popustop/Popustop.655.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.656.json
+++ b/db/Popustop/Popustop.656.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.657.json
+++ b/db/Popustop/Popustop.657.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.658.json
+++ b/db/Popustop/Popustop.658.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.659.json
+++ b/db/Popustop/Popustop.659.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.660.json
+++ b/db/Popustop/Popustop.660.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.661.json
+++ b/db/Popustop/Popustop.661.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.662.json
+++ b/db/Popustop/Popustop.662.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.663.json
+++ b/db/Popustop/Popustop.663.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.664.json
+++ b/db/Popustop/Popustop.664.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.665.json
+++ b/db/Popustop/Popustop.665.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.667.json
+++ b/db/Popustop/Popustop.667.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.668.json
+++ b/db/Popustop/Popustop.668.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.669.json
+++ b/db/Popustop/Popustop.669.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.670.json
+++ b/db/Popustop/Popustop.670.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.671.json
+++ b/db/Popustop/Popustop.671.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.700.json
+++ b/db/Popustop/Popustop.700.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.701.json
+++ b/db/Popustop/Popustop.701.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.702.json
+++ b/db/Popustop/Popustop.702.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.703.json
+++ b/db/Popustop/Popustop.703.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.704.json
+++ b/db/Popustop/Popustop.704.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.705.json
+++ b/db/Popustop/Popustop.705.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.706.json
+++ b/db/Popustop/Popustop.706.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.707.json
+++ b/db/Popustop/Popustop.707.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.708.json
+++ b/db/Popustop/Popustop.708.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.709.json
+++ b/db/Popustop/Popustop.709.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.710.json
+++ b/db/Popustop/Popustop.710.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.711.json
+++ b/db/Popustop/Popustop.711.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.712.json
+++ b/db/Popustop/Popustop.712.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.713.json
+++ b/db/Popustop/Popustop.713.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.714.json
+++ b/db/Popustop/Popustop.714.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.715.json
+++ b/db/Popustop/Popustop.715.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.716.json
+++ b/db/Popustop/Popustop.716.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.717.json
+++ b/db/Popustop/Popustop.717.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.718.json
+++ b/db/Popustop/Popustop.718.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.719.json
+++ b/db/Popustop/Popustop.719.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.720.json
+++ b/db/Popustop/Popustop.720.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.721.json
+++ b/db/Popustop/Popustop.721.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.722.json
+++ b/db/Popustop/Popustop.722.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.723.json
+++ b/db/Popustop/Popustop.723.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.724.json
+++ b/db/Popustop/Popustop.724.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.725.json
+++ b/db/Popustop/Popustop.725.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.726.json
+++ b/db/Popustop/Popustop.726.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.727.json
+++ b/db/Popustop/Popustop.727.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.728.json
+++ b/db/Popustop/Popustop.728.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.729.json
+++ b/db/Popustop/Popustop.729.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.730.json
+++ b/db/Popustop/Popustop.730.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.731.json
+++ b/db/Popustop/Popustop.731.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.732.json
+++ b/db/Popustop/Popustop.732.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.733.json
+++ b/db/Popustop/Popustop.733.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.734.json
+++ b/db/Popustop/Popustop.734.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.735.json
+++ b/db/Popustop/Popustop.735.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.736.json
+++ b/db/Popustop/Popustop.736.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.737.json
+++ b/db/Popustop/Popustop.737.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.738.json
+++ b/db/Popustop/Popustop.738.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.739.json
+++ b/db/Popustop/Popustop.739.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.740.json
+++ b/db/Popustop/Popustop.740.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.741.json
+++ b/db/Popustop/Popustop.741.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.742.json
+++ b/db/Popustop/Popustop.742.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.743.json
+++ b/db/Popustop/Popustop.743.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.744.json
+++ b/db/Popustop/Popustop.744.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.745.json
+++ b/db/Popustop/Popustop.745.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.746.json
+++ b/db/Popustop/Popustop.746.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.747.json
+++ b/db/Popustop/Popustop.747.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.748.json
+++ b/db/Popustop/Popustop.748.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.749.json
+++ b/db/Popustop/Popustop.749.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.750.json
+++ b/db/Popustop/Popustop.750.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.751.json
+++ b/db/Popustop/Popustop.751.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.752.json
+++ b/db/Popustop/Popustop.752.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.753.json
+++ b/db/Popustop/Popustop.753.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.754.json
+++ b/db/Popustop/Popustop.754.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.755.json
+++ b/db/Popustop/Popustop.755.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.756.json
+++ b/db/Popustop/Popustop.756.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.757.json
+++ b/db/Popustop/Popustop.757.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.758.json
+++ b/db/Popustop/Popustop.758.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.759.json
+++ b/db/Popustop/Popustop.759.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.760.json
+++ b/db/Popustop/Popustop.760.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.761.json
+++ b/db/Popustop/Popustop.761.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.762.json
+++ b/db/Popustop/Popustop.762.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.763.json
+++ b/db/Popustop/Popustop.763.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.764.json
+++ b/db/Popustop/Popustop.764.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.765.json
+++ b/db/Popustop/Popustop.765.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.766.json
+++ b/db/Popustop/Popustop.766.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.767.json
+++ b/db/Popustop/Popustop.767.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.768.json
+++ b/db/Popustop/Popustop.768.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.769.json
+++ b/db/Popustop/Popustop.769.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.770.json
+++ b/db/Popustop/Popustop.770.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.771.json
+++ b/db/Popustop/Popustop.771.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.800.json
+++ b/db/Popustop/Popustop.800.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.801.json
+++ b/db/Popustop/Popustop.801.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.802.json
+++ b/db/Popustop/Popustop.802.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.803.json
+++ b/db/Popustop/Popustop.803.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.804.json
+++ b/db/Popustop/Popustop.804.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.805.json
+++ b/db/Popustop/Popustop.805.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.806.json
+++ b/db/Popustop/Popustop.806.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.807.json
+++ b/db/Popustop/Popustop.807.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.808.json
+++ b/db/Popustop/Popustop.808.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.809.json
+++ b/db/Popustop/Popustop.809.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.810.json
+++ b/db/Popustop/Popustop.810.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.811.json
+++ b/db/Popustop/Popustop.811.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.812.json
+++ b/db/Popustop/Popustop.812.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.813.json
+++ b/db/Popustop/Popustop.813.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.814.json
+++ b/db/Popustop/Popustop.814.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.815.json
+++ b/db/Popustop/Popustop.815.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.816.json
+++ b/db/Popustop/Popustop.816.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.817.json
+++ b/db/Popustop/Popustop.817.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.818.json
+++ b/db/Popustop/Popustop.818.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.819.json
+++ b/db/Popustop/Popustop.819.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.820.json
+++ b/db/Popustop/Popustop.820.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.821.json
+++ b/db/Popustop/Popustop.821.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.822.json
+++ b/db/Popustop/Popustop.822.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.823.json
+++ b/db/Popustop/Popustop.823.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.824.json
+++ b/db/Popustop/Popustop.824.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.825.json
+++ b/db/Popustop/Popustop.825.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.826.json
+++ b/db/Popustop/Popustop.826.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.827.json
+++ b/db/Popustop/Popustop.827.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.828.json
+++ b/db/Popustop/Popustop.828.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.829.json
+++ b/db/Popustop/Popustop.829.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.830.json
+++ b/db/Popustop/Popustop.830.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.831.json
+++ b/db/Popustop/Popustop.831.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.832.json
+++ b/db/Popustop/Popustop.832.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.833.json
+++ b/db/Popustop/Popustop.833.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.834.json
+++ b/db/Popustop/Popustop.834.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.835.json
+++ b/db/Popustop/Popustop.835.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.836.json
+++ b/db/Popustop/Popustop.836.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.837.json
+++ b/db/Popustop/Popustop.837.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.838.json
+++ b/db/Popustop/Popustop.838.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.839.json
+++ b/db/Popustop/Popustop.839.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.840.json
+++ b/db/Popustop/Popustop.840.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.841.json
+++ b/db/Popustop/Popustop.841.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.842.json
+++ b/db/Popustop/Popustop.842.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.843.json
+++ b/db/Popustop/Popustop.843.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.844.json
+++ b/db/Popustop/Popustop.844.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.845.json
+++ b/db/Popustop/Popustop.845.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.846.json
+++ b/db/Popustop/Popustop.846.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.847.json
+++ b/db/Popustop/Popustop.847.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.848.json
+++ b/db/Popustop/Popustop.848.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.849.json
+++ b/db/Popustop/Popustop.849.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.850.json
+++ b/db/Popustop/Popustop.850.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.851.json
+++ b/db/Popustop/Popustop.851.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.852.json
+++ b/db/Popustop/Popustop.852.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.853.json
+++ b/db/Popustop/Popustop.853.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.854.json
+++ b/db/Popustop/Popustop.854.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.855.json
+++ b/db/Popustop/Popustop.855.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.856.json
+++ b/db/Popustop/Popustop.856.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.857.json
+++ b/db/Popustop/Popustop.857.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.858.json
+++ b/db/Popustop/Popustop.858.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.859.json
+++ b/db/Popustop/Popustop.859.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.860.json
+++ b/db/Popustop/Popustop.860.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.861.json
+++ b/db/Popustop/Popustop.861.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.862.json
+++ b/db/Popustop/Popustop.862.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.863.json
+++ b/db/Popustop/Popustop.863.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.864.json
+++ b/db/Popustop/Popustop.864.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.865.json
+++ b/db/Popustop/Popustop.865.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.866.json
+++ b/db/Popustop/Popustop.866.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.867.json
+++ b/db/Popustop/Popustop.867.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.868.json
+++ b/db/Popustop/Popustop.868.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.869.json
+++ b/db/Popustop/Popustop.869.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.870.json
+++ b/db/Popustop/Popustop.870.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.871.json
+++ b/db/Popustop/Popustop.871.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.900.json
+++ b/db/Popustop/Popustop.900.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.901.json
+++ b/db/Popustop/Popustop.901.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.902.json
+++ b/db/Popustop/Popustop.902.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.903.json
+++ b/db/Popustop/Popustop.903.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.904.json
+++ b/db/Popustop/Popustop.904.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.905.json
+++ b/db/Popustop/Popustop.905.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.906.json
+++ b/db/Popustop/Popustop.906.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.907.json
+++ b/db/Popustop/Popustop.907.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.908.json
+++ b/db/Popustop/Popustop.908.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.909.json
+++ b/db/Popustop/Popustop.909.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.910.json
+++ b/db/Popustop/Popustop.910.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.911.json
+++ b/db/Popustop/Popustop.911.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.912.json
+++ b/db/Popustop/Popustop.912.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.913.json
+++ b/db/Popustop/Popustop.913.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.914.json
+++ b/db/Popustop/Popustop.914.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.915.json
+++ b/db/Popustop/Popustop.915.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.916.json
+++ b/db/Popustop/Popustop.916.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.917.json
+++ b/db/Popustop/Popustop.917.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.918.json
+++ b/db/Popustop/Popustop.918.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.919.json
+++ b/db/Popustop/Popustop.919.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.920.json
+++ b/db/Popustop/Popustop.920.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.921.json
+++ b/db/Popustop/Popustop.921.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.922.json
+++ b/db/Popustop/Popustop.922.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.923.json
+++ b/db/Popustop/Popustop.923.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.924.json
+++ b/db/Popustop/Popustop.924.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.925.json
+++ b/db/Popustop/Popustop.925.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.926.json
+++ b/db/Popustop/Popustop.926.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.927.json
+++ b/db/Popustop/Popustop.927.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.928.json
+++ b/db/Popustop/Popustop.928.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.929.json
+++ b/db/Popustop/Popustop.929.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.930.json
+++ b/db/Popustop/Popustop.930.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.931.json
+++ b/db/Popustop/Popustop.931.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.932.json
+++ b/db/Popustop/Popustop.932.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.933.json
+++ b/db/Popustop/Popustop.933.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.934.json
+++ b/db/Popustop/Popustop.934.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.935.json
+++ b/db/Popustop/Popustop.935.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.936.json
+++ b/db/Popustop/Popustop.936.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.937.json
+++ b/db/Popustop/Popustop.937.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.938.json
+++ b/db/Popustop/Popustop.938.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.939.json
+++ b/db/Popustop/Popustop.939.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.940.json
+++ b/db/Popustop/Popustop.940.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.941.json
+++ b/db/Popustop/Popustop.941.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.942.json
+++ b/db/Popustop/Popustop.942.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.943.json
+++ b/db/Popustop/Popustop.943.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.944.json
+++ b/db/Popustop/Popustop.944.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.945.json
+++ b/db/Popustop/Popustop.945.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.946.json
+++ b/db/Popustop/Popustop.946.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.947.json
+++ b/db/Popustop/Popustop.947.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.948.json
+++ b/db/Popustop/Popustop.948.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.949.json
+++ b/db/Popustop/Popustop.949.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.950.json
+++ b/db/Popustop/Popustop.950.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.951.json
+++ b/db/Popustop/Popustop.951.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.952.json
+++ b/db/Popustop/Popustop.952.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.953.json
+++ b/db/Popustop/Popustop.953.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.954.json
+++ b/db/Popustop/Popustop.954.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.955.json
+++ b/db/Popustop/Popustop.955.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.956.json
+++ b/db/Popustop/Popustop.956.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.957.json
+++ b/db/Popustop/Popustop.957.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.958.json
+++ b/db/Popustop/Popustop.958.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.959.json
+++ b/db/Popustop/Popustop.959.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.960.json
+++ b/db/Popustop/Popustop.960.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.961.json
+++ b/db/Popustop/Popustop.961.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.962.json
+++ b/db/Popustop/Popustop.962.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.963.json
+++ b/db/Popustop/Popustop.963.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.964.json
+++ b/db/Popustop/Popustop.964.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.965.json
+++ b/db/Popustop/Popustop.965.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.966.json
+++ b/db/Popustop/Popustop.966.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.967.json
+++ b/db/Popustop/Popustop.967.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.968.json
+++ b/db/Popustop/Popustop.968.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.969.json
+++ b/db/Popustop/Popustop.969.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.970.json
+++ b/db/Popustop/Popustop.970.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.971.json
+++ b/db/Popustop/Popustop.971.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.bboard.line4.json
+++ b/db/Popustop/Popustop.bboard.line4.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/Popustop.elevator1.line1055.json
+++ b/db/Popustop/Popustop.elevator1.line1055.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "|", 

--- a/db/Popustop/Popustop.elevator1.line155.json
+++ b/db/Popustop/Popustop.elevator1.line155.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "|", 

--- a/db/Popustop/Popustop.elevator1.line255.json
+++ b/db/Popustop/Popustop.elevator1.line255.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "|", 

--- a/db/Popustop/Popustop.elevator1.line355.json
+++ b/db/Popustop/Popustop.elevator1.line355.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "|", 

--- a/db/Popustop/Popustop.elevator1.line455.json
+++ b/db/Popustop/Popustop.elevator1.line455.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "|", 

--- a/db/Popustop/Popustop.elevator1.line55.json
+++ b/db/Popustop/Popustop.elevator1.line55.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "|", 

--- a/db/Popustop/Popustop.elevator1.line555.json
+++ b/db/Popustop/Popustop.elevator1.line555.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "|", 

--- a/db/Popustop/Popustop.elevator1.line655.json
+++ b/db/Popustop/Popustop.elevator1.line655.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "|", 

--- a/db/Popustop/Popustop.elevator1.line755.json
+++ b/db/Popustop/Popustop.elevator1.line755.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "|", 

--- a/db/Popustop/Popustop.elevator1.line855.json
+++ b/db/Popustop/Popustop.elevator1.line855.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "|", 

--- a/db/Popustop/Popustop.elevator1.line955.json
+++ b/db/Popustop/Popustop.elevator1.line955.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "|", 

--- a/db/Popustop/Popustop.hall1.line108.json
+++ b/db/Popustop/Popustop.hall1.line108.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line125.json
+++ b/db/Popustop/Popustop.hall1.line125.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line129", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line141.json
+++ b/db/Popustop/Popustop.hall1.line141.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall2.line145", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line160.json
+++ b/db/Popustop/Popustop.hall1.line160.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line176.json
+++ b/db/Popustop/Popustop.hall1.line176.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line192.json
+++ b/db/Popustop/Popustop.hall1.line192.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line208.json
+++ b/db/Popustop/Popustop.hall1.line208.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line225.json
+++ b/db/Popustop/Popustop.hall1.line225.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line229", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line241.json
+++ b/db/Popustop/Popustop.hall1.line241.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall2.line245", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line25.json
+++ b/db/Popustop/Popustop.hall1.line25.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line29", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line260.json
+++ b/db/Popustop/Popustop.hall1.line260.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line276.json
+++ b/db/Popustop/Popustop.hall1.line276.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line292.json
+++ b/db/Popustop/Popustop.hall1.line292.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line308.json
+++ b/db/Popustop/Popustop.hall1.line308.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line325.json
+++ b/db/Popustop/Popustop.hall1.line325.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line329", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line341.json
+++ b/db/Popustop/Popustop.hall1.line341.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall2.line345", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line360.json
+++ b/db/Popustop/Popustop.hall1.line360.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line376.json
+++ b/db/Popustop/Popustop.hall1.line376.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line392.json
+++ b/db/Popustop/Popustop.hall1.line392.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line408.json
+++ b/db/Popustop/Popustop.hall1.line408.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line41.json
+++ b/db/Popustop/Popustop.hall1.line41.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall2.line45", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line425.json
+++ b/db/Popustop/Popustop.hall1.line425.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line429", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line441.json
+++ b/db/Popustop/Popustop.hall1.line441.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall2.line445", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line460.json
+++ b/db/Popustop/Popustop.hall1.line460.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line476.json
+++ b/db/Popustop/Popustop.hall1.line476.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line492.json
+++ b/db/Popustop/Popustop.hall1.line492.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line508.json
+++ b/db/Popustop/Popustop.hall1.line508.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line525.json
+++ b/db/Popustop/Popustop.hall1.line525.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line529", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line541.json
+++ b/db/Popustop/Popustop.hall1.line541.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall2.line545", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line560.json
+++ b/db/Popustop/Popustop.hall1.line560.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line576.json
+++ b/db/Popustop/Popustop.hall1.line576.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line592.json
+++ b/db/Popustop/Popustop.hall1.line592.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line60.json
+++ b/db/Popustop/Popustop.hall1.line60.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line608.json
+++ b/db/Popustop/Popustop.hall1.line608.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line625.json
+++ b/db/Popustop/Popustop.hall1.line625.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line629", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line641.json
+++ b/db/Popustop/Popustop.hall1.line641.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall2.line645", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line660.json
+++ b/db/Popustop/Popustop.hall1.line660.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line676.json
+++ b/db/Popustop/Popustop.hall1.line676.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line692.json
+++ b/db/Popustop/Popustop.hall1.line692.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line708.json
+++ b/db/Popustop/Popustop.hall1.line708.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line725.json
+++ b/db/Popustop/Popustop.hall1.line725.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line729", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line741.json
+++ b/db/Popustop/Popustop.hall1.line741.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall2.line745", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line76.json
+++ b/db/Popustop/Popustop.hall1.line76.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line760.json
+++ b/db/Popustop/Popustop.hall1.line760.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line776.json
+++ b/db/Popustop/Popustop.hall1.line776.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line792.json
+++ b/db/Popustop/Popustop.hall1.line792.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line8.json
+++ b/db/Popustop/Popustop.hall1.line8.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line808.json
+++ b/db/Popustop/Popustop.hall1.line808.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line825.json
+++ b/db/Popustop/Popustop.hall1.line825.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line829", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line841.json
+++ b/db/Popustop/Popustop.hall1.line841.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall2.line845", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line860.json
+++ b/db/Popustop/Popustop.hall1.line860.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line876.json
+++ b/db/Popustop/Popustop.hall1.line876.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall1.line892.json
+++ b/db/Popustop/Popustop.hall1.line892.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall1.line92.json
+++ b/db/Popustop/Popustop.hall1.line92.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall11000.line1025.json
+++ b/db/Popustop/Popustop.hall11000.line1025.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall21000.line1029", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall11000.line1041.json
+++ b/db/Popustop/Popustop.hall11000.line1041.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall21000.line1045", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall11000.line1076.json
+++ b/db/Popustop/Popustop.hall11000.line1076.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall11000.line925.json
+++ b/db/Popustop/Popustop.hall11000.line925.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall21000.line929", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall11000.line941.json
+++ b/db/Popustop/Popustop.hall11000.line941.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall21000.line945", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall11000.line976.json
+++ b/db/Popustop/Popustop.hall11000.line976.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line112.json
+++ b/db/Popustop/Popustop.hall2.line112.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line12.json
+++ b/db/Popustop/Popustop.hall2.line12.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line129.json
+++ b/db/Popustop/Popustop.hall2.line129.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line133", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line145.json
+++ b/db/Popustop/Popustop.hall2.line145.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall3.line149", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line164.json
+++ b/db/Popustop/Popustop.hall2.line164.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line180.json
+++ b/db/Popustop/Popustop.hall2.line180.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line176", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line196.json
+++ b/db/Popustop/Popustop.hall2.line196.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line212.json
+++ b/db/Popustop/Popustop.hall2.line212.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line229.json
+++ b/db/Popustop/Popustop.hall2.line229.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line233", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line245.json
+++ b/db/Popustop/Popustop.hall2.line245.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall3.line249", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line264.json
+++ b/db/Popustop/Popustop.hall2.line264.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line280.json
+++ b/db/Popustop/Popustop.hall2.line280.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line276", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line29.json
+++ b/db/Popustop/Popustop.hall2.line29.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line33", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line296.json
+++ b/db/Popustop/Popustop.hall2.line296.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line312.json
+++ b/db/Popustop/Popustop.hall2.line312.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line329.json
+++ b/db/Popustop/Popustop.hall2.line329.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line333", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line345.json
+++ b/db/Popustop/Popustop.hall2.line345.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall3.line349", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line364.json
+++ b/db/Popustop/Popustop.hall2.line364.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line380.json
+++ b/db/Popustop/Popustop.hall2.line380.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line376", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line396.json
+++ b/db/Popustop/Popustop.hall2.line396.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line412.json
+++ b/db/Popustop/Popustop.hall2.line412.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line429.json
+++ b/db/Popustop/Popustop.hall2.line429.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line433", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line445.json
+++ b/db/Popustop/Popustop.hall2.line445.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall3.line449", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line45.json
+++ b/db/Popustop/Popustop.hall2.line45.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall3.line49", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line464.json
+++ b/db/Popustop/Popustop.hall2.line464.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line480.json
+++ b/db/Popustop/Popustop.hall2.line480.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line476", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line496.json
+++ b/db/Popustop/Popustop.hall2.line496.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line512.json
+++ b/db/Popustop/Popustop.hall2.line512.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line529.json
+++ b/db/Popustop/Popustop.hall2.line529.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line533", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line545.json
+++ b/db/Popustop/Popustop.hall2.line545.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall3.line549", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line564.json
+++ b/db/Popustop/Popustop.hall2.line564.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line580.json
+++ b/db/Popustop/Popustop.hall2.line580.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line576", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line596.json
+++ b/db/Popustop/Popustop.hall2.line596.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line612.json
+++ b/db/Popustop/Popustop.hall2.line612.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line629.json
+++ b/db/Popustop/Popustop.hall2.line629.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line633", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line64.json
+++ b/db/Popustop/Popustop.hall2.line64.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line645.json
+++ b/db/Popustop/Popustop.hall2.line645.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall3.line649", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line664.json
+++ b/db/Popustop/Popustop.hall2.line664.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line680.json
+++ b/db/Popustop/Popustop.hall2.line680.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line676", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line696.json
+++ b/db/Popustop/Popustop.hall2.line696.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line712.json
+++ b/db/Popustop/Popustop.hall2.line712.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line729.json
+++ b/db/Popustop/Popustop.hall2.line729.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line733", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line745.json
+++ b/db/Popustop/Popustop.hall2.line745.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall3.line749", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line764.json
+++ b/db/Popustop/Popustop.hall2.line764.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line780.json
+++ b/db/Popustop/Popustop.hall2.line780.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line776", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line796.json
+++ b/db/Popustop/Popustop.hall2.line796.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line80.json
+++ b/db/Popustop/Popustop.hall2.line80.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line76", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line812.json
+++ b/db/Popustop/Popustop.hall2.line812.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line829.json
+++ b/db/Popustop/Popustop.hall2.line829.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line833", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line845.json
+++ b/db/Popustop/Popustop.hall2.line845.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall3.line849", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line864.json
+++ b/db/Popustop/Popustop.hall2.line864.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line880.json
+++ b/db/Popustop/Popustop.hall2.line880.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall1.line876", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall2.line896.json
+++ b/db/Popustop/Popustop.hall2.line896.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall2.line96.json
+++ b/db/Popustop/Popustop.hall2.line96.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall21000.line1029.json
+++ b/db/Popustop/Popustop.hall21000.line1029.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall31000.line1033", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall21000.line1045.json
+++ b/db/Popustop/Popustop.hall21000.line1045.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall31000.line1049", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall21000.line1080.json
+++ b/db/Popustop/Popustop.hall21000.line1080.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall11000.line1076", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall21000.line929.json
+++ b/db/Popustop/Popustop.hall21000.line929.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall31000.line933", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall21000.line945.json
+++ b/db/Popustop/Popustop.hall21000.line945.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall31000.line949", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall21000.line980.json
+++ b/db/Popustop/Popustop.hall21000.line980.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall11000.line976", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line100.json
+++ b/db/Popustop/Popustop.hall3.line100.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line116.json
+++ b/db/Popustop/Popustop.hall3.line116.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line133.json
+++ b/db/Popustop/Popustop.hall3.line133.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line137", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line149.json
+++ b/db/Popustop/Popustop.hall3.line149.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall4.line153", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line16.json
+++ b/db/Popustop/Popustop.hall3.line16.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line168.json
+++ b/db/Popustop/Popustop.hall3.line168.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line184.json
+++ b/db/Popustop/Popustop.hall3.line184.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line180", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line200.json
+++ b/db/Popustop/Popustop.hall3.line200.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line216.json
+++ b/db/Popustop/Popustop.hall3.line216.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line233.json
+++ b/db/Popustop/Popustop.hall3.line233.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line237", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line249.json
+++ b/db/Popustop/Popustop.hall3.line249.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall4.line253", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line268.json
+++ b/db/Popustop/Popustop.hall3.line268.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line284.json
+++ b/db/Popustop/Popustop.hall3.line284.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line280", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line300.json
+++ b/db/Popustop/Popustop.hall3.line300.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line316.json
+++ b/db/Popustop/Popustop.hall3.line316.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line33.json
+++ b/db/Popustop/Popustop.hall3.line33.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line37", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line333.json
+++ b/db/Popustop/Popustop.hall3.line333.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line337", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line349.json
+++ b/db/Popustop/Popustop.hall3.line349.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall4.line353", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line368.json
+++ b/db/Popustop/Popustop.hall3.line368.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line384.json
+++ b/db/Popustop/Popustop.hall3.line384.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line380", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line400.json
+++ b/db/Popustop/Popustop.hall3.line400.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line416.json
+++ b/db/Popustop/Popustop.hall3.line416.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line433.json
+++ b/db/Popustop/Popustop.hall3.line433.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line437", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line449.json
+++ b/db/Popustop/Popustop.hall3.line449.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall4.line453", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line468.json
+++ b/db/Popustop/Popustop.hall3.line468.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line484.json
+++ b/db/Popustop/Popustop.hall3.line484.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line480", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line49.json
+++ b/db/Popustop/Popustop.hall3.line49.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall4.line53", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line500.json
+++ b/db/Popustop/Popustop.hall3.line500.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line516.json
+++ b/db/Popustop/Popustop.hall3.line516.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line533.json
+++ b/db/Popustop/Popustop.hall3.line533.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line537", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line549.json
+++ b/db/Popustop/Popustop.hall3.line549.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall4.line553", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line568.json
+++ b/db/Popustop/Popustop.hall3.line568.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line584.json
+++ b/db/Popustop/Popustop.hall3.line584.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line580", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line600.json
+++ b/db/Popustop/Popustop.hall3.line600.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line616.json
+++ b/db/Popustop/Popustop.hall3.line616.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line633.json
+++ b/db/Popustop/Popustop.hall3.line633.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line637", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line649.json
+++ b/db/Popustop/Popustop.hall3.line649.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall4.line653", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line668.json
+++ b/db/Popustop/Popustop.hall3.line668.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line68.json
+++ b/db/Popustop/Popustop.hall3.line68.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line684.json
+++ b/db/Popustop/Popustop.hall3.line684.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line680", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line700.json
+++ b/db/Popustop/Popustop.hall3.line700.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line716.json
+++ b/db/Popustop/Popustop.hall3.line716.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line733.json
+++ b/db/Popustop/Popustop.hall3.line733.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line737", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line749.json
+++ b/db/Popustop/Popustop.hall3.line749.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall4.line753", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line768.json
+++ b/db/Popustop/Popustop.hall3.line768.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line784.json
+++ b/db/Popustop/Popustop.hall3.line784.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line780", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line800.json
+++ b/db/Popustop/Popustop.hall3.line800.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line816.json
+++ b/db/Popustop/Popustop.hall3.line816.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line833.json
+++ b/db/Popustop/Popustop.hall3.line833.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall4.line837", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line84.json
+++ b/db/Popustop/Popustop.hall3.line84.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line80", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line849.json
+++ b/db/Popustop/Popustop.hall3.line849.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall4.line853", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line868.json
+++ b/db/Popustop/Popustop.hall3.line868.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall3.line884.json
+++ b/db/Popustop/Popustop.hall3.line884.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall2.line880", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall3.line900.json
+++ b/db/Popustop/Popustop.hall3.line900.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall31000.line1033.json
+++ b/db/Popustop/Popustop.hall31000.line1033.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall41000.line1037", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall31000.line1049.json
+++ b/db/Popustop/Popustop.hall31000.line1049.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall41000.line1053", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall31000.line1084.json
+++ b/db/Popustop/Popustop.hall31000.line1084.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall21000.line1080", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall31000.line933.json
+++ b/db/Popustop/Popustop.hall31000.line933.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall41000.line937", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall31000.line949.json
+++ b/db/Popustop/Popustop.hall31000.line949.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-Popustop.hall41000.line953", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall31000.line984.json
+++ b/db/Popustop/Popustop.hall31000.line984.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall21000.line980", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line104.json
+++ b/db/Popustop/Popustop.hall4.line104.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line120.json
+++ b/db/Popustop/Popustop.hall4.line120.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line137.json
+++ b/db/Popustop/Popustop.hall4.line137.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-144.elby.line156", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line153.json
+++ b/db/Popustop/Popustop.hall4.line153.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-144.elby.line154", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line172.json
+++ b/db/Popustop/Popustop.hall4.line172.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line188.json
+++ b/db/Popustop/Popustop.hall4.line188.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line184", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line20.json
+++ b/db/Popustop/Popustop.hall4.line20.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line204.json
+++ b/db/Popustop/Popustop.hall4.line204.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line220.json
+++ b/db/Popustop/Popustop.hall4.line220.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line237.json
+++ b/db/Popustop/Popustop.hall4.line237.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-152.elby.line256", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line253.json
+++ b/db/Popustop/Popustop.hall4.line253.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-152.elby.line254", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line272.json
+++ b/db/Popustop/Popustop.hall4.line272.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line288.json
+++ b/db/Popustop/Popustop.hall4.line288.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line284", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line304.json
+++ b/db/Popustop/Popustop.hall4.line304.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line320.json
+++ b/db/Popustop/Popustop.hall4.line320.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line337.json
+++ b/db/Popustop/Popustop.hall4.line337.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-160.elby.line356", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line353.json
+++ b/db/Popustop/Popustop.hall4.line353.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-160.elby.line354", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line37.json
+++ b/db/Popustop/Popustop.hall4.line37.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-136.elby.line56", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line372.json
+++ b/db/Popustop/Popustop.hall4.line372.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line388.json
+++ b/db/Popustop/Popustop.hall4.line388.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line384", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line404.json
+++ b/db/Popustop/Popustop.hall4.line404.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line420.json
+++ b/db/Popustop/Popustop.hall4.line420.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line437.json
+++ b/db/Popustop/Popustop.hall4.line437.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-168.elby.line456", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line453.json
+++ b/db/Popustop/Popustop.hall4.line453.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-168.elby.line454", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line472.json
+++ b/db/Popustop/Popustop.hall4.line472.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line488.json
+++ b/db/Popustop/Popustop.hall4.line488.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line484", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line504.json
+++ b/db/Popustop/Popustop.hall4.line504.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line520.json
+++ b/db/Popustop/Popustop.hall4.line520.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line53.json
+++ b/db/Popustop/Popustop.hall4.line53.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-136.elby.line54", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line537.json
+++ b/db/Popustop/Popustop.hall4.line537.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-184.elby.line556", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line553.json
+++ b/db/Popustop/Popustop.hall4.line553.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-184.elby.line554", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line572.json
+++ b/db/Popustop/Popustop.hall4.line572.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line588.json
+++ b/db/Popustop/Popustop.hall4.line588.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line584", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line604.json
+++ b/db/Popustop/Popustop.hall4.line604.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line620.json
+++ b/db/Popustop/Popustop.hall4.line620.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line637.json
+++ b/db/Popustop/Popustop.hall4.line637.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-192.elby.line656", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line653.json
+++ b/db/Popustop/Popustop.hall4.line653.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-192.elby.line654", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line672.json
+++ b/db/Popustop/Popustop.hall4.line672.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line688.json
+++ b/db/Popustop/Popustop.hall4.line688.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line684", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line704.json
+++ b/db/Popustop/Popustop.hall4.line704.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line72.json
+++ b/db/Popustop/Popustop.hall4.line72.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line720.json
+++ b/db/Popustop/Popustop.hall4.line720.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line737.json
+++ b/db/Popustop/Popustop.hall4.line737.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-200.elby.line756", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line753.json
+++ b/db/Popustop/Popustop.hall4.line753.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-200.elby.line754", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line772.json
+++ b/db/Popustop/Popustop.hall4.line772.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line788.json
+++ b/db/Popustop/Popustop.hall4.line788.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line784", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line804.json
+++ b/db/Popustop/Popustop.hall4.line804.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line820.json
+++ b/db/Popustop/Popustop.hall4.line820.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line837.json
+++ b/db/Popustop/Popustop.hall4.line837.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-216.elby.line856", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line853.json
+++ b/db/Popustop/Popustop.hall4.line853.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-216.elby.line854", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line872.json
+++ b/db/Popustop/Popustop.hall4.line872.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall4.line88.json
+++ b/db/Popustop/Popustop.hall4.line88.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line84", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line888.json
+++ b/db/Popustop/Popustop.hall4.line888.json
@@ -1,9 +1,9 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall3.line884", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall4.line904.json
+++ b/db/Popustop/Popustop.hall4.line904.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.hall41000.line1037.json
+++ b/db/Popustop/Popustop.hall41000.line1037.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-232.elby1000.line1056", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall41000.line1053.json
+++ b/db/Popustop/Popustop.hall41000.line1053.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-232.elby1000.line1054", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall41000.line1088.json
+++ b/db/Popustop/Popustop.hall41000.line1088.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall31000.line1084", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall41000.line937.json
+++ b/db/Popustop/Popustop.hall41000.line937.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-224.elby1000.line956", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall41000.line953.json
+++ b/db/Popustop/Popustop.hall41000.line953.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "context-224.elby1000.line954", 
           "", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.hall41000.line988.json
+++ b/db/Popustop/Popustop.hall41000.line988.json
@@ -3,7 +3,7 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": "!ASTROESC!177", 
+        "town_dir": "\u007f", 
         "neighbors": [
           "", 
           "context-Popustop.hall31000.line984", 
@@ -13,7 +13,7 @@
         "realm": "Popustop", 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": "!ASTROESC!177", 
+        "port_dir": "\u007f", 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.lobby.line3.json
+++ b/db/Popustop/Popustop.lobby.line3.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "}", 

--- a/db/Popustop/Popustop.stairs.line1021.json
+++ b/db/Popustop/Popustop.stairs.line1021.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.stairs.line121.json
+++ b/db/Popustop/Popustop.stairs.line121.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.stairs.line2.json
+++ b/db/Popustop/Popustop.stairs.line2.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "}", 

--- a/db/Popustop/Popustop.stairs.line21.json
+++ b/db/Popustop/Popustop.stairs.line21.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.stairs.line221.json
+++ b/db/Popustop/Popustop.stairs.line221.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.stairs.line321.json
+++ b/db/Popustop/Popustop.stairs.line321.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.stairs.line421.json
+++ b/db/Popustop/Popustop.stairs.line421.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.stairs.line521.json
+++ b/db/Popustop/Popustop.stairs.line521.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.stairs.line621.json
+++ b/db/Popustop/Popustop.stairs.line621.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.stairs.line721.json
+++ b/db/Popustop/Popustop.stairs.line721.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.stairs.line821.json
+++ b/db/Popustop/Popustop.stairs.line821.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/Popustop.stairs.line921.json
+++ b/db/Popustop/Popustop.stairs.line921.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 

--- a/db/Popustop/basement.line1.json
+++ b/db/Popustop/basement.line1.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "", 

--- a/db/Popustop/roof.line1105.json
+++ b/db/Popustop/roof.line1105.json
@@ -1,6 +1,6 @@
 [
   {
-    "capacity": 6, 
+    "capacity": 64, 
     "mods": [
       {
         "town_dir": "~", 


### PR DESCRIPTION
An older version of Astroturf did not correctly translate escaped octal ASCII table offsets and this bug is reflected in some of the converted Popustop regions.

This escape notation was only used for characters at octal 177, so this PR translates them to the corresponding PETSCII rune, right arrow, which Neohabitat represents by the ASCII rune ```\x7f```, which using JSON standard Unicode character encoding is ```\u007f```.

This now parses correctly:

![screen shot 2017-05-23 at 3 44 32 pm](https://cloud.githubusercontent.com/assets/15283/26379625/0272e63e-3fcf-11e7-83d1-7973af199afd.png)

Finally, capacity is updated to 64 in any Popustop region where it was not set as such.