### PR TITLE
Adds downtown teleporter plaques and text-teleporterhelp

### DIFF
--- a/db/Text/text-teleporterhelp.json
+++ b/db/Text/text-teleporterhelp.json
@@ -1,0 +1,35 @@
+{
+	"ref": "text-teleporterhelp",
+	"pages": [
+		 "----------------------------------------" +
+		 "       HOW TO USE THE TELEPORTER        " + 
+		 "                                        " +
+		 "Using a teleporter requires tokens, so  " +
+		 "you must first GET tokens out of your   " +
+		 "pocket and then place your cursor on the" +
+		 "teleporter. While your cursor is still  " +
+		 "on the elevator perform a PUT command.  " +
+		 "Upon inserting a token you should hear  " +
+		 "a brief sound indicating success. Make  " +
+		 "sure your avatar is inside the teleport " +
+		 "and that your cursor is placed on the   " +
+		 "teleporter itself. Now, type in '42nd'  " +
+		 "or 'plaza' and press RETURN. Typing in  " +
+		 "'home' will also take you to your       " +
+		 "own private turf.",
+     
+ 		"----------------------------------------" +
+		"          THE PHONE HOME BOOK           " +
+		"Hyper Dr Cross: pop-hyperdrive          " +
+		"Hyper Dr North End: pop-hyperdrivenorth " +
+		"Hyper Dr South End: pop-hyperdrivesouth " +
+		"Outamy Wy Cross: pop-outamyway          " +
+		"Outamy Wy North End: pop-outamywaynorth " +
+		"Outamy Wy South End: pop-outamywaysouth " +
+		"Road St Cross: pop-roadstreet           " +
+		"Road St North End: pop-roadstreetnorth  " +
+		"Road St South End: pop-roadstreetsouth  " +
+		"Street Rd Cross: pop-streetroad         " +
+		"Street Rd North End: pop-streetroadnorth" +
+		"Street Rd South End: pop-streetroadsouth"]
+}

--- a/db/new_Downtown/item-Downtown.plaque.json
+++ b/db/new_Downtown/item-Downtown.plaque.json
@@ -1,0 +1,98 @@
+[
+  {
+    "type" : "item",
+    "ref" : "item-Downtown.plaque",
+    "name" : "Teleporter Plaque",
+    "in" : "context-Downtown_3b", 
+    "mods" : [ 
+      {
+        "type" : "Plaque",
+        "x" : 80,
+        "y" : 60,
+        "style": 2,
+        "last_page" : 2,
+        "path" : "text-teleporterhelp"
+      } 
+    ]
+  },
+  {
+    "type" : "item",
+    "ref" : "item-Downtown.plaque0",
+    "name" : "Teleporter Plaque",
+    "in" : "context-Downtown_4e", 
+    "mods" : [ 
+      {
+        "type" : "Plaque",
+        "x" : 30,
+        "y" : 140,
+        "style": 2, 
+        "last_page" : 2,
+        "path" : "text-teleporterhelp"
+      } 
+    ]
+  },
+  {
+    "type" : "item",
+    "ref" : "item-Downtown.plaque1",
+    "name" : "Teleporter Plaque",
+    "in" : "context-Downtown_4g", 
+    "mods" : [ 
+      {
+        "type" : "Plaque",
+        "x" : 110,
+        "y" : 140,
+        "style": 2, 
+        "last_page" : 2,
+        "path" : "text-teleporterhelp"
+      } 
+    ]
+  },      
+  {
+    "type" : "item",
+    "ref" : "item-Downtown.plaque2",
+    "name" : "Teleporter Plaque",
+    "in" : "context-Downtown_6e",
+    "mods" : [ 
+      {
+        "type" : "Plaque",
+        "x" : 40,
+        "y" : 140,
+        "style": 2, 
+        "last_page" : 2,
+        "path" : "text-teleporterhelp"
+      } 
+    ]
+  },
+  {
+    "type" : "item",
+    "ref" : "item-Downtown.plaque3",
+    "name" : "Teleporter Plaque",
+    "in" : "context-Downtown_6g",
+    "mods" : [ 
+      {
+        "type" : "Plaque",
+        "x" : 120,
+        "y" : 140,
+        "style": 2, 
+        "last_page" : 2,
+        "path" : "text-teleporterhelp"
+      } 
+    ]
+  },
+  {
+    "type" : "item",
+    "ref" : "item-Downtown.plaque4",
+    "name" : "Teleporter Plaque",
+    "in" : "context-Downtown_7j",
+    "mods" : [ 
+      {
+        "type" : "Plaque",
+        "x" : 80,
+        "y" : 60,
+        "style": 2, 
+        "last_page" : 2,
+        "path" : "text-teleporterhelp"
+      } 
+    ]
+  }
+]     


### PR DESCRIPTION
Plaques in the plaza regions are at the base of the teleporters, while plaques in other areas are mounted on the walls. If you want, I can change it so that all plaques conform to being at the base of the teleporter. If there are any areas that I'm missing that require a plaque just leave a comment and I'll make sure it gets added. 

I also noticed players were having a lot of trouble finding their friends turf, so I made a second page that lists all the teleporters for the street regions.

On the side note, I couldn't get the plaque centered at the base of the teleporter for Plaza NE, so it looks a bit odd.
![plaza nw](https://user-images.githubusercontent.com/7967050/27494301-48e2c346-581b-11e7-89b0-52511ad2c7c6.JPG)

![elevator plaque 2](https://user-images.githubusercontent.com/7967050/27494114-6934dac2-581a-11e7-80ca-d15452dd1109.JPG)
