### PR TITLE
Regionator tweaks

### DIFF
--- a/db/Desert/Desert_1a.json
+++ b/db/Desert/Desert_1a.json
@@ -1,0 +1,129 @@
+[
+  {
+    "ref": "context-Desert_1a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_1b", 
+          "context-Desert_2a", 
+          "", 
+          "context-Desert_1b"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.6d0b.Desert_1a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_1a"
+  }, 
+  {
+    "ref": "item-Flat.33bc.Desert_1a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1a"
+  }, 
+  {
+    "ref": "item-Tree.bc4d.Desert_1a", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 84, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_1a"
+  }, 
+  {
+    "ref": "item-Pond.bfb1.Desert_1a", 
+    "mods": [
+      {
+        "y": 43, 
+        "x": 112, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 4
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-Desert_1a"
+  }, 
+  {
+    "ref": "item-Tree.a486.Desert_1a", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 32, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_1a"
+  }, 
+  {
+    "ref": "item-Tree.3bba.Desert_1a", 
+    "mods": [
+      {
+        "y": 130, 
+        "x": 16, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_1a"
+  }, 
+  {
+    "ref": "item-Flat.c74c.Desert_1a", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1a"
+  }
+]

--- a/db/Desert/Desert_1b.json
+++ b/db/Desert/Desert_1b.json
@@ -1,0 +1,115 @@
+[
+  {
+    "ref": "context-Desert_1b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_2c", 
+          "context-Desert_1c", 
+          "context-Desert_1a", 
+          "context-Desert_2b"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.a510.Desert_1b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_1b"
+  }, 
+  {
+    "ref": "item-Flat.2498.Desert_1b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1b"
+  }, 
+  {
+    "ref": "item-Tree.0763.Desert_1b", 
+    "mods": [
+      {
+        "y": 102, 
+        "x": 100, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_1b"
+  }, 
+  {
+    "ref": "item-Bush.430c.Desert_1b", 
+    "mods": [
+      {
+        "y": 132, 
+        "x": 24, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_1b"
+  }, 
+  {
+    "ref": "item-Bush.2117.Desert_1b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 9, 
+        "gr_state": 1, 
+        "y": 139, 
+        "x": 132, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_1b"
+  }, 
+  {
+    "ref": "item-Flat.44f4.Desert_1b", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1b"
+  }
+]

--- a/db/Desert/Desert_1c.json
+++ b/db/Desert/Desert_1c.json
@@ -1,0 +1,146 @@
+[
+  {
+    "ref": "context-Desert_1c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_1d", 
+          "context-Desert_2c", 
+          "context-Desert_1c", 
+          "context-Desert_5c"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.4e6e.Desert_1c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_1c"
+  }, 
+  {
+    "ref": "item-Flat.53be.Desert_1c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1c"
+  }, 
+  {
+    "ref": "item-Tree.9c70.Desert_1c", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 92, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_1c"
+  }, 
+  {
+    "ref": "item-Bush.146a.Desert_1c", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 56
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_1c"
+  }, 
+  {
+    "ref": "item-Tree.8b2f.Desert_1c", 
+    "mods": [
+      {
+        "y": 148, 
+        "x": 40, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_1c"
+  }, 
+  {
+    "ref": "item-Flat.6eb5.Desert_1c", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1c"
+  }, 
+  {
+    "ref": "item-Bush.202f.Desert_1c", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 92, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_1c"
+  }, 
+  {
+    "ref": "item-Bush.b8f8.Desert_1c", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_1c"
+  }
+]

--- a/db/Desert/Desert_1d.json
+++ b/db/Desert/Desert_1d.json
@@ -1,0 +1,69 @@
+[
+  {
+    "ref": "context-Desert_1d", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_2e", 
+          "context-Desert_2d", 
+          "context-Desert_1e", 
+          "context-Desert_2d"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.bf81.Desert_1d", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_1d"
+  }, 
+  {
+    "ref": "item-Flat.eb99.Desert_1d", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1d"
+  }, 
+  {
+    "ref": "item-Flat.2e66.Desert_1d", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1d"
+  }
+]

--- a/db/Desert/Desert_1e.json
+++ b/db/Desert/Desert_1e.json
@@ -1,0 +1,101 @@
+[
+  {
+    "ref": "context-Desert_1e", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_3e", 
+          "context-Desert_2e", 
+          "context-Desert_1d", 
+          "context-Desert_1f"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.44a8.Desert_1e", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_1e"
+  }, 
+  {
+    "ref": "item-Flat.0fb4.Desert_1e", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1e"
+  }, 
+  {
+    "ref": "item-Tree.10f4.Desert_1e", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 68, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_1e"
+  }, 
+  {
+    "ref": "item-Garbage_can.c366.Desert_1e", 
+    "mods": [
+      {
+        "orientation": 228, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 144, 
+        "x": 116, 
+        "type": "Garbage_can", 
+        "open_flags": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Garbage_can", 
+    "in": "context-Desert_1e"
+  }, 
+  {
+    "ref": "item-Flat.7d12.Desert_1e", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1e"
+  }
+]

--- a/db/Desert/Desert_1f.json
+++ b/db/Desert/Desert_1f.json
@@ -1,0 +1,221 @@
+[
+  {
+    "ref": "context-Desert_1f", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-Desert_2f", 
+          "context-Desert_1e", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.1c3f.Desert_1f", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Flat.69b4.Desert_1f", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Pond.6f78.Desert_1f", 
+    "mods": [
+      {
+        "y": 10, 
+        "x": 72, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Bush.da4b.Desert_1f", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 36, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 56
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Pond.52a5.Desert_1f", 
+    "mods": [
+      {
+        "y": 14, 
+        "x": 56, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Flat.91ec.Desert_1f", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Pond.4874.Desert_1f", 
+    "mods": [
+      {
+        "y": 5, 
+        "x": 36, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Pond.e47a.Desert_1f", 
+    "mods": [
+      {
+        "y": 5, 
+        "x": 60, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Flat.f9f8.Desert_1f", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Bush.a898.Desert_1f", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 92, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Pond.8f6b.Desert_1f", 
+    "mods": [
+      {
+        "y": 25, 
+        "x": 44, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Pond.abf7.Desert_1f", 
+    "mods": [
+      {
+        "y": 14, 
+        "x": 40, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-Desert_1f"
+  }, 
+  {
+    "ref": "item-Tree.509e.Desert_1f", 
+    "mods": [
+      {
+        "y": 132, 
+        "x": 24, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_1f"
+  }
+]

--- a/db/Desert/Desert_2a.json
+++ b/db/Desert/Desert_2a.json
@@ -1,0 +1,116 @@
+[
+  {
+    "ref": "context-Desert_2a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_2b", 
+          "context-Desert_3a", 
+          "", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.4a33.Desert_2a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_2a"
+  }, 
+  {
+    "ref": "item-Flat.6ce2.Desert_2a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2a"
+  }, 
+  {
+    "ref": "item-Bush.debe.Desert_2a", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 12, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 56
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_2a"
+  }, 
+  {
+    "ref": "item-Flat.fdab.Desert_2a", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2a"
+  }, 
+  {
+    "ref": "item-Bush.a18d.Desert_2a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 92, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_2a"
+  }, 
+  {
+    "ref": "item-Bush.d241.Desert_2a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_2a"
+  }
+]

--- a/db/Desert/Desert_2b.json
+++ b/db/Desert/Desert_2b.json
@@ -1,0 +1,114 @@
+[
+  {
+    "ref": "context-Desert_2b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-Desert_3b", 
+          "", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.f377.Desert_2b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_2b"
+  }, 
+  {
+    "ref": "item-Flat.3701.Desert_2b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2b"
+  }, 
+  {
+    "ref": "item-Street.17db.Desert_2b", 
+    "mods": [
+      {
+        "y": 12, 
+        "x": 60, 
+        "type": "Street", 
+        "orientation": 8, 
+        "gr_state": 5
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Desert_2b"
+  }, 
+  {
+    "ref": "item-Tree.7016.Desert_2b", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 24, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_2b"
+  }, 
+  {
+    "ref": "item-Street.67fa.Desert_2b", 
+    "mods": [
+      {
+        "y": 12, 
+        "x": 72, 
+        "type": "Street", 
+        "orientation": 8, 
+        "gr_state": 5
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Desert_2b"
+  }, 
+  {
+    "ref": "item-Flat.2317.Desert_2b", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2b"
+  }
+]

--- a/db/Desert/Desert_2c.json
+++ b/db/Desert/Desert_2c.json
@@ -1,0 +1,160 @@
+[
+  {
+    "ref": "context-Desert_2c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_3c", 
+          "", 
+          "", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.890d.Desert_2c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_2c"
+  }, 
+  {
+    "ref": "item-Flat.3c7f.Desert_2c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2c"
+  }, 
+  {
+    "ref": "item-Trapezoid.2b89.Desert_2c", 
+    "mods": [
+      {
+        "lower_right_x": 8, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 249, 
+        "trapezoid_type": 0, 
+        "y": 20, 
+        "x": 52, 
+        "height": 21, 
+        "type": "Trapezoid", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-Desert_2c"
+  }, 
+  {
+    "ref": "item-Bush.f46f.Desert_2c", 
+    "mods": [
+      {
+        "y": 132, 
+        "x": 24, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 56
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_2c"
+  }, 
+  {
+    "ref": "item-Bush.9b40.Desert_2c", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 9, 
+        "gr_state": 1, 
+        "y": 139, 
+        "x": 132, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_2c"
+  }, 
+  {
+    "ref": "item-Trapezoid.216f.Desert_2c", 
+    "mods": [
+      {
+        "lower_right_x": 15, 
+        "upper_left_x": 2, 
+        "upper_right_x": 2, 
+        "lower_left_x": 7, 
+        "trapezoid_type": 0, 
+        "y": 19, 
+        "x": 52, 
+        "height": 16, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-Desert_2c"
+  }, 
+  {
+    "ref": "item-Trapezoid.acd2.Desert_2c", 
+    "mods": [
+      {
+        "lower_right_x": 1, 
+        "upper_left_x": 0, 
+        "upper_right_x": 7, 
+        "lower_left_x": 1, 
+        "trapezoid_type": 0, 
+        "y": 131, 
+        "x": 60, 
+        "height": 4, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-Desert_2c"
+  }, 
+  {
+    "ref": "item-Flat.2052.Desert_2c", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2c"
+  }
+]

--- a/db/Desert/Desert_2d.json
+++ b/db/Desert/Desert_2d.json
@@ -1,0 +1,114 @@
+[
+  {
+    "ref": "context-Desert_2d", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-Desert_3d", 
+          "", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.0dee.Desert_2d", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_2d"
+  }, 
+  {
+    "ref": "item-Flat.0bc6.Desert_2d", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2d"
+  }, 
+  {
+    "ref": "item-Street.dafa.Desert_2d", 
+    "mods": [
+      {
+        "y": 12, 
+        "x": 60, 
+        "type": "Street", 
+        "orientation": 8, 
+        "gr_state": 5
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Desert_2d"
+  }, 
+  {
+    "ref": "item-Tree.dd3d.Desert_2d", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 120, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_2d"
+  }, 
+  {
+    "ref": "item-Street.0511.Desert_2d", 
+    "mods": [
+      {
+        "y": 12, 
+        "x": 72, 
+        "type": "Street", 
+        "orientation": 8, 
+        "gr_state": 5
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Desert_2d"
+  }, 
+  {
+    "ref": "item-Flat.1d6c.Desert_2d", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2d"
+  }
+]

--- a/db/Desert/Desert_2e.json
+++ b/db/Desert/Desert_2e.json
@@ -1,0 +1,148 @@
+[
+  {
+    "ref": "context-Desert_2e", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_1f", 
+          "context-Desert_3e", 
+          "", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.0529.Desert_2e", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_2e"
+  }, 
+  {
+    "ref": "item-Flat.8806.Desert_2e", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2e"
+  }, 
+  {
+    "ref": "item-Tree.c5f0.Desert_2e", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 8, 
+        "gr_state": 4, 
+        "y": 60, 
+        "x": 72, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_2e"
+  }, 
+  {
+    "ref": "item-Tree.029d.Desert_2e", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 8, 
+        "gr_state": 3, 
+        "y": 67, 
+        "x": 64, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_2e"
+  }, 
+  {
+    "ref": "item-Tree.3e9d.Desert_2e", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 8, 
+        "gr_state": 1, 
+        "y": 29, 
+        "x": 64, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_2e"
+  }, 
+  {
+    "ref": "item-Tree.4e64.Desert_2e", 
+    "mods": [
+      {
+        "y": 130, 
+        "x": 16, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_2e"
+  }, 
+  {
+    "ref": "item-Flat.3f97.Desert_2e", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2e"
+  }, 
+  {
+    "ref": "item-Bush.312b.Desert_2e", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_2e"
+  }
+]

--- a/db/Desert/Desert_2f.json
+++ b/db/Desert/Desert_2f.json
@@ -1,0 +1,129 @@
+[
+  {
+    "ref": "context-Desert_2f", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-Desert_3f", 
+          "", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.435a.Desert_2f", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_2f"
+  }, 
+  {
+    "ref": "item-Flat.1573.Desert_2f", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2f"
+  }, 
+  {
+    "ref": "item-Tree.80c3.Desert_2f", 
+    "mods": [
+      {
+        "y": 102, 
+        "x": 52, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_2f"
+  }, 
+  {
+    "ref": "item-Bush.255e.Desert_2f", 
+    "mods": [
+      {
+        "y": 132, 
+        "x": 24, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 56
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_2f"
+  }, 
+  {
+    "ref": "item-Bush.89bf.Desert_2f", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 9, 
+        "gr_state": 1, 
+        "y": 139, 
+        "x": 132, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_2f"
+  }, 
+  {
+    "ref": "item-Atm.e77a.Desert_2f", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 88, 
+        "type": "Atm", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Atm", 
+    "in": "context-Desert_2f"
+  }, 
+  {
+    "ref": "item-Flat.f462.Desert_2f", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_2f"
+  }
+]

--- a/db/Desert/Desert_3a.json
+++ b/db/Desert/Desert_3a.json
@@ -1,0 +1,115 @@
+[
+  {
+    "ref": "context-Desert_3a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_4b", 
+          "context-Desert_4a", 
+          "", 
+          "context-Desert_2b"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.75b9.Desert_3a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_3a"
+  }, 
+  {
+    "ref": "item-Flat.549c.Desert_3a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3a"
+  }, 
+  {
+    "ref": "item-Street.ed24.Desert_3a", 
+    "mods": [
+      {
+        "y": 12, 
+        "x": 60, 
+        "type": "Street", 
+        "orientation": 8, 
+        "gr_state": 5
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Desert_3a"
+  }, 
+  {
+    "ref": "item-Knick_knack.b64a.Desert_3a", 
+    "mods": [
+      {
+        "style": 12, 
+        "orientation": 16, 
+        "y": 154, 
+        "x": 76, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "context-Desert_3a"
+  }, 
+  {
+    "ref": "item-Street.300e.Desert_3a", 
+    "mods": [
+      {
+        "y": 12, 
+        "x": 72, 
+        "type": "Street", 
+        "orientation": 8, 
+        "gr_state": 5
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Desert_3a"
+  }, 
+  {
+    "ref": "item-Flat.9d44.Desert_3a", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3a"
+  }
+]

--- a/db/Desert/Desert_3b.json
+++ b/db/Desert/Desert_3b.json
@@ -1,0 +1,69 @@
+[
+  {
+    "ref": "context-Desert_3b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_3c", 
+          "context-Desert_2c", 
+          "", 
+          "context-Desert_1b"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.a902.Desert_3b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_3b"
+  }, 
+  {
+    "ref": "item-Flat.b8cc.Desert_3b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3b"
+  }, 
+  {
+    "ref": "item-Flat.10d2.Desert_3b", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3b"
+  }
+]

--- a/db/Desert/Desert_3c.json
+++ b/db/Desert/Desert_3c.json
@@ -1,0 +1,146 @@
+[
+  {
+    "ref": "context-Desert_3c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_3b", 
+          "context-Desert_4d", 
+          "", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.ecc0.Desert_3c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_3c"
+  }, 
+  {
+    "ref": "item-Flat.2450.Desert_3c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3c"
+  }, 
+  {
+    "ref": "item-Street.ec74.Desert_3c", 
+    "mods": [
+      {
+        "y": 12, 
+        "x": 68, 
+        "type": "Street", 
+        "orientation": 8, 
+        "gr_state": 7
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Desert_3c"
+  }, 
+  {
+    "ref": "item-Rock.5960.Desert_3c", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 100, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-Desert_3c"
+  }, 
+  {
+    "ref": "item-Rock.3dec.Desert_3c", 
+    "mods": [
+      {
+        "y": 148, 
+        "x": 120, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-Desert_3c"
+  }, 
+  {
+    "ref": "item-Rock.4352.Desert_3c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 162, 
+        "x": 24, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-Desert_3c"
+  }, 
+  {
+    "ref": "item-Rock.7f7a.Desert_3c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 72, 
+        "mass": 1, 
+        "y": 152, 
+        "x": 144, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-Desert_3c"
+  }, 
+  {
+    "ref": "item-Flat.09bc.Desert_3c", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3c"
+  }
+]

--- a/db/Desert/Desert_3d.json
+++ b/db/Desert/Desert_3d.json
@@ -1,0 +1,130 @@
+[
+  {
+    "ref": "context-Desert_3d", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_2e", 
+          "", 
+          "", 
+          "context-Desert_2d"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.250b.Desert_3d", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_3d"
+  }, 
+  {
+    "ref": "item-Flat.edb3.Desert_3d", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3d"
+  }, 
+  {
+    "ref": "item-Teleport.ce63.Desert_3d", 
+    "mods": [
+      {
+        "y": 132, 
+        "x": 92, 
+        "type": "Teleport", 
+        "orientation": 0, 
+        "address": "desert"
+      }
+    ], 
+    "type": "item", 
+    "name": "Teleport", 
+    "in": "context-Desert_3d"
+  }, 
+  {
+    "ref": "item-Tree.c29a.Desert_3d", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 64, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_3d"
+  }, 
+  {
+    "ref": "item-Tree.8737.Desert_3d", 
+    "mods": [
+      {
+        "y": 130, 
+        "x": 16, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_3d"
+  }, 
+  {
+    "ref": "item-Flat.3958.Desert_3d", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3d"
+  }, 
+  {
+    "ref": "item-Bush.5d74.Desert_3d", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_3d"
+  }
+]

--- a/db/Desert/Desert_3e.json
+++ b/db/Desert/Desert_3e.json
@@ -1,0 +1,126 @@
+[
+  {
+    "ref": "context-Desert_3e", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_4d", 
+          "", 
+          "", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.33a8.Desert_3e", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_3e"
+  }, 
+  {
+    "ref": "item-Flat.a49e.Desert_3e", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3e"
+  }, 
+  {
+    "ref": "item-Street.fda4.Desert_3e", 
+    "mods": [
+      {
+        "y": 12, 
+        "x": 68, 
+        "type": "Street", 
+        "orientation": 8, 
+        "gr_state": 6
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Desert_3e"
+  }, 
+  {
+    "ref": "item-Tree.b456.Desert_3e", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 20, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 32
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_3e"
+  }, 
+  {
+    "ref": "item-Short_sign.41d5.Desert_3e", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "ascii": [
+          138, 
+          128, 
+          133, 
+          131, 
+          56, 
+          48, 
+          32, 
+          32, 
+          32, 
+          32
+        ], 
+        "y": 32, 
+        "x": 116, 
+        "type": "Short_sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Short_sign", 
+    "in": "context-Desert_3e"
+  }, 
+  {
+    "ref": "item-Flat.6ef4.Desert_3e", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3e"
+  }
+]

--- a/db/Desert/Desert_3f.json
+++ b/db/Desert/Desert_3f.json
@@ -1,0 +1,114 @@
+[
+  {
+    "ref": "context-Desert_3f", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-Desert_1f", 
+          "", 
+          "context-Desert_5f"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.6c09.Desert_3f", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_3f"
+  }, 
+  {
+    "ref": "item-Flat.80ef.Desert_3f", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3f"
+  }, 
+  {
+    "ref": "item-Tree.9910.Desert_3f", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 84, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_3f"
+  }, 
+  {
+    "ref": "item-Tree.6e47.Desert_3f", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 32, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_3f"
+  }, 
+  {
+    "ref": "item-Tree.49de.Desert_3f", 
+    "mods": [
+      {
+        "y": 130, 
+        "x": 16, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_3f"
+  }, 
+  {
+    "ref": "item-Flat.1f8d.Desert_3f", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_3f"
+  }
+]

--- a/db/Desert/Desert_4a.json
+++ b/db/Desert/Desert_4a.json
@@ -1,0 +1,148 @@
+[
+  {
+    "ref": "context-Desert_4a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_4d", 
+          "context-Desert_5a", 
+          "", 
+          "context-Desert_3a"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.50c2.Desert_4a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_4a"
+  }, 
+  {
+    "ref": "item-Flat.a714.Desert_4a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4a"
+  }, 
+  {
+    "ref": "item-Tree.f4bb.Desert_4a", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 8, 
+        "gr_state": 4, 
+        "y": 60, 
+        "x": 56, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_4a"
+  }, 
+  {
+    "ref": "item-Tree.9089.Desert_4a", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 67, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_4a"
+  }, 
+  {
+    "ref": "item-Tree.9f21.Desert_4a", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 8, 
+        "gr_state": 1, 
+        "y": 29, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_4a"
+  }, 
+  {
+    "ref": "item-Tree.f418.Desert_4a", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 9, 
+        "gr_state": 2, 
+        "y": 77, 
+        "x": 44, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_4a"
+  }, 
+  {
+    "ref": "item-Tree.8777.Desert_4a", 
+    "mods": [
+      {
+        "y": 130, 
+        "x": 84, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_4a"
+  }, 
+  {
+    "ref": "item-Flat.bda2.Desert_4a", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4a"
+  }
+]

--- a/db/Desert/Desert_4b.json
+++ b/db/Desert/Desert_4b.json
@@ -1,0 +1,141 @@
+[
+  {
+    "ref": "context-Desert_4b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-Desert_3b", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.7a30.Desert_4b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_4b"
+  }, 
+  {
+    "ref": "item-Flat.960a.Desert_4b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4b"
+  }, 
+  {
+    "ref": "item-Street.a89a.Desert_4b", 
+    "mods": [
+      {
+        "y": 12, 
+        "x": 68, 
+        "type": "Street", 
+        "orientation": 220, 
+        "gr_state": 6
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Desert_4b"
+  }, 
+  {
+    "ref": "item-Sign.59b7.Desert_4b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "ascii": [
+          134, 
+          83, 
+          80, 
+          69, 
+          69, 
+          68, 
+          134, 
+          128, 
+          66, 
+          85, 
+          77, 
+          80, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ], 
+        "y": 130, 
+        "x": 48, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-Desert_4b"
+  }, 
+  {
+    "ref": "item-Flat.ff5d.Desert_4b", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4b"
+  }
+]

--- a/db/Desert/Desert_4c.json
+++ b/db/Desert/Desert_4c.json
@@ -1,0 +1,130 @@
+[
+  {
+    "ref": "context-Desert_4c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_3d", 
+          "", 
+          "", 
+          "context-Desert_4b"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.a931.Desert_4c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_4c"
+  }, 
+  {
+    "ref": "item-Flat.2995.Desert_4c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4c"
+  }, 
+  {
+    "ref": "item-Street.727f.Desert_4c", 
+    "mods": [
+      {
+        "y": 12, 
+        "x": 68, 
+        "type": "Street", 
+        "orientation": 8, 
+        "gr_state": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Desert_4c"
+  }, 
+  {
+    "ref": "item-Rock.3012.Desert_4c", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 56, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-Desert_4c"
+  }, 
+  {
+    "ref": "item-Rock.9043.Desert_4c", 
+    "mods": [
+      {
+        "y": 158, 
+        "x": 120, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-Desert_4c"
+  }, 
+  {
+    "ref": "item-Rock.64f8.Desert_4c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 88, 
+        "mass": 1, 
+        "y": 129, 
+        "x": 144, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-Desert_4c"
+  }, 
+  {
+    "ref": "item-Flat.52f2.Desert_4c", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4c"
+  }
+]

--- a/db/Desert/Desert_4d.json
+++ b/db/Desert/Desert_4d.json
@@ -1,0 +1,186 @@
+[
+  {
+    "ref": "context-Desert_4d", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_4e", 
+          "context-Desert_5d", 
+          "", 
+          "context-Desert_3d"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.8bc5.Desert_4d", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_4d"
+  }, 
+  {
+    "ref": "item-Flat.dd6a.Desert_4d", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4d"
+  }, 
+  {
+    "ref": "item-Couch.2fea.Desert_4d", 
+    "mods": [
+      {
+        "y": 148, 
+        "x": 20, 
+        "type": "Couch", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Couch", 
+    "in": "context-Desert_4d"
+  }, 
+  {
+    "ref": "item-Rock.61df.Desert_4d", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 56, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-Desert_4d"
+  }, 
+  {
+    "ref": "item-Rock.d696.Desert_4d", 
+    "mods": [
+      {
+        "y": 158, 
+        "x": 120, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-Desert_4d"
+  }, 
+  {
+    "ref": "item-Sign.1fe4.Desert_4d", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "ascii": [
+          134, 
+          128, 
+          82, 
+          69, 
+          83, 
+          84, 
+          134, 
+          128, 
+          83, 
+          84, 
+          79, 
+          80, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ], 
+        "y": 35, 
+        "x": 108, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-Desert_4d"
+  }, 
+  {
+    "ref": "item-Rock.6ce3.Desert_4d", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 88, 
+        "mass": 1, 
+        "y": 129, 
+        "x": 144, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-Desert_4d"
+  }, 
+  {
+    "ref": "item-Flat.ee64.Desert_4d", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4d"
+  }
+]

--- a/db/Desert/Desert_4e.json
+++ b/db/Desert/Desert_4e.json
@@ -1,0 +1,84 @@
+[
+  {
+    "ref": "context-Desert_4e", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_4f", 
+          "context-Desert_5e", 
+          "context-Desert_4d", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.d33f.Desert_4e", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_4e"
+  }, 
+  {
+    "ref": "item-Flat.3d8d.Desert_4e", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4e"
+  }, 
+  {
+    "ref": "item-Street.5e4a.Desert_4e", 
+    "mods": [
+      {
+        "y": 12, 
+        "x": 68, 
+        "type": "Street", 
+        "orientation": 220, 
+        "gr_state": 6
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Desert_4e"
+  }, 
+  {
+    "ref": "item-Flat.c381.Desert_4e", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4e"
+  }
+]

--- a/db/Desert/Desert_4f.json
+++ b/db/Desert/Desert_4f.json
@@ -1,0 +1,69 @@
+[
+  {
+    "ref": "context-Desert_4f", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-Desert_5e", 
+          "context-Desert_3f"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.8504.Desert_4f", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_4f"
+  }, 
+  {
+    "ref": "item-Flat.5bba.Desert_4f", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4f"
+  }, 
+  {
+    "ref": "item-Flat.1834.Desert_4f", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_4f"
+  }
+]

--- a/db/Desert/Desert_5a.json
+++ b/db/Desert/Desert_5a.json
@@ -1,0 +1,99 @@
+[
+  {
+    "ref": "context-Desert_5a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_5b", 
+          "context-Desert_5b", 
+          "", 
+          "context-Desert_4a"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.97d4.Desert_5a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_5a"
+  }, 
+  {
+    "ref": "item-Flat.563c.Desert_5a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5a"
+  }, 
+  {
+    "ref": "item-Tree.383a.Desert_5a", 
+    "mods": [
+      {
+        "y": 102, 
+        "x": 24, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_5a"
+  }, 
+  {
+    "ref": "item-Tree.1aac.Desert_5a", 
+    "mods": [
+      {
+        "y": 108, 
+        "x": 24, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 17
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_5a"
+  }, 
+  {
+    "ref": "item-Flat.f409.Desert_5a", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5a"
+  }
+]

--- a/db/Desert/Desert_5b.json
+++ b/db/Desert/Desert_5b.json
@@ -1,0 +1,130 @@
+[
+  {
+    "ref": "context-Desert_5b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_4c", 
+          "", 
+          "", 
+          "context-Desert_5c"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.6f24.Desert_5b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_5b"
+  }, 
+  {
+    "ref": "item-Flat.3053.Desert_5b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5b"
+  }, 
+  {
+    "ref": "item-Tree.f909.Desert_5b", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 84, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_5b"
+  }, 
+  {
+    "ref": "item-Tree.5d72.Desert_5b", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 64, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_5b"
+  }, 
+  {
+    "ref": "item-Tree.3e99.Desert_5b", 
+    "mods": [
+      {
+        "y": 130, 
+        "x": 16, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_5b"
+  }, 
+  {
+    "ref": "item-Flat.0dcc.Desert_5b", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5b"
+  }, 
+  {
+    "ref": "item-Bush.7c06.Desert_5b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_5b"
+  }
+]

--- a/db/Desert/Desert_5c.json
+++ b/db/Desert/Desert_5c.json
@@ -1,0 +1,98 @@
+[
+  {
+    "ref": "context-Desert_5c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "", 
+          "context-Desert_4c"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.076f.Desert_5c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_5c"
+  }, 
+  {
+    "ref": "item-Flat.47d0.Desert_5c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5c"
+  }, 
+  {
+    "ref": "item-Coke_machine.dfec.Desert_5c", 
+    "mods": [
+      {
+        "y": 144, 
+        "x": 24, 
+        "type": "Coke_machine", 
+        "orientation": 148
+      }
+    ], 
+    "type": "item", 
+    "name": "Coke_machine", 
+    "in": "context-Desert_5c"
+  }, 
+  {
+    "ref": "item-Tree.aafa.Desert_5c", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 68, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 17
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_5c"
+  }, 
+  {
+    "ref": "item-Flat.e00c.Desert_5c", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5c"
+  }
+]

--- a/db/Desert/Desert_5d.json
+++ b/db/Desert/Desert_5d.json
@@ -1,0 +1,117 @@
+[
+  {
+    "ref": "context-Desert_5d", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-Desert_5f", 
+          "", 
+          "context-Desert_5c", 
+          "context-Desert_4d"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.e412.Desert_5d", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_5d"
+  }, 
+  {
+    "ref": "item-Flat.c6cc.Desert_5d", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5d"
+  }, 
+  {
+    "ref": "item-Tree.6972.Desert_5d", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 60, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_5d"
+  }, 
+  {
+    "ref": "item-Tree.ebcb.Desert_5d", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 8, 
+        "gr_state": 1, 
+        "y": 29, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_5d"
+  }, 
+  {
+    "ref": "item-Tree.ddbc.Desert_5d", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 9, 
+        "gr_state": 2, 
+        "y": 53, 
+        "x": 44, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_5d"
+  }, 
+  {
+    "ref": "item-Flat.e932.Desert_5d", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5d"
+  }
+]

--- a/db/Desert/Desert_5e.json
+++ b/db/Desert/Desert_5e.json
@@ -1,0 +1,131 @@
+[
+  {
+    "ref": "context-Desert_5e", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-Desert_5d", 
+          "context-Desert_4e"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.19fd.Desert_5e", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_5e"
+  }, 
+  {
+    "ref": "item-Flat.6bee.Desert_5e", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5e"
+  }, 
+  {
+    "ref": "item-Tree.0802.Desert_5e", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 64, 
+        "style": 5, 
+        "type": "Tree", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Desert_5e"
+  }, 
+  {
+    "ref": "item-Bush.d19a.Desert_5e", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 12, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 56
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_5e"
+  }, 
+  {
+    "ref": "item-Flat.3710.Desert_5e", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5e"
+  }, 
+  {
+    "ref": "item-Bush.1d58.Desert_5e", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 92, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_5e"
+  }, 
+  {
+    "ref": "item-Bush.6591.Desert_5e", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-Desert_5e"
+  }
+]

--- a/db/Desert/Desert_5f.json
+++ b/db/Desert/Desert_5f.json
@@ -1,0 +1,69 @@
+[
+  {
+    "ref": "context-Desert_5f", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Desert", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "", 
+          "context-Desert_4f"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.bc1e.Desert_5f", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Desert_5f"
+  }, 
+  {
+    "ref": "item-Flat.92f0.Desert_5f", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5f"
+  }, 
+  {
+    "ref": "item-Flat.8bf4.Desert_5f", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-Desert_5f"
+  }
+]

--- a/regionator/mod_index.yml
+++ b/regionator/mod_index.yml
@@ -130,10 +130,6 @@ Shovel: {}
 Sign:
   CHOMP: ascii
 
-Street:
-  8: width
-  9: height
-
 Super_trapezoid:
   <<: *polygonal
   14: pattern_x_size

--- a/regionator/mod_renames.yml
+++ b/regionator/mod_renames.yml
@@ -2,3 +2,4 @@
 
 ---
 wind_up_toy: Windup_toy
+teleport_booth: Teleport


### PR DESCRIPTION
- Removed the width/height values from mod_index. When entering a region containing a street with these fields, you would crash every time.
- Added teleport_booth to mod_renames to ensure older RDL files are compatible for conversion to JSON