### PR TITLE
Move db.close() into callback

### DIFF
--- a/tools/generateBookOfRecords.js
+++ b/tools/generateBookOfRecords.js
@@ -216,8 +216,8 @@ MongoClient.connect("mongodb://" + Argv.mongo, function(err, db) {
 		if (undefined !== users) {
 			processUserStats(users);
 		}
+		db.close();
 	});
-	db.close();
 });
 
 


### PR DESCRIPTION
There is a race condition in generateBookOfRecords.js that will result in a DB close before the completion of the DB query. This PR corrects this issue by moving ```db.close()``` into the callback.