### PR TITLE
Fixes F7 not displaying an avatars home correctly

### DIFF
--- a/src/main/java/org/made/neohabitat/mods/Avatar.java
+++ b/src/main/java/org/made/neohabitat/mods/Avatar.java
@@ -1721,7 +1721,7 @@ public class Avatar extends Container implements UserMod {
 		} else {
 			try {
 				String[] splitContext = turf.split("-");
-				String[] splitTurf = splitContext[1].split("\\.");
+				String[] splitTurf = splitContext[1].split("\\.|_");
 				String realm = splitTurf[0].substring(0, 1).toUpperCase() + splitTurf[0].substring(1);
 				String turfId = splitTurf[1];
 				return String.format("%s #%s", realm, turfId);
@@ -1731,7 +1731,7 @@ public class Avatar extends Container implements UserMod {
 			}
 		}
 	}
-
+	
 	/**
 	 * Checks for new Mail and sends a MAILARRIVED$ notification to the Avatar if so.
 	 */


### PR DESCRIPTION
This really only applies to regions that contain underscores. But, it will now say "you live at HyperDr #830" instead of "you live at unknown."