### PR TITLE
Huge update!

### DIFF
--- a/db/.dbshell
+++ b/db/.dbshell
@@ -1,0 +1,2 @@
+db.odb.remove({});
+db.odb.remove({});

--- a/db/Dnalsi/dnalsi_02.json
+++ b/db/Dnalsi/dnalsi_02.json
@@ -1,0 +1,198 @@
+[
+  {
+    "ref": "context-dnalsi_02", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_03", 
+          "context-dnalsi_12", 
+          "", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.ff39.dnalsi_02", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_02"
+  }, 
+  {
+    "ref": "item-Wall.f540.dnalsi_02", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_02"
+  }, 
+  {
+    "ref": "item-Trapezoid.d217.dnalsi_02", 
+    "mods": [
+      {
+        "lower_right_x": 1, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 246, 
+        "trapezoid_type": 0, 
+        "y": 56, 
+        "x": 32, 
+        "height": 18, 
+        "type": "Trapezoid", 
+        "orientation": 156
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_02"
+  }, 
+  {
+    "ref": "item-Trapezoid.23a9.dnalsi_02", 
+    "mods": [
+      {
+        "lower_right_x": 19, 
+        "upper_left_x": 254, 
+        "upper_right_x": 24, 
+        "lower_left_x": 6, 
+        "trapezoid_type": 0, 
+        "y": 48, 
+        "x": 16, 
+        "height": 8, 
+        "type": "Trapezoid", 
+        "orientation": 204
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_02"
+  }, 
+  {
+    "ref": "item-Tree.e66d.dnalsi_02", 
+    "mods": [
+      {
+        "y": 133, 
+        "x": 12, 
+        "style": 7, 
+        "type": "Tree", 
+        "orientation": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_02"
+  }, 
+  {
+    "ref": "item-Tree.9f9e.dnalsi_02", 
+    "mods": [
+      {
+        "y": 142, 
+        "x": 20, 
+        "style": 7, 
+        "type": "Tree", 
+        "orientation": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_02"
+  }, 
+  {
+    "ref": "item-Tree.0e36.dnalsi_02", 
+    "mods": [
+      {
+        "y": 151, 
+        "x": 28, 
+        "style": 7, 
+        "type": "Tree", 
+        "orientation": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_02"
+  }, 
+  {
+    "ref": "item-Flat.7722.dnalsi_02", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 24, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_02"
+  }, 
+  {
+    "ref": "item-Bottle.4213.dnalsi_02", 
+    "mods": [
+      {
+        "y": 150, 
+        "x": 88, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "context-dnalsi_02"
+  }, 
+  {
+    "ref": "item-Bottle.b1b4.dnalsi_02", 
+    "mods": [
+      {
+        "y": 144, 
+        "x": 104, 
+        "type": "Bottle", 
+        "orientation": 1, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "context-dnalsi_02"
+  }, 
+  {
+    "ref": "item-Ground.699b.dnalsi_02", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 24, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_02"
+  }
+]

--- a/db/Dnalsi/dnalsi_03.json
+++ b/db/Dnalsi/dnalsi_03.json
@@ -1,0 +1,156 @@
+[
+  {
+    "ref": "context-dnalsi_03", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_04", 
+          "", 
+          "context-dnalsi_02", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.c738.dnalsi_03", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_03"
+  }, 
+  {
+    "ref": "item-Wall.cc61.dnalsi_03", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_03"
+  }, 
+  {
+    "ref": "item-Tree.f8c3.dnalsi_03", 
+    "mods": [
+      {
+        "y": 22, 
+        "x": 28, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 237
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_03"
+  }, 
+  {
+    "ref": "item-Pond.3e63.dnalsi_03", 
+    "mods": [
+      {
+        "y": 128, 
+        "x": 24, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_03"
+  }, 
+  {
+    "ref": "item-Pond.9235.dnalsi_03", 
+    "mods": [
+      {
+        "y": 128, 
+        "x": 48, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_03"
+  }, 
+  {
+    "ref": "item-Tree.3da2.dnalsi_03", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 88, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_03"
+  }, 
+  {
+    "ref": "item-Tree.b5e7.dnalsi_03", 
+    "mods": [
+      {
+        "y": 21, 
+        "x": 112, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_03"
+  }, 
+  {
+    "ref": "item-Ground.670c.dnalsi_03", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_03"
+  }, 
+  {
+    "ref": "item-Pond.0a77.dnalsi_03", 
+    "mods": [
+      {
+        "y": 11, 
+        "x": 40, 
+        "type": "Pond", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_03"
+  }
+]

--- a/db/Dnalsi/dnalsi_04.json
+++ b/db/Dnalsi/dnalsi_04.json
@@ -1,0 +1,191 @@
+[
+  {
+    "ref": "context-dnalsi_04", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_05", 
+          "", 
+          "context-dnalsi_03", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.f955.dnalsi_04", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_04"
+  }, 
+  {
+    "ref": "item-Wall.d04e.dnalsi_04", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_04"
+  }, 
+  {
+    "ref": "item-Tree.9d4a.dnalsi_04", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 237, 
+        "gr_state": 1, 
+        "y": 29, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_04"
+  }, 
+  {
+    "ref": "item-Tree.4d68.dnalsi_04", 
+    "mods": [
+      {
+        "y": 128, 
+        "x": 112, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_04"
+  }, 
+  {
+    "ref": "item-Tree.0e05.dnalsi_04", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 189, 
+        "gr_state": 3, 
+        "y": 73, 
+        "x": 44, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_04"
+  }, 
+  {
+    "ref": "item-Tree.7cc9.dnalsi_04", 
+    "mods": [
+      {
+        "y": 23, 
+        "x": 104, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_04"
+  }, 
+  {
+    "ref": "item-Ground.4190.dnalsi_04", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_04"
+  }, 
+  {
+    "ref": "item-Bottle.635b.dnalsi_04", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 24, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "context-dnalsi_04"
+  }, 
+  {
+    "ref": "item-Bush.9f69.dnalsi_04", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_04"
+  }, 
+  {
+    "ref": "item-Bush.1386.dnalsi_04", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 17, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_04"
+  }, 
+  {
+    "ref": "item-Bush.3631.dnalsi_04", 
+    "mods": [
+      {
+        "y": 17, 
+        "x": 48, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_04"
+  }
+]

--- a/db/Dnalsi/dnalsi_05.json
+++ b/db/Dnalsi/dnalsi_05.json
@@ -1,0 +1,155 @@
+[
+  {
+    "ref": "context-dnalsi_05", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_15", 
+          "context-dnalsi_04", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.357e.dnalsi_05", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_05"
+  }, 
+  {
+    "ref": "item-Wall.bc21.dnalsi_05", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_05"
+  }, 
+  {
+    "ref": "item-Sign.42da.dnalsi_05", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 16, 
+        "ascii": [
+          128, 
+          68, 
+          110, 
+          97, 
+          108, 
+          115, 
+          105, 
+          134, 
+          134, 
+          32, 
+          80, 
+          111, 
+          105, 
+          110, 
+          116, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ], 
+        "y": 18, 
+        "x": 48, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-dnalsi_05"
+  }, 
+  {
+    "ref": "item-Rock.f6ff.dnalsi_05", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "mass": 1, 
+        "y": 131, 
+        "x": 44, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_05"
+  }, 
+  {
+    "ref": "item-Ground.3001.dnalsi_05", 
+    "mods": [
+      {
+        "y": 5, 
+        "x": 64, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_05"
+  }, 
+  {
+    "ref": "item-Ground.fa4b.dnalsi_05", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_05"
+  }
+]

--- a/db/Dnalsi/dnalsi_08.json
+++ b/db/Dnalsi/dnalsi_08.json
@@ -1,0 +1,151 @@
+[
+  {
+    "ref": "context-dnalsi_08", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_09", 
+          "context-dnalsi_18", 
+          "", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.75db.dnalsi_08", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 92, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_08"
+  }, 
+  {
+    "ref": "item-Wall.9b35.dnalsi_08", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 92, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_08"
+  }, 
+  {
+    "ref": "item-Knick_knack.2bf1.dnalsi_08", 
+    "mods": [
+      {
+        "style": 7, 
+        "orientation": 0, 
+        "y": 26, 
+        "x": 24, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "context-dnalsi_08"
+  }, 
+  {
+    "ref": "item-Knick_knack.9d3a.dnalsi_08", 
+    "mods": [
+      {
+        "style": 7, 
+        "orientation": 16, 
+        "y": 24, 
+        "x": 12, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "context-dnalsi_08"
+  }, 
+  {
+    "ref": "item-Flat.9e5d.dnalsi_08", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 188, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_08"
+  }, 
+  {
+    "ref": "item-Flat.ff35.dnalsi_08", 
+    "mods": [
+      {
+        "flat_type": 3, 
+        "style": 4, 
+        "orientation": 0, 
+        "y": 0, 
+        "x": 188, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_08"
+  }, 
+  {
+    "ref": "item-Trapezoid.41ea.dnalsi_08", 
+    "mods": [
+      {
+        "lower_right_x": 33, 
+        "orientation": 0, 
+        "gr_state": 2, 
+        "upper_right_x": 33, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 3, 
+        "y": 149, 
+        "x": 8, 
+        "height": 21, 
+        "type": "Trapezoid", 
+        "upper_left_x": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_08"
+  }, 
+  {
+    "ref": "item-Ground.7c63.dnalsi_08", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 92, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_08"
+  }
+]

--- a/db/Dnalsi/dnalsi_09.json
+++ b/db/Dnalsi/dnalsi_09.json
@@ -1,0 +1,146 @@
+[
+  {
+    "ref": "context-dnalsi_09", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_0a", 
+          "context-dnalsi_19", 
+          "context-dnalsi_08", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.376c.dnalsi_09", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_09"
+  }, 
+  {
+    "ref": "item-Wall.8f9d.dnalsi_09", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_09"
+  }, 
+  {
+    "ref": "item-Bush.024a.dnalsi_09", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 1, 
+        "y": 140, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_09"
+  }, 
+  {
+    "ref": "item-Bottle.97c6.dnalsi_09", 
+    "mods": [
+      {
+        "y": 140, 
+        "x": 68, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "context-dnalsi_09"
+  }, 
+  {
+    "ref": "item-Ground.6cfc.dnalsi_09", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_09"
+  }, 
+  {
+    "ref": "item-Bush.c21d.dnalsi_09", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 152, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_09"
+  }, 
+  {
+    "ref": "item-Bush.3fca.dnalsi_09", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 24, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_09"
+  }, 
+  {
+    "ref": "item-Bush.860f.dnalsi_09", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 1, 
+        "y": 130, 
+        "x": 68, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_09"
+  }
+]

--- a/db/Dnalsi/dnalsi_0a.json
+++ b/db/Dnalsi/dnalsi_0a.json
@@ -1,0 +1,159 @@
+[
+  {
+    "ref": "context-dnalsi_0a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_1a", 
+          "context-dnalsi_09", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.f765.dnalsi_0a", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_0a"
+  }, 
+  {
+    "ref": "item-Wall.c976.dnalsi_0a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_0a"
+  }, 
+  {
+    "ref": "item-Rock.1dd0.dnalsi_0a", 
+    "mods": [
+      {
+        "y": 148, 
+        "x": 92, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_0a"
+  }, 
+  {
+    "ref": "item-Rock.3784.dnalsi_0a", 
+    "mods": [
+      {
+        "y": 148, 
+        "x": 100, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_0a"
+  }, 
+  {
+    "ref": "item-Rock.37fc.dnalsi_0a", 
+    "mods": [
+      {
+        "y": 153, 
+        "x": 100, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 17
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_0a"
+  }, 
+  {
+    "ref": "item-Ground.a7b1.dnalsi_0a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_0a"
+  }, 
+  {
+    "ref": "item-Bush.bd37.dnalsi_0a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_0a"
+  }, 
+  {
+    "ref": "item-Bush.3498.dnalsi_0a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 17, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_0a"
+  }, 
+  {
+    "ref": "item-Bush.4e76.dnalsi_0a", 
+    "mods": [
+      {
+        "y": 17, 
+        "x": 48, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_0a"
+  }
+]

--- a/db/Dnalsi/dnalsi_11.json
+++ b/db/Dnalsi/dnalsi_11.json
@@ -1,0 +1,99 @@
+[
+  {
+    "ref": "context-dnalsi_11", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_12", 
+          "context-dnalsi_21", 
+          "", 
+          ""
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.a06c.dnalsi_11", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_11"
+  }, 
+  {
+    "ref": "item-Wall.666c.dnalsi_11", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_11"
+  }, 
+  {
+    "ref": "item-Ground.cc0d.dnalsi_11", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 192, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_11"
+  }, 
+  {
+    "ref": "item-Bush.960d.dnalsi_11", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 145, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_11"
+  }, 
+  {
+    "ref": "item-Bush.5258.dnalsi_11", 
+    "mods": [
+      {
+        "y": 17, 
+        "x": 64, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 9
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_11"
+  }
+]

--- a/db/Dnalsi/dnalsi_12.json
+++ b/db/Dnalsi/dnalsi_12.json
@@ -1,0 +1,189 @@
+[
+  {
+    "ref": "context-dnalsi_12", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-dnalsi_11", 
+          "context-dnalsi_02"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.d1b8.dnalsi_12", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 68, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_12"
+  }, 
+  {
+    "ref": "item-Wall.4204.dnalsi_12", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 68, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_12"
+  }, 
+  {
+    "ref": "item-Ground.9129.dnalsi_12", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_12"
+  }, 
+  {
+    "ref": "item-Tree.2117.dnalsi_12", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 105, 
+        "x": 100, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_12"
+  }, 
+  {
+    "ref": "item-Tree.dcc5.dnalsi_12", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 128, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_12"
+  }, 
+  {
+    "ref": "item-Tree.f721.dnalsi_12", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 84, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_12"
+  }, 
+  {
+    "ref": "item-Ground.2f40.dnalsi_12", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_12"
+  }, 
+  {
+    "ref": "item-Sky.4b07.dnalsi_12", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_12"
+  }, 
+  {
+    "ref": "item-Plant.6cc1.dnalsi_12", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 142, 
+        "x": 12, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_12"
+  }, 
+  {
+    "ref": "item-Tree.98a6.dnalsi_12", 
+    "mods": [
+      {
+        "y": 90, 
+        "x": 0, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 140
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_12"
+  }, 
+  {
+    "ref": "item-Bush.9574.dnalsi_12", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 31, 
+        "x": 60, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_12"
+  }
+]

--- a/db/Dnalsi/dnalsi_15.json
+++ b/db/Dnalsi/dnalsi_15.json
@@ -1,0 +1,243 @@
+[
+  {
+    "ref": "context-dnalsi_15", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_25", 
+          "", 
+          "context-dnalsi_05"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.f786.dnalsi_15", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Wall.1f95.dnalsi_15", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Plant.caf4.dnalsi_15", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 104, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Tree.7064.dnalsi_15", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 62, 
+        "x": 36, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Tree.42c5.dnalsi_15", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 139, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Tree.1e87.dnalsi_15", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Plant.54a7.dnalsi_15", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 52, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Ground.bbff.dnalsi_15", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Tree.a1ab.dnalsi_15", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 71, 
+        "x": 96, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Tree.d2a6.dnalsi_15", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 89, 
+        "x": 92, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Tree.fee1.dnalsi_15", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 106, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Tree.039c.dnalsi_15", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 3, 
+        "y": 120, 
+        "x": 76, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Plant.466c.dnalsi_15", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 25, 
+        "x": 124, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_15"
+  }, 
+  {
+    "ref": "item-Plant.17cc.dnalsi_15", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 48, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 24, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_15"
+  }
+]

--- a/db/Dnalsi/dnalsi_18.json
+++ b/db/Dnalsi/dnalsi_18.json
@@ -1,0 +1,145 @@
+[
+  {
+    "ref": "context-dnalsi_18", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_19", 
+          "context-dnalsi_28", 
+          "", 
+          "context-dnalsi_08"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.049a.dnalsi_18", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_18"
+  }, 
+  {
+    "ref": "item-Wall.c164.dnalsi_18", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_18"
+  }, 
+  {
+    "ref": "item-Tree.d7be.dnalsi_18", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "gr_state": 2, 
+        "y": 205, 
+        "x": 120, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_18"
+  }, 
+  {
+    "ref": "item-Tree.ca55.dnalsi_18", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 48, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_18"
+  }, 
+  {
+    "ref": "item-Tree.0ff3.dnalsi_18", 
+    "mods": [
+      {
+        "y": 26, 
+        "x": 52, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_18"
+  }, 
+  {
+    "ref": "item-Tree.1b51.dnalsi_18", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 1, 
+        "gr_state": 4, 
+        "y": 135, 
+        "x": 128, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_18"
+  }, 
+  {
+    "ref": "item-Tree.ed71.dnalsi_18", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 100, 
+        "x": 104, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_18"
+  }, 
+  {
+    "ref": "item-Ground.d722.dnalsi_18", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_18"
+  }
+]

--- a/db/Dnalsi/dnalsi_19.json
+++ b/db/Dnalsi/dnalsi_19.json
@@ -1,0 +1,179 @@
+[
+  {
+    "ref": "context-dnalsi_19", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_1a", 
+          "context-dnalsi_29", 
+          "context-dnalsi_18", 
+          "context-dnalsi_09"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.0492.dnalsi_19", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_19"
+  }, 
+  {
+    "ref": "item-Flat.d806.dnalsi_19", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 0, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_19"
+  }, 
+  {
+    "ref": "item-Bush.9a40.dnalsi_19", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 37, 
+        "x": 72, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_19"
+  }, 
+  {
+    "ref": "item-Bush.ac07.dnalsi_19", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 37, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_19"
+  }, 
+  {
+    "ref": "item-Bush.a5fc.dnalsi_19", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_19"
+  }, 
+  {
+    "ref": "item-Flat.8fe1.dnalsi_19", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 12, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_19"
+  }, 
+  {
+    "ref": "item-Rock.1d3f.dnalsi_19", 
+    "mods": [
+      {
+        "y": 148, 
+        "x": 108, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_19"
+  }, 
+  {
+    "ref": "item-Rock.19f9.dnalsi_19", 
+    "mods": [
+      {
+        "y": 149, 
+        "x": 96, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_19"
+  }, 
+  {
+    "ref": "item-Flat.bff1.dnalsi_19", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_19"
+  }, 
+  {
+    "ref": "item-Bush.3073.dnalsi_19", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 100, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_19"
+  }
+]

--- a/db/Dnalsi/dnalsi_1a.json
+++ b/db/Dnalsi/dnalsi_1a.json
@@ -1,0 +1,301 @@
+[
+  {
+    "ref": "context-dnalsi_1a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_1b", 
+          "context-dnalsi_2a", 
+          "context-dnalsi_19", 
+          "context-dnalsi_0a"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.fcd3.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 68, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Wall.8be3.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 68, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Flat.a0c8.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 164, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Rock.f373.dnalsi_1a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 148, 
+        "x": 64, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Tree.acb4.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 48, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Tree.5597.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 128, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Tree.d93f.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 92, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Ground.e9dd.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Sky.171a.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 164, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Rock.13d9.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 153, 
+        "x": 132, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Rock.e0ee.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Box.daba.dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Rock.d2fe.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 1, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Box.daba.dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Box.daba.dnalsi_1a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 0, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 1, 
+        "x": 1, 
+        "type": "Box", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Box", 
+    "in": "item-Hole.ca0d.dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Rock.c9ae.dnalsi_1a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.ca0d.dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Rock.286e.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 2, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.ca0d.dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Bottle.3b3a.dnalsi_1a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 4, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Hole.ca0d.dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Bottle.a7ef.dnalsi_1a", 
+    "mods": [
+      {
+        "orientation": 56, 
+        "gr_state": 1, 
+        "y": 3, 
+        "x": 3, 
+        "type": "Bottle", 
+        "filled": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Hole.ca0d.dnalsi_1a"
+  }, 
+  {
+    "ref": "item-Hole.ca0d.dnalsi_1a", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 149, 
+        "x": 112, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_1a"
+  }
+]

--- a/db/Dnalsi/dnalsi_1b.json
+++ b/db/Dnalsi/dnalsi_1b.json
@@ -1,0 +1,225 @@
+[
+  {
+    "ref": "context-dnalsi_1b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_1c", 
+          "context-dnalsi_2b", 
+          "context-dnalsi_1a", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.0a3b.dnalsi_1b", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Wall.ec92.dnalsi_1b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Tree.4e34.dnalsi_1b", 
+    "mods": [
+      {
+        "y": 26, 
+        "x": 28, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 237
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Tree.2ef5.dnalsi_1b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 72, 
+        "x": 36, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Tree.90c2.dnalsi_1b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 25, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Tree.6e08.dnalsi_1b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Tree.5f0d.dnalsi_1b", 
+    "mods": [
+      {
+        "y": 21, 
+        "x": 112, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Ground.aff0.dnalsi_1b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Tree.ff0e.dnalsi_1b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 71, 
+        "x": 96, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Tree.f050.dnalsi_1b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 89, 
+        "x": 92, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Tree.8fd7.dnalsi_1b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 106, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Tree.ff7b.dnalsi_1b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 3, 
+        "y": 120, 
+        "x": 76, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1b"
+  }, 
+  {
+    "ref": "item-Plant.68e6.dnalsi_1b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 124, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_1b"
+  }
+]

--- a/db/Dnalsi/dnalsi_1c.json
+++ b/db/Dnalsi/dnalsi_1c.json
@@ -1,0 +1,176 @@
+[
+  {
+    "ref": "context-dnalsi_1c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_1d", 
+          "context-dnalsi_2c", 
+          "context-dnalsi_1b", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.cc98.dnalsi_1c", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_1c"
+  }, 
+  {
+    "ref": "item-Wall.fca3.dnalsi_1c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_1c"
+  }, 
+  {
+    "ref": "item-Tree.dc1f.dnalsi_1c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 237, 
+        "gr_state": 1, 
+        "y": 22, 
+        "x": 32, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1c"
+  }, 
+  {
+    "ref": "item-Tree.4d9b.dnalsi_1c", 
+    "mods": [
+      {
+        "y": 129, 
+        "x": 64, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1c"
+  }, 
+  {
+    "ref": "item-Tree.8f8a.dnalsi_1c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 189, 
+        "gr_state": 3, 
+        "y": 73, 
+        "x": 28, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1c"
+  }, 
+  {
+    "ref": "item-Tree.9c7e.dnalsi_1c", 
+    "mods": [
+      {
+        "y": 23, 
+        "x": 104, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1c"
+  }, 
+  {
+    "ref": "item-Ground.b69a.dnalsi_1c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_1c"
+  }, 
+  {
+    "ref": "item-Bush.1394.dnalsi_1c", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_1c"
+  }, 
+  {
+    "ref": "item-Bush.d0a6.dnalsi_1c", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 17, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_1c"
+  }, 
+  {
+    "ref": "item-Bush.52e4.dnalsi_1c", 
+    "mods": [
+      {
+        "y": 17, 
+        "x": 48, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_1c"
+  }
+]

--- a/db/Dnalsi/dnalsi_1d.json
+++ b/db/Dnalsi/dnalsi_1d.json
@@ -1,0 +1,196 @@
+[
+  {
+    "ref": "context-dnalsi_1d", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-1152", 
+          "context-dnalsi_1c", 
+          "context-dnalsi_2d", 
+          ""
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.6581.dnalsi_1d", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 64, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_1d"
+  }, 
+  {
+    "ref": "item-Wall.e39d.dnalsi_1d", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 64, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_1d"
+  }, 
+  {
+    "ref": "item-Hole.2246.dnalsi_1d", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 143, 
+        "x": 128, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_1d"
+  }, 
+  {
+    "ref": "item-Hole.7a4e.dnalsi_1d", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 159, 
+        "x": 96, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_1d"
+  }, 
+  {
+    "ref": "item-Flat.4a5f.dnalsi_1d", 
+    "mods": [
+      {
+        "flat_type": 3, 
+        "style": 4, 
+        "orientation": 0, 
+        "y": 0, 
+        "x": 160, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_1d"
+  }, 
+  {
+    "ref": "item-Tree.6cae.dnalsi_1d", 
+    "mods": [
+      {
+        "y": 141, 
+        "x": 80, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 189
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1d"
+  }, 
+  {
+    "ref": "item-Tree.3e4a.dnalsi_1d", 
+    "mods": [
+      {
+        "y": 21, 
+        "x": 128, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_1d"
+  }, 
+  {
+    "ref": "item-Ground.f017.dnalsi_1d", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 64, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_1d"
+  }, 
+  {
+    "ref": "item-Flat.6cdd.dnalsi_1d", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 160, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_1d"
+  }, 
+  {
+    "ref": "item-Bush.3dee.dnalsi_1d", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 137, 
+        "x": 88, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_1d"
+  }, 
+  {
+    "ref": "item-Bush.6de4.dnalsi_1d", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 145, 
+        "x": 64, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_1d"
+  }
+]

--- a/db/Dnalsi/dnalsi_21.json
+++ b/db/Dnalsi/dnalsi_21.json
@@ -1,0 +1,365 @@
+[
+  {
+    "ref": "context-dnalsi_21", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave1_0a", 
+          "context-dnalsi_31", 
+          "", 
+          "context-dnalsi_11"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.121a.dnalsi_21", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Wall.123e.dnalsi_21", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Tree.05c4.dnalsi_21", 
+    "mods": [
+      {
+        "y": 92, 
+        "x": 0, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 140
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Tree.0afa.dnalsi_21", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 190, 
+        "x": 36, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Tree.b03f.dnalsi_21", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 139, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Tree.9463.dnalsi_21", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Tree.61b8.dnalsi_21", 
+    "mods": [
+      {
+        "y": 21, 
+        "x": 112, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Ground.453c.dnalsi_21", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Tree.587f.dnalsi_21", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 71, 
+        "x": 96, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Tree.60c1.dnalsi_21", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 89, 
+        "x": 92, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Tree.64a0.dnalsi_21", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 106, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Tree.ff52.dnalsi_21", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 3, 
+        "y": 120, 
+        "x": 76, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_21"
+  }, 
+  {
+    "ref": "item-Knick_knack.756e.dnalsi_21", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 72, 
+        "y": 2, 
+        "x": 2, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Hole.9c9d.dnalsi_21"
+  }, 
+  {
+    "ref": "item-Knick_knack.17b1.dnalsi_21", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 72, 
+        "y": 1, 
+        "x": 1, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Hole.9c9d.dnalsi_21"
+  }, 
+  {
+    "ref": "item-Knick_knack.5209.dnalsi_21", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 72, 
+        "y": 3, 
+        "x": 3, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Hole.9c9d.dnalsi_21"
+  }, 
+  {
+    "ref": "item-Knick_knack.b3c3.dnalsi_21", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 72, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Hole.9c9d.dnalsi_21"
+  }, 
+  {
+    "ref": "item-Shovel.64b3.dnalsi_21", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 4, 
+        "type": "Shovel", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Shovel", 
+    "in": "item-Hole.9c9d.dnalsi_21"
+  }, 
+  {
+    "ref": "item-Rock.5837.dnalsi_21", 
+    "mods": [
+      {
+        "y": 8, 
+        "x": 8, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.9c9d.dnalsi_21"
+  }, 
+  {
+    "ref": "item-Rock.cd65.dnalsi_21", 
+    "mods": [
+      {
+        "y": 7, 
+        "x": 7, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.9c9d.dnalsi_21"
+  }, 
+  {
+    "ref": "item-Rock.3b33.dnalsi_21", 
+    "mods": [
+      {
+        "y": 6, 
+        "x": 6, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 32
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.9c9d.dnalsi_21"
+  }, 
+  {
+    "ref": "item-Rock.9840.dnalsi_21", 
+    "mods": [
+      {
+        "y": 5, 
+        "x": 5, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 56
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.9c9d.dnalsi_21"
+  }, 
+  {
+    "ref": "item-Hole.9c9d.dnalsi_21", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 148, 
+        "x": 76, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_21"
+  }
+]

--- a/db/Dnalsi/dnalsi_25.json
+++ b/db/Dnalsi/dnalsi_25.json
@@ -1,0 +1,127 @@
+[
+  {
+    "ref": "context-dnalsi_25", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_26", 
+          "", 
+          "", 
+          "context-dnalsi_15"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.eb01.dnalsi_25", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_25"
+  }, 
+  {
+    "ref": "item-Wall.74e2.dnalsi_25", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_25"
+  }, 
+  {
+    "ref": "item-Ground.401e.dnalsi_25", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 68, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_25"
+  }, 
+  {
+    "ref": "item-Tree.8408.dnalsi_25", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 0, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_25"
+  }, 
+  {
+    "ref": "item-Tree.4e8a.dnalsi_25", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "gr_state": 1, 
+        "y": 135, 
+        "x": 112, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_25"
+  }, 
+  {
+    "ref": "item-Ground.dbea.dnalsi_25", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_25"
+  }, 
+  {
+    "ref": "item-Sky.914c.dnalsi_25", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 68, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_25"
+  }
+]

--- a/db/Dnalsi/dnalsi_26.json
+++ b/db/Dnalsi/dnalsi_26.json
@@ -1,0 +1,256 @@
+[
+  {
+    "ref": "context-dnalsi_26", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_36", 
+          "context-dnalsi_25", 
+          ""
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.e92c.dnalsi_26", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_26"
+  }, 
+  {
+    "ref": "item-Wall.6bfa.dnalsi_26", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 136, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_26"
+  }, 
+  {
+    "ref": "item-Hole.5ac7.dnalsi_26", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 148, 
+        "x": 64, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_26"
+  }, 
+  {
+    "ref": "item-Knick_knack.0eaf.dnalsi_26", 
+    "mods": [
+      {
+        "style": 7, 
+        "orientation": 17, 
+        "y": 24, 
+        "x": 8, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "context-dnalsi_26"
+  }, 
+  {
+    "ref": "item-Knick_knack.e7aa.dnalsi_26", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 96, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Hole.ce92.dnalsi_26"
+  }, 
+  {
+    "ref": "item-Hole.ce92.dnalsi_26", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 148, 
+        "x": 112, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_26"
+  }, 
+  {
+    "ref": "item-Bag.07d6.dnalsi_26", 
+    "mods": [
+      {
+        "orientation": 48, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Bag", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Bag", 
+    "in": "item-Box.8a4f.dnalsi_26"
+  }, 
+  {
+    "ref": "item-Box.8a4f.dnalsi_26", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 138, 
+        "x": 100, 
+        "type": "Box", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Box", 
+    "in": "context-dnalsi_26"
+  }, 
+  {
+    "ref": "item-Ground.4a6d.dnalsi_26", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 44, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_26"
+  }, 
+  {
+    "ref": "item-Plant.be5a.dnalsi_26", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 143, 
+        "x": 40, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_26"
+  }, 
+  {
+    "ref": "item-Plant.7cc4.dnalsi_26", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 128, 
+        "x": 36, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_26"
+  }, 
+  {
+    "ref": "item-Flat.476c.dnalsi_26", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 44, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_26"
+  }, 
+  {
+    "ref": "item-Flat.f13e.dnalsi_26", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_26"
+  }, 
+  {
+    "ref": "item-Trapezoid.8ffa.dnalsi_26", 
+    "mods": [
+      {
+        "lower_right_x": 23, 
+        "orientation": 0, 
+        "gr_state": 2, 
+        "upper_right_x": 23, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 3, 
+        "y": 148, 
+        "x": 0, 
+        "height": 21, 
+        "type": "Trapezoid", 
+        "upper_left_x": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_26"
+  }
+]

--- a/db/Dnalsi/dnalsi_28.json
+++ b/db/Dnalsi/dnalsi_28.json
@@ -1,0 +1,327 @@
+[
+  {
+    "ref": "context-dnalsi_28", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_29", 
+          "context-dnalsi_38", 
+          "", 
+          "context-dnalsi_18"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.8963.dnalsi_28", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Wall.c0cd.dnalsi_28", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Tree.c7c9.dnalsi_28", 
+    "mods": [
+      {
+        "y": 26, 
+        "x": 28, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 237
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Tree.1609.dnalsi_28", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 76, 
+        "x": 36, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Tree.410e.dnalsi_28", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 25, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Tree.5d99.dnalsi_28", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Tree.d898.dnalsi_28", 
+    "mods": [
+      {
+        "y": 21, 
+        "x": 112, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Ground.21e0.dnalsi_28", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Tree.863f.dnalsi_28", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 71, 
+        "x": 96, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Tree.6884.dnalsi_28", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 89, 
+        "x": 92, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Tree.ac6b.dnalsi_28", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 106, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Tree.2cef.dnalsi_28", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 3, 
+        "y": 120, 
+        "x": 76, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Plant.76f7.dnalsi_28", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 124, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Hole.2cec.dnalsi_28", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 146, 
+        "x": 76, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Hole.eb55.dnalsi_28", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 146, 
+        "x": 76, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_28"
+  }, 
+  {
+    "ref": "item-Knick_knack.a200.dnalsi_28", 
+    "mods": [
+      {
+        "style": 10, 
+        "orientation": 80, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Bag.43ab.dnalsi_28"
+  }, 
+  {
+    "ref": "item-Flashlight.6d95.dnalsi_28", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 1, 
+        "type": "Flashlight", 
+        "orientation": 8, 
+        "on": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flashlight", 
+    "in": "item-Bag.43ab.dnalsi_28"
+  }, 
+  {
+    "ref": "item-Bag.43ab.dnalsi_28", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Bag", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Bag", 
+    "in": "item-Hole.f586.dnalsi_28"
+  }, 
+  {
+    "ref": "item-Hole.f586.dnalsi_28", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 146, 
+        "x": 76, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_28"
+  }
+]

--- a/db/Dnalsi/dnalsi_29.json
+++ b/db/Dnalsi/dnalsi_29.json
@@ -1,0 +1,164 @@
+[
+  {
+    "ref": "context-dnalsi_29", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_2a", 
+          "context-dnalsi_39", 
+          "context-dnalsi_28", 
+          "context-dnalsi_19"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.6fcc.dnalsi_29", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_29"
+  }, 
+  {
+    "ref": "item-Flat.3d0e.dnalsi_29", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 0, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_29"
+  }, 
+  {
+    "ref": "item-Bush.e67d.dnalsi_29", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 9, 
+        "gr_state": 2, 
+        "y": 37, 
+        "x": 72, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_29"
+  }, 
+  {
+    "ref": "item-Bush.9aa7.dnalsi_29", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 12, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_29"
+  }, 
+  {
+    "ref": "item-Bush.25b1.dnalsi_29", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_29"
+  }, 
+  {
+    "ref": "item-Flat.ffd0.dnalsi_29", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 12, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_29"
+  }, 
+  {
+    "ref": "item-Flat.d556.dnalsi_29", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_29"
+  }, 
+  {
+    "ref": "item-Bush.0f41.dnalsi_29", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 100, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_29"
+  }, 
+  {
+    "ref": "item-Bush.e12b.dnalsi_29", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_29"
+  }
+]

--- a/db/Dnalsi/dnalsi_2a.json
+++ b/db/Dnalsi/dnalsi_2a.json
@@ -1,0 +1,220 @@
+[
+  {
+    "ref": "context-dnalsi_2a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_2b", 
+          "context-dnalsi_3a", 
+          "context-dnalsi_29", 
+          "context-dnalsi_1a"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.d731.dnalsi_2a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_2a"
+  }, 
+  {
+    "ref": "item-Flat.b178.dnalsi_2a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_2a"
+  }, 
+  {
+    "ref": "item-Bush.e944.dnalsi_2a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 25, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 64, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2a"
+  }, 
+  {
+    "ref": "item-Bush.a7db.dnalsi_2a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 56, 
+        "gr_state": 2, 
+        "y": 40, 
+        "x": 8, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2a"
+  }, 
+  {
+    "ref": "item-Bush.7d77.dnalsi_2a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2a"
+  }, 
+  {
+    "ref": "item-Teleport.9ef6.dnalsi_2a", 
+    "mods": [
+      {
+        "y": 136, 
+        "x": 104, 
+        "type": "Teleport", 
+        "orientation": 204, 
+        "address": "dnalsi"
+      }
+    ], 
+    "type": "item", 
+    "name": "Teleport", 
+    "in": "context-dnalsi_2a"
+  }, 
+  {
+    "ref": "item-Bush.7f76.dnalsi_2a", 
+    "mods": [
+      {
+        "y": 129, 
+        "x": 8, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 33
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2a"
+  }, 
+  {
+    "ref": "item-Sign.136a.dnalsi_2a", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 196, 
+        "ascii": [
+          136, 
+          133, 
+          87, 
+          69, 
+          76, 
+          67, 
+          79, 
+          77, 
+          69, 
+          134, 
+          32, 
+          32, 
+          84, 
+          79, 
+          134, 
+          68, 
+          133, 
+          39, 
+          133, 
+          110, 
+          97, 
+          108, 
+          115, 
+          105, 
+          134, 
+          73, 
+          115, 
+          108, 
+          97, 
+          110, 
+          100, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ], 
+        "y": 42, 
+        "x": 24, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-dnalsi_2a"
+  }, 
+  {
+    "ref": "item-Flat.b30b.dnalsi_2a", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_2a"
+  }, 
+  {
+    "ref": "item-Bush.d77e.dnalsi_2a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2a"
+  }
+]

--- a/db/Dnalsi/dnalsi_2b.json
+++ b/db/Dnalsi/dnalsi_2b.json
@@ -1,0 +1,162 @@
+[
+  {
+    "ref": "context-dnalsi_2b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_2c", 
+          "context-dnalsi_3b", 
+          "context-dnalsi_2a", 
+          "context-dnalsi_1b"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.bf0b.dnalsi_2b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_2b"
+  }, 
+  {
+    "ref": "item-Flat.c287.dnalsi_2b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_2b"
+  }, 
+  {
+    "ref": "item-Bush.b4ba.dnalsi_2b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 56, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2b"
+  }, 
+  {
+    "ref": "item-Bush.e209.dnalsi_2b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2b"
+  }, 
+  {
+    "ref": "item-Bush.043e.dnalsi_2b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2b"
+  }, 
+  {
+    "ref": "item-Rock.304d.dnalsi_2b", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 24, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_2b"
+  }, 
+  {
+    "ref": "item-Rock.f76a.dnalsi_2b", 
+    "mods": [
+      {
+        "y": 148, 
+        "x": 124, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_2b"
+  }, 
+  {
+    "ref": "item-Rock.6545.dnalsi_2b", 
+    "mods": [
+      {
+        "y": 149, 
+        "x": 132, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_2b"
+  }, 
+  {
+    "ref": "item-Flat.e872.dnalsi_2b", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_2b"
+  }
+]

--- a/db/Dnalsi/dnalsi_2c.json
+++ b/db/Dnalsi/dnalsi_2c.json
@@ -1,0 +1,163 @@
+[
+  {
+    "ref": "context-dnalsi_2c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_2d", 
+          "context-dnalsi_3c", 
+          "context-dnalsi_2b", 
+          "context-dnalsi_1c"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.5461.dnalsi_2c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_2c"
+  }, 
+  {
+    "ref": "item-Flat.6b7f.dnalsi_2c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_2c"
+  }, 
+  {
+    "ref": "item-Bush.800b.dnalsi_2c", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 9, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 72, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2c"
+  }, 
+  {
+    "ref": "item-Bush.f87e.dnalsi_2c", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2c"
+  }, 
+  {
+    "ref": "item-Bush.d47a.dnalsi_2c", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2c"
+  }, 
+  {
+    "ref": "item-Rock.409c.dnalsi_2c", 
+    "mods": [
+      {
+        "y": 148, 
+        "x": 108, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_2c"
+  }, 
+  {
+    "ref": "item-Rock.03bf.dnalsi_2c", 
+    "mods": [
+      {
+        "y": 149, 
+        "x": 96, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_2c"
+  }, 
+  {
+    "ref": "item-Flat.6f22.dnalsi_2c", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_2c"
+  }, 
+  {
+    "ref": "item-Bush.a728.dnalsi_2c", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 100, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2c"
+  }
+]

--- a/db/Dnalsi/dnalsi_2d.json
+++ b/db/Dnalsi/dnalsi_2d.json
@@ -1,0 +1,194 @@
+[
+  {
+    "ref": "context-dnalsi_2d", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_3d", 
+          "context-dnalsi_2c", 
+          "context-dnalsi_1d"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.25e6.dnalsi_2d", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_2d"
+  }, 
+  {
+    "ref": "item-Wall.e147.dnalsi_2d", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_2d"
+  }, 
+  {
+    "ref": "item-Tree.9a29.dnalsi_2d", 
+    "mods": [
+      {
+        "y": 132, 
+        "x": 28, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 237
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_2d"
+  }, 
+  {
+    "ref": "item-Tree.5526.dnalsi_2d", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 236, 
+        "gr_state": 3, 
+        "y": 67, 
+        "x": 36, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_2d"
+  }, 
+  {
+    "ref": "item-Tree.3f40.dnalsi_2d", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 21, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_2d"
+  }, 
+  {
+    "ref": "item-Tree.b68b.dnalsi_2d", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 80, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 189
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_2d"
+  }, 
+  {
+    "ref": "item-Tree.c4ce.dnalsi_2d", 
+    "mods": [
+      {
+        "y": 21, 
+        "x": 128, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_2d"
+  }, 
+  {
+    "ref": "item-Ground.712d.dnalsi_2d", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_2d"
+  }, 
+  {
+    "ref": "item-Hole.b455.dnalsi_2d", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 143, 
+        "x": 128, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_2d"
+  }, 
+  {
+    "ref": "item-Bush.1002.dnalsi_2d", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 137, 
+        "x": 88, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2d"
+  }, 
+  {
+    "ref": "item-Bush.9148.dnalsi_2d", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 135, 
+        "x": 64, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_2d"
+  }
+]

--- a/db/Dnalsi/dnalsi_30.json
+++ b/db/Dnalsi/dnalsi_30.json
@@ -1,0 +1,192 @@
+[
+  {
+    "ref": "context-dnalsi_30", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_31", 
+          "context-dnalsi_40", 
+          "", 
+          ""
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.8443.dnalsi_30", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_30"
+  }, 
+  {
+    "ref": "item-Wall.c5f4.dnalsi_30", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 168, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_30"
+  }, 
+  {
+    "ref": "item-Sign.e48f.dnalsi_30", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 188, 
+        "ascii": [
+          139, 
+          32, 
+          82, 
+          73, 
+          80, 
+          134, 
+          84, 
+          73, 
+          68, 
+          69, 
+          83, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ], 
+        "y": 26, 
+        "x": 56, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-dnalsi_30"
+  }, 
+  {
+    "ref": "item-Head.1628.dnalsi_30", 
+    "mods": [
+      {
+        "y": 30, 
+        "x": 100, 
+        "style": 38, 
+        "type": "Head", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Head", 
+    "in": "context-dnalsi_30"
+  }, 
+  {
+    "ref": "item-Trapezoid.448c.dnalsi_30", 
+    "mods": [
+      {
+        "lower_right_x": 66, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "upper_right_x": 66, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 3, 
+        "y": 156, 
+        "x": 96, 
+        "height": 37, 
+        "type": "Trapezoid", 
+        "upper_left_x": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_30"
+  }, 
+  {
+    "ref": "item-Head.1d04.dnalsi_30", 
+    "mods": [
+      {
+        "y": 34, 
+        "x": 136, 
+        "style": 38, 
+        "type": "Head", 
+        "orientation": 96
+      }
+    ], 
+    "type": "item", 
+    "name": "Head", 
+    "in": "context-dnalsi_30"
+  }, 
+  {
+    "ref": "item-Flat.cdee.dnalsi_30", 
+    "mods": [
+      {
+        "flat_type": 3, 
+        "style": 4, 
+        "orientation": 0, 
+        "y": 0, 
+        "x": 72, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_30"
+  }, 
+  {
+    "ref": "item-Ground.7d28.dnalsi_30", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 168, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_30"
+  }
+]

--- a/db/Dnalsi/dnalsi_31.json
+++ b/db/Dnalsi/dnalsi_31.json
@@ -1,0 +1,201 @@
+[
+  {
+    "ref": "context-dnalsi_31", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-dnalsi_30", 
+          "context-dnalsi_21"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.9700.dnalsi_31", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 68, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_31"
+  }, 
+  {
+    "ref": "item-Wall.c930.dnalsi_31", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 68, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_31"
+  }, 
+  {
+    "ref": "item-Ground.afc7.dnalsi_31", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_31"
+  }, 
+  {
+    "ref": "item-Hole.002d.dnalsi_31", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 148, 
+        "x": 24, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_31"
+  }, 
+  {
+    "ref": "item-Hole.142b.dnalsi_31", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 145, 
+        "x": 56, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_31"
+  }, 
+  {
+    "ref": "item-Tree.9919.dnalsi_31", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 128, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_31"
+  }, 
+  {
+    "ref": "item-Hole.2912.dnalsi_31", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 145, 
+        "x": 88, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_31"
+  }, 
+  {
+    "ref": "item-Ground.7404.dnalsi_31", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_31"
+  }, 
+  {
+    "ref": "item-Sky.ebdb.dnalsi_31", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_31"
+  }, 
+  {
+    "ref": "item-Hole.8c6d.dnalsi_31", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 145, 
+        "x": 124, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_31"
+  }, 
+  {
+    "ref": "item-Hole.0d74.dnalsi_31", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 162, 
+        "x": 32, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_31"
+  }
+]

--- a/db/Dnalsi/dnalsi_36.json
+++ b/db/Dnalsi/dnalsi_36.json
@@ -1,0 +1,237 @@
+[
+  {
+    "ref": "context-dnalsi_36", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_37", 
+          "", 
+          "context-dnalsi_cave3_2c", 
+          "context-dnalsi_26"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.dd72.dnalsi_36", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_36"
+  }, 
+  {
+    "ref": "item-Wall.01f1.dnalsi_36", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_36"
+  }, 
+  {
+    "ref": "item-Ground.1ed6.dnalsi_36", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 68, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_36"
+  }, 
+  {
+    "ref": "item-Rock.c1a2.dnalsi_36", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 148, 
+        "x": 64, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_36"
+  }, 
+  {
+    "ref": "item-Tree.612f.dnalsi_36", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 48, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_36"
+  }, 
+  {
+    "ref": "item-Tree.3434.dnalsi_36", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 128, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_36"
+  }, 
+  {
+    "ref": "item-Tree.9b48.dnalsi_36", 
+    "mods": [
+      {
+        "y": 136, 
+        "x": 92, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_36"
+  }, 
+  {
+    "ref": "item-Ground.09d3.dnalsi_36", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_36"
+  }, 
+  {
+    "ref": "item-Sky.2652.dnalsi_36", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 68, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_36"
+  }, 
+  {
+    "ref": "item-Rock.9c2b.dnalsi_36", 
+    "mods": [
+      {
+        "y": 3, 
+        "x": 3, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.0eac.dnalsi_36"
+  }, 
+  {
+    "ref": "item-Rock.4268.dnalsi_36", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 72, 
+        "mass": 1, 
+        "y": 1, 
+        "x": 1, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.0eac.dnalsi_36"
+  }, 
+  {
+    "ref": "item-Rock.5792.dnalsi_36", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.0eac.dnalsi_36"
+  }, 
+  {
+    "ref": "item-Rock.d78a.dnalsi_36", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 2, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.0eac.dnalsi_36"
+  }, 
+  {
+    "ref": "item-Hole.0eac.dnalsi_36", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 149, 
+        "x": 112, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_36"
+  }
+]

--- a/db/Dnalsi/dnalsi_37.json
+++ b/db/Dnalsi/dnalsi_37.json
@@ -1,0 +1,147 @@
+[
+  {
+    "ref": "context-dnalsi_37", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_38", 
+          "context-dnalsi_47", 
+          "context-dnalsi_36", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.b35c.dnalsi_37", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_37"
+  }, 
+  {
+    "ref": "item-Wall.c301.dnalsi_37", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_37"
+  }, 
+  {
+    "ref": "item-Tree.2e64.dnalsi_37", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 3, 
+        "y": 74, 
+        "x": 60, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_37"
+  }, 
+  {
+    "ref": "item-Tree.9f19.dnalsi_37", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 62, 
+        "x": 36, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_37"
+  }, 
+  {
+    "ref": "item-Tree.07cc.dnalsi_37", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 146, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_37"
+  }, 
+  {
+    "ref": "item-Tree.39d5.dnalsi_37", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 81, 
+        "x": 100, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_37"
+  }, 
+  {
+    "ref": "item-Tree.b1be.dnalsi_37", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 29, 
+        "x": 112, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_37"
+  }, 
+  {
+    "ref": "item-Ground.4ebb.dnalsi_37", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_37"
+  }
+]

--- a/db/Dnalsi/dnalsi_38.json
+++ b/db/Dnalsi/dnalsi_38.json
@@ -1,0 +1,174 @@
+[
+  {
+    "ref": "context-dnalsi_38", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_39", 
+          "context-dnalsi_48", 
+          "context-dnalsi_37", 
+          "context-dnalsi_28"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.eaea.dnalsi_38", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 68, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_38"
+  }, 
+  {
+    "ref": "item-Wall.df82.dnalsi_38", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 68, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_38"
+  }, 
+  {
+    "ref": "item-Ground.1007.dnalsi_38", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_38"
+  }, 
+  {
+    "ref": "item-Tree.d3c9.dnalsi_38", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 105, 
+        "x": 100, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_38"
+  }, 
+  {
+    "ref": "item-Plant.c4ac.dnalsi_38", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 24, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_38"
+  }, 
+  {
+    "ref": "item-Tree.7d23.dnalsi_38", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 128, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_38"
+  }, 
+  {
+    "ref": "item-Tree.1d67.dnalsi_38", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 44, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_38"
+  }, 
+  {
+    "ref": "item-Ground.d2e5.dnalsi_38", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_38"
+  }, 
+  {
+    "ref": "item-Sky.ed85.dnalsi_38", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_38"
+  }, 
+  {
+    "ref": "item-Plant.0a3e.dnalsi_38", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 142, 
+        "x": 12, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_38"
+  }
+]

--- a/db/Dnalsi/dnalsi_39.json
+++ b/db/Dnalsi/dnalsi_39.json
@@ -1,0 +1,226 @@
+[
+  {
+    "ref": "context-dnalsi_39", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_3a", 
+          "context-dnalsi_4a", 
+          "context-dnalsi_38", 
+          "context-dnalsi_2a"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.2b51.dnalsi_39", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_39"
+  }, 
+  {
+    "ref": "item-Flat.15df.dnalsi_39", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 0, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_39"
+  }, 
+  {
+    "ref": "item-Rock.2e74.dnalsi_39", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 132, 
+        "x": 32, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_39"
+  }, 
+  {
+    "ref": "item-Bush.45ea.dnalsi_39", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_39"
+  }, 
+  {
+    "ref": "item-Head.4fa9.dnalsi_39", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 44, 
+        "type": "Head", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Head", 
+    "in": "item-Bag.fb4e.dnalsi_39"
+  }, 
+  {
+    "ref": "item-Bag.fb4e.dnalsi_39", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Bag", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Bag", 
+    "in": "item-Hole.c9d5.dnalsi_39"
+  }, 
+  {
+    "ref": "item-Hole.c9d5.dnalsi_39", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 149, 
+        "x": 84, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_39"
+  }, 
+  {
+    "ref": "item-Flat.a9b9.dnalsi_39", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 12, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_39"
+  }, 
+  {
+    "ref": "item-Rock.85ac.dnalsi_39", 
+    "mods": [
+      {
+        "y": 149, 
+        "x": 88, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_39"
+  }, 
+  {
+    "ref": "item-Rock.a390.dnalsi_39", 
+    "mods": [
+      {
+        "y": 149, 
+        "x": 96, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_39"
+  }, 
+  {
+    "ref": "item-Flat.d2af.dnalsi_39", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_39"
+  }, 
+  {
+    "ref": "item-Rock.a926.dnalsi_39", 
+    "mods": [
+      {
+        "y": 154, 
+        "x": 92, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_39"
+  }, 
+  {
+    "ref": "item-Bush.0067.dnalsi_39", 
+    "mods": [
+      {
+        "y": 25, 
+        "x": 128, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 9
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_39"
+  }
+]

--- a/db/Dnalsi/dnalsi_3a.json
+++ b/db/Dnalsi/dnalsi_3a.json
@@ -1,0 +1,133 @@
+[
+  {
+    "ref": "context-dnalsi_3a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_3b", 
+          "context-dnalsi_4a", 
+          "context-dnalsi_39", 
+          "context-dnalsi_2a"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.da0b.dnalsi_3a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_3a"
+  }, 
+  {
+    "ref": "item-Flat.94ab.dnalsi_3a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_3a"
+  }, 
+  {
+    "ref": "item-Bush.8ace.dnalsi_3a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 25, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 72, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_3a"
+  }, 
+  {
+    "ref": "item-Bush.8012.dnalsi_3a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 8, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_3a"
+  }, 
+  {
+    "ref": "item-Bush.f120.dnalsi_3a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_3a"
+  }, 
+  {
+    "ref": "item-Flat.c7ce.dnalsi_3a", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_3a"
+  }, 
+  {
+    "ref": "item-Bush.25df.dnalsi_3a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_3a"
+  }
+]

--- a/db/Dnalsi/dnalsi_3b.json
+++ b/db/Dnalsi/dnalsi_3b.json
@@ -1,0 +1,163 @@
+[
+  {
+    "ref": "context-dnalsi_3b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_3c", 
+          "context-dnalsi_4b", 
+          "context-dnalsi_3a", 
+          "context-dnalsi_2b"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.9daf.dnalsi_3b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_3b"
+  }, 
+  {
+    "ref": "item-Flat.b15f.dnalsi_3b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_3b"
+  }, 
+  {
+    "ref": "item-Bush.cc15.dnalsi_3b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 25, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 72, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_3b"
+  }, 
+  {
+    "ref": "item-Bush.23d9.dnalsi_3b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 8, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_3b"
+  }, 
+  {
+    "ref": "item-Bush.ce4e.dnalsi_3b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_3b"
+  }, 
+  {
+    "ref": "item-Bush.9352.dnalsi_3b", 
+    "mods": [
+      {
+        "y": 133, 
+        "x": 92, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 24
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_3b"
+  }, 
+  {
+    "ref": "item-Bush.41bd.dnalsi_3b", 
+    "mods": [
+      {
+        "y": 129, 
+        "x": 8, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 33
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_3b"
+  }, 
+  {
+    "ref": "item-Flat.4bdc.dnalsi_3b", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_3b"
+  }, 
+  {
+    "ref": "item-Bush.1813.dnalsi_3b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_3b"
+  }
+]

--- a/db/Dnalsi/dnalsi_3c.json
+++ b/db/Dnalsi/dnalsi_3c.json
@@ -1,0 +1,157 @@
+[
+  {
+    "ref": "context-dnalsi_3c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_3d", 
+          "context-dnalsi_4c", 
+          "context-dnalsi_3b", 
+          "context-dnalsi_2c"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.f478.dnalsi_3c", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 68, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_3c"
+  }, 
+  {
+    "ref": "item-Wall.ba0e.dnalsi_3c", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 68, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_3c"
+  }, 
+  {
+    "ref": "item-Flat.efdb.dnalsi_3c", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 164, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_3c"
+  }, 
+  {
+    "ref": "item-Tree.c5a0.dnalsi_3c", 
+    "mods": [
+      {
+        "y": 26, 
+        "x": 80, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_3c"
+  }, 
+  {
+    "ref": "item-Tree.a66e.dnalsi_3c", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 48, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_3c"
+  }, 
+  {
+    "ref": "item-Tree.7bf6.dnalsi_3c", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 128, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_3c"
+  }, 
+  {
+    "ref": "item-Tree.e9f3.dnalsi_3c", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 92, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_3c"
+  }, 
+  {
+    "ref": "item-Ground.b70b.dnalsi_3c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_3c"
+  }, 
+  {
+    "ref": "item-Sky.40df.dnalsi_3c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_3c"
+  }
+]

--- a/db/Dnalsi/dnalsi_3d.json
+++ b/db/Dnalsi/dnalsi_3d.json
@@ -1,0 +1,144 @@
+[
+  {
+    "ref": "context-dnalsi_3d", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-dnalsi_3c", 
+          "context-dnalsi_2d"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.e0ec.dnalsi_3d", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_3d"
+  }, 
+  {
+    "ref": "item-Wall.0069.dnalsi_3d", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_3d"
+  }, 
+  {
+    "ref": "item-Tree.0c6e.dnalsi_3d", 
+    "mods": [
+      {
+        "y": 131, 
+        "x": 20, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 237
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_3d"
+  }, 
+  {
+    "ref": "item-Tree.6c9a.dnalsi_3d", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 74, 
+        "x": 36, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_3d"
+  }, 
+  {
+    "ref": "item-Tree.8bf9.dnalsi_3d", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_3d"
+  }, 
+  {
+    "ref": "item-Tree.6b5b.dnalsi_3d", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 88, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_3d"
+  }, 
+  {
+    "ref": "item-Tree.4862.dnalsi_3d", 
+    "mods": [
+      {
+        "y": 21, 
+        "x": 112, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_3d"
+  }, 
+  {
+    "ref": "item-Ground.afd5.dnalsi_3d", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_3d"
+  }
+]

--- a/db/Dnalsi/dnalsi_40.json
+++ b/db/Dnalsi/dnalsi_40.json
@@ -1,0 +1,131 @@
+[
+  {
+    "ref": "context-dnalsi_40", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_50", 
+          "", 
+          "context-dnalsi_30"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.6f47.dnalsi_40", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_40"
+  }, 
+  {
+    "ref": "item-Wall.2a8a.dnalsi_40", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_40"
+  }, 
+  {
+    "ref": "item-Tree.8407.dnalsi_40", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "gr_state": 3, 
+        "y": 152, 
+        "x": 44, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_40"
+  }, 
+  {
+    "ref": "item-Tree.6fdf.dnalsi_40", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 4, 
+        "y": 146, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_40"
+  }, 
+  {
+    "ref": "item-Tree.05b6.dnalsi_40", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 79, 
+        "x": 100, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_40"
+  }, 
+  {
+    "ref": "item-Tree.3b2b.dnalsi_40", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 112, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_40"
+  }, 
+  {
+    "ref": "item-Ground.a1a9.dnalsi_40", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_40"
+  }
+]

--- a/db/Dnalsi/dnalsi_47.json
+++ b/db/Dnalsi/dnalsi_47.json
@@ -1,0 +1,211 @@
+[
+  {
+    "ref": "context-dnalsi_47", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_48", 
+          "context-dnalsi_57", 
+          "", 
+          "context-dnalsi_37"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.e098.dnalsi_47", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_47"
+  }, 
+  {
+    "ref": "item-Flat.13df.dnalsi_47", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_47"
+  }, 
+  {
+    "ref": "item-Trapezoid.af37.dnalsi_47", 
+    "mods": [
+      {
+        "lower_right_x": 17, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 232, 
+        "trapezoid_type": 0, 
+        "y": 48, 
+        "x": 72, 
+        "height": 32, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_47"
+  }, 
+  {
+    "ref": "item-Trapezoid.2d5c.dnalsi_47", 
+    "mods": [
+      {
+        "lower_right_x": 14, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 247, 
+        "trapezoid_type": 0, 
+        "y": 48, 
+        "x": 24, 
+        "height": 16, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_47"
+  }, 
+  {
+    "ref": "item-Trapezoid.7845.dnalsi_47", 
+    "mods": [
+      {
+        "lower_right_x": 29, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 235, 
+        "trapezoid_type": 0, 
+        "y": 48, 
+        "x": 104, 
+        "height": 28, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_47"
+  }, 
+  {
+    "ref": "item-Trapezoid.175c.dnalsi_47", 
+    "mods": [
+      {
+        "lower_right_x": 8, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 238, 
+        "trapezoid_type": 0, 
+        "y": 48, 
+        "x": 48, 
+        "height": 24, 
+        "type": "Trapezoid", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_47"
+  }, 
+  {
+    "ref": "item-Bush.c0bf.dnalsi_47", 
+    "mods": [
+      {
+        "y": 129, 
+        "x": 16, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 49
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_47"
+  }, 
+  {
+    "ref": "item-Rock.d40c.dnalsi_47", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 108, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_47"
+  }, 
+  {
+    "ref": "item-Flat.8c6d.dnalsi_47", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_47"
+  }, 
+  {
+    "ref": "item-Bush.1fe5.dnalsi_47", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 136, 
+        "x": 108, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_47"
+  }, 
+  {
+    "ref": "item-Rock.b578.dnalsi_47", 
+    "mods": [
+      {
+        "y": 137, 
+        "x": 88, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_47"
+  }
+]

--- a/db/Dnalsi/dnalsi_48.json
+++ b/db/Dnalsi/dnalsi_48.json
@@ -1,0 +1,133 @@
+[
+  {
+    "ref": "context-dnalsi_48", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_49", 
+          "context-dnalsi_58", 
+          "context-dnalsi_47", 
+          "context-dnalsi_38"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.0b62.dnalsi_48", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_48"
+  }, 
+  {
+    "ref": "item-Flat.ac47.dnalsi_48", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_48"
+  }, 
+  {
+    "ref": "item-Bush.b168.dnalsi_48", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 9, 
+        "gr_state": 2, 
+        "y": 39, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_48"
+  }, 
+  {
+    "ref": "item-Flat.9047.dnalsi_48", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 12, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_48"
+  }, 
+  {
+    "ref": "item-Flat.6a06.dnalsi_48", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_48"
+  }, 
+  {
+    "ref": "item-Bush.aea0.dnalsi_48", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 9, 
+        "gr_state": 2, 
+        "y": 133, 
+        "x": 48, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_48"
+  }, 
+  {
+    "ref": "item-Bush.3289.dnalsi_48", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_48"
+  }
+]

--- a/db/Dnalsi/dnalsi_49.json
+++ b/db/Dnalsi/dnalsi_49.json
@@ -1,0 +1,148 @@
+[
+  {
+    "ref": "context-dnalsi_49", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_4a", 
+          "context-dnalsi_59", 
+          "context-dnalsi_48", 
+          "context-dnalsi_39"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.dece.dnalsi_49", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_49"
+  }, 
+  {
+    "ref": "item-Flat.d911.dnalsi_49", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_49"
+  }, 
+  {
+    "ref": "item-Bush.1ea9.dnalsi_49", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 9, 
+        "gr_state": 2, 
+        "y": 39, 
+        "x": 80, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_49"
+  }, 
+  {
+    "ref": "item-Bottle.0742.dnalsi_49", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 84, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "context-dnalsi_49"
+  }, 
+  {
+    "ref": "item-Flat.a46c.dnalsi_49", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 12, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_49"
+  }, 
+  {
+    "ref": "item-Flat.e822.dnalsi_49", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_49"
+  }, 
+  {
+    "ref": "item-Bush.cdd1.dnalsi_49", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 25, 
+        "gr_state": 2, 
+        "y": 133, 
+        "x": 36, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_49"
+  }, 
+  {
+    "ref": "item-Bush.7d10.dnalsi_49", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 56, 
+        "gr_state": 2, 
+        "y": 152, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_49"
+  }
+]

--- a/db/Dnalsi/dnalsi_4a.json
+++ b/db/Dnalsi/dnalsi_4a.json
@@ -1,0 +1,261 @@
+[
+  {
+    "ref": "context-dnalsi_4a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_4b", 
+          "context-dnalsi_5a", 
+          "context-dnalsi_49", 
+          "context-dnalsi_3a"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.084b.dnalsi_4a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Flat.4b06.dnalsi_4a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Bush.ff38.dnalsi_4a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 25, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 72, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Book.156c.dnalsi_4a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "last_page": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Book"
+      }
+    ], 
+    "type": "item", 
+    "name": "Book", 
+    "in": "item-Vendo_front.ca00.dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Book.a9b9.dnalsi_4a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "last_page": 0, 
+        "y": 1, 
+        "x": 1, 
+        "type": "Book"
+      }
+    ], 
+    "type": "item", 
+    "name": "Book", 
+    "in": "item-Vendo_front.ca00.dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Vendo_front.ca00.dnalsi_4a", 
+    "mods": [
+      {
+        "display_item": 3, 
+        "style": 1, 
+        "orientation": 0, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Vendo_front", 
+        "open_flags": 3, 
+        "item_price": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Vendo_front", 
+    "in": "item-Vendo_inside.c74b.dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Book.c330.dnalsi_4a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "last_page": 0, 
+        "y": 1, 
+        "x": 1, 
+        "type": "Book"
+      }
+    ], 
+    "type": "item", 
+    "name": "Book", 
+    "in": "item-Vendo_inside.c74b.dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Vendo_inside.c74b.dnalsi_4a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 236, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 3, 
+        "y": 27, 
+        "x": 12, 
+        "type": "Vendo_inside", 
+        "open_flags": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Vendo_inside", 
+    "in": "context-dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Bush.3e5a.dnalsi_4a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 88, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Flat.3756.dnalsi_4a", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Bush.b1de.dnalsi_4a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Dropbox.180e.dnalsi_4a", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 124, 
+        "type": "Dropbox", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Dropbox", 
+    "in": "context-dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Rock.c47e.dnalsi_4a", 
+    "mods": [
+      {
+        "y": 137, 
+        "x": 88, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_4a"
+  }, 
+  {
+    "ref": "item-Short_sign.161a.dnalsi_4a", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 16, 
+        "ascii": [
+          80, 
+          79, 
+          83, 
+          84, 
+          67, 
+          65, 
+          82, 
+          68, 
+          32, 
+          32
+        ], 
+        "gr_state": 9, 
+        "y": 81, 
+        "x": 4, 
+        "type": "Short_sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Short_sign", 
+    "in": "context-dnalsi_4a"
+  }
+]

--- a/db/Dnalsi/dnalsi_4b.json
+++ b/db/Dnalsi/dnalsi_4b.json
@@ -1,0 +1,148 @@
+[
+  {
+    "ref": "context-dnalsi_4b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_4c", 
+          "context-dnalsi_5b", 
+          "context-dnalsi_4a", 
+          "context-dnalsi_3b"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.e703.dnalsi_4b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_4b"
+  }, 
+  {
+    "ref": "item-Flat.ccba.dnalsi_4b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_4b"
+  }, 
+  {
+    "ref": "item-Bush.27fa.dnalsi_4b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 9, 
+        "gr_state": 2, 
+        "y": 39, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_4b"
+  }, 
+  {
+    "ref": "item-Bush.57ae.dnalsi_4b", 
+    "mods": [
+      {
+        "y": 137, 
+        "x": 12, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_4b"
+  }, 
+  {
+    "ref": "item-Flat.de48.dnalsi_4b", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 12, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_4b"
+  }, 
+  {
+    "ref": "item-Flat.8a2d.dnalsi_4b", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_4b"
+  }, 
+  {
+    "ref": "item-Bush.b4f6.dnalsi_4b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 9, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 48, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_4b"
+  }, 
+  {
+    "ref": "item-Bush.3b54.dnalsi_4b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_4b"
+  }
+]

--- a/db/Dnalsi/dnalsi_4c.json
+++ b/db/Dnalsi/dnalsi_4c.json
@@ -1,0 +1,172 @@
+[
+  {
+    "ref": "context-dnalsi_4c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_5c", 
+          "context-dnalsi_4b", 
+          "context-dnalsi_3c"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.f5e0.dnalsi_4c", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_4c"
+  }, 
+  {
+    "ref": "item-Wall.9bd9.dnalsi_4c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_4c"
+  }, 
+  {
+    "ref": "item-Short_sign.e4fa.dnalsi_4c", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "type": "Short_sign", 
+        "gr_state": 1, 
+        "y": 0, 
+        "x": 0, 
+        "ascii": [
+          133, 
+          131, 
+          78, 
+          79, 
+          84, 
+          32, 
+          72, 
+          69, 
+          82, 
+          69
+        ]
+      }
+    ], 
+    "type": "item", 
+    "name": "Short_sign", 
+    "in": "item-Hole.798d.dnalsi_4c"
+  }, 
+  {
+    "ref": "item-Hole.798d.dnalsi_4c", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 156, 
+        "x": 60, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_4c"
+  }, 
+  {
+    "ref": "item-Tree.04be.dnalsi_4c", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 48, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_4c"
+  }, 
+  {
+    "ref": "item-Tree.9a35.dnalsi_4c", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 48, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_4c"
+  }, 
+  {
+    "ref": "item-Tree.5f71.dnalsi_4c", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 88, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_4c"
+  }, 
+  {
+    "ref": "item-Tree.5b9b.dnalsi_4c", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 92, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_4c"
+  }, 
+  {
+    "ref": "item-Ground.c623.dnalsi_4c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_4c"
+  }
+]

--- a/db/Dnalsi/dnalsi_50.json
+++ b/db/Dnalsi/dnalsi_50.json
@@ -1,0 +1,176 @@
+[
+  {
+    "ref": "context-dnalsi_50", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_60", 
+          "", 
+          "context-dnalsi_40"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.c033.dnalsi_50", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_50"
+  }, 
+  {
+    "ref": "item-Wall.e018.dnalsi_50", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_50"
+  }, 
+  {
+    "ref": "item-Tree.0a86.dnalsi_50", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 237, 
+        "gr_state": 1, 
+        "y": 26, 
+        "x": 32, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_50"
+  }, 
+  {
+    "ref": "item-Tree.06ba.dnalsi_50", 
+    "mods": [
+      {
+        "y": 130, 
+        "x": 92, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 196
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_50"
+  }, 
+  {
+    "ref": "item-Tree.731f.dnalsi_50", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 189, 
+        "gr_state": 3, 
+        "y": 79, 
+        "x": 28, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_50"
+  }, 
+  {
+    "ref": "item-Tree.4649.dnalsi_50", 
+    "mods": [
+      {
+        "y": 23, 
+        "x": 104, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 197
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_50"
+  }, 
+  {
+    "ref": "item-Ground.6f13.dnalsi_50", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_50"
+  }, 
+  {
+    "ref": "item-Bush.b760.dnalsi_50", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_50"
+  }, 
+  {
+    "ref": "item-Bush.0aee.dnalsi_50", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 17, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_50"
+  }, 
+  {
+    "ref": "item-Bush.5820.dnalsi_50", 
+    "mods": [
+      {
+        "y": 17, 
+        "x": 48, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_50"
+  }
+]

--- a/db/Dnalsi/dnalsi_57.json
+++ b/db/Dnalsi/dnalsi_57.json
@@ -1,0 +1,207 @@
+[
+  {
+    "ref": "context-dnalsi_57", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_58", 
+          "context-dnalsi_67", 
+          "", 
+          "context-dnalsi_47"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.5a0b.dnalsi_57", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_57"
+  }, 
+  {
+    "ref": "item-Flat.9ea1.dnalsi_57", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_57"
+  }, 
+  {
+    "ref": "item-Trapezoid.3ca5.dnalsi_57", 
+    "mods": [
+      {
+        "lower_right_x": 28, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 245, 
+        "trapezoid_type": 0, 
+        "y": 48, 
+        "x": 48, 
+        "height": 19, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_57"
+  }, 
+  {
+    "ref": "item-Bush.d022.dnalsi_57", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 12, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_57"
+  }, 
+  {
+    "ref": "item-Trapezoid.e0d7.dnalsi_57", 
+    "mods": [
+      {
+        "lower_right_x": 27, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 232, 
+        "trapezoid_type": 0, 
+        "y": 48, 
+        "x": 92, 
+        "height": 28, 
+        "type": "Trapezoid", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_57"
+  }, 
+  {
+    "ref": "item-Flat.22ea.dnalsi_57", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 12, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_57"
+  }, 
+  {
+    "ref": "item-Trapezoid.eaec.dnalsi_57", 
+    "mods": [
+      {
+        "lower_right_x": 38, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 231, 
+        "trapezoid_type": 0, 
+        "y": 48, 
+        "x": 136, 
+        "height": 21, 
+        "type": "Trapezoid", 
+        "orientation": 204
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_57"
+  }, 
+  {
+    "ref": "item-Tree.646a.dnalsi_57", 
+    "mods": [
+      {
+        "y": 90, 
+        "x": 24, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 252
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_57"
+  }, 
+  {
+    "ref": "item-Flat.5332.dnalsi_57", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_57"
+  }, 
+  {
+    "ref": "item-Bush.b2bd.dnalsi_57", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 100, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_57"
+  }, 
+  {
+    "ref": "item-Bush.744f.dnalsi_57", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_57"
+  }
+]

--- a/db/Dnalsi/dnalsi_58.json
+++ b/db/Dnalsi/dnalsi_58.json
@@ -1,0 +1,268 @@
+[
+  {
+    "ref": "context-dnalsi_58", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_59", 
+          "context-dnalsi_68", 
+          "context-dnalsi_57", 
+          "context-dnalsi_48"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.6d4f.dnalsi_58", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_58"
+  }, 
+  {
+    "ref": "item-Flat.01c9.dnalsi_58", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_58"
+  }, 
+  {
+    "ref": "item-Bush.f7af.dnalsi_58", 
+    "mods": [
+      {
+        "y": 38, 
+        "x": 48, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 25
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_58"
+  }, 
+  {
+    "ref": "item-Bush.209e.dnalsi_58", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 56, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 8, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_58"
+  }, 
+  {
+    "ref": "item-Countertop.f111.dnalsi_58", 
+    "mods": [
+      {
+        "orientation": 252, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 152, 
+        "x": 100, 
+        "type": "Countertop", 
+        "open_flags": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Countertop", 
+    "in": "context-dnalsi_58"
+  }, 
+  {
+    "ref": "item-Plant.1d70.dnalsi_58", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 44, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_58"
+  }, 
+  {
+    "ref": "item-Sign.7e4a.dnalsi_58", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 212, 
+        "ascii": [
+          133, 
+          73, 
+          115, 
+          108, 
+          97, 
+          110, 
+          100, 
+          134, 
+          128, 
+          66, 
+          111, 
+          98, 
+          39, 
+          115, 
+          134, 
+          32, 
+          99, 
+          111, 
+          108, 
+          100, 
+          134, 
+          100, 
+          114, 
+          105, 
+          110, 
+          107, 
+          115, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ], 
+        "y": 50, 
+        "x": 92, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-dnalsi_58"
+  }, 
+  {
+    "ref": "item-Bottle.aaa4.dnalsi_58", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "gr_state": 1, 
+        "y": 2, 
+        "x": 2, 
+        "type": "Bottle", 
+        "filled": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Countertop.eefd.dnalsi_58"
+  }, 
+  {
+    "ref": "item-Bottle.0910.dnalsi_58", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Countertop.eefd.dnalsi_58"
+  }, 
+  {
+    "ref": "item-Bottle.2497.dnalsi_58", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 1, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Countertop.eefd.dnalsi_58"
+  }, 
+  {
+    "ref": "item-Countertop.eefd.dnalsi_58", 
+    "mods": [
+      {
+        "orientation": 252, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 152, 
+        "x": 88, 
+        "type": "Countertop", 
+        "open_flags": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Countertop", 
+    "in": "context-dnalsi_58"
+  }, 
+  {
+    "ref": "item-Flat.b894.dnalsi_58", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_58"
+  }, 
+  {
+    "ref": "item-Bottle.c033.dnalsi_58", 
+    "mods": [
+      {
+        "y": 149, 
+        "x": 100, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "context-dnalsi_58"
+  }
+]

--- a/db/Dnalsi/dnalsi_59.json
+++ b/db/Dnalsi/dnalsi_59.json
@@ -1,0 +1,320 @@
+[
+  {
+    "ref": "context-dnalsi_59", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_5a", 
+          "context-dnalsi_69", 
+          "context-dnalsi_58", 
+          "context-dnalsi_49"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.7945.dnalsi_59", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_59"
+  }, 
+  {
+    "ref": "item-Flat.4237.dnalsi_59", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bush.29d4.dnalsi_59", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 9, 
+        "gr_state": 2, 
+        "y": 158, 
+        "x": 80, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bottle.225d.dnalsi_59", 
+    "mods": [
+      {
+        "y": 6, 
+        "x": 6, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Hole.b552.dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bottle.7b54.dnalsi_59", 
+    "mods": [
+      {
+        "y": 5, 
+        "x": 5, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Hole.b552.dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bottle.76d8.dnalsi_59", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 4, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Hole.b552.dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bottle.6f90.dnalsi_59", 
+    "mods": [
+      {
+        "y": 3, 
+        "x": 3, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Hole.b552.dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bottle.ac69.dnalsi_59", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 2, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Hole.b552.dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bottle.cf2f.dnalsi_59", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 1, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Hole.b552.dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bottle.6a8e.dnalsi_59", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "item-Hole.b552.dnalsi_59"
+  }, 
+  {
+    "ref": "item-Hole.b552.dnalsi_59", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 156, 
+        "x": 56, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_59"
+  }, 
+  {
+    "ref": "item-Flat.1e89.dnalsi_59", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 12, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_59"
+  }, 
+  {
+    "ref": "item-Flat.cbf6.dnalsi_59", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bush.04d2.dnalsi_59", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 25, 
+        "gr_state": 2, 
+        "y": 143, 
+        "x": 52, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bush.aa30.dnalsi_59", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 56, 
+        "gr_state": 2, 
+        "y": 42, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bush.3111.dnalsi_59", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 56, 
+        "gr_state": 2, 
+        "y": 44, 
+        "x": 104, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bush.72bb.dnalsi_59", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 56, 
+        "gr_state": 2, 
+        "y": 42, 
+        "x": 80, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bush.b7c3.dnalsi_59", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 57, 
+        "gr_state": 2, 
+        "y": 44, 
+        "x": 80, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_59"
+  }, 
+  {
+    "ref": "item-Bush.08e9.dnalsi_59", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 57, 
+        "gr_state": 2, 
+        "y": 44, 
+        "x": 44, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_59"
+  }
+]

--- a/db/Dnalsi/dnalsi_5a.json
+++ b/db/Dnalsi/dnalsi_5a.json
@@ -1,0 +1,189 @@
+[
+  {
+    "ref": "context-dnalsi_5a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_5b", 
+          "context-dnalsi_6a", 
+          "context-dnalsi_59", 
+          "context-dnalsi_4a"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.d18f.dnalsi_5a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_5a"
+  }, 
+  {
+    "ref": "item-Flat.b5c2.dnalsi_5a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_5a"
+  }, 
+  {
+    "ref": "item-Sign.3aff.dnalsi_5a", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 252, 
+        "ascii": [
+          128, 
+          76, 
+          79, 
+          83, 
+          84, 
+          63, 
+          63, 
+          134, 
+          84, 
+          45, 
+          66, 
+          111, 
+          111, 
+          116, 
+          104, 
+          32, 
+          134, 
+          51, 
+          128, 
+          83, 
+          113, 
+          32, 
+          85, 
+          112, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ], 
+        "y": 28, 
+        "x": 132, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-dnalsi_5a"
+  }, 
+  {
+    "ref": "item-Bush.72af.dnalsi_5a", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 12, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 56
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_5a"
+  }, 
+  {
+    "ref": "item-Flat.143f.dnalsi_5a", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 12, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_5a"
+  }, 
+  {
+    "ref": "item-Flat.e9df.dnalsi_5a", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_5a"
+  }, 
+  {
+    "ref": "item-Bush.486f.dnalsi_5a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 100, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_5a"
+  }, 
+  {
+    "ref": "item-Bush.83c0.dnalsi_5a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_5a"
+  }
+]

--- a/db/Dnalsi/dnalsi_5b.json
+++ b/db/Dnalsi/dnalsi_5b.json
@@ -1,0 +1,207 @@
+[
+  {
+    "ref": "context-dnalsi_5b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_5c", 
+          "context-dnalsi_6b", 
+          "context-dnalsi_5a", 
+          "context-dnalsi_4b"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.1169.dnalsi_5b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_5b"
+  }, 
+  {
+    "ref": "item-Flat.ce73.dnalsi_5b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_5b"
+  }, 
+  {
+    "ref": "item-Bush.61a1.dnalsi_5b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 25, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 72, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_5b"
+  }, 
+  {
+    "ref": "item-Bush.04df.dnalsi_5b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 56, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 8, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_5b"
+  }, 
+  {
+    "ref": "item-Bush.5711.dnalsi_5b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_5b"
+  }, 
+  {
+    "ref": "item-Pond.16c7.dnalsi_5b", 
+    "mods": [
+      {
+        "y": 16, 
+        "x": 40, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_5b"
+  }, 
+  {
+    "ref": "item-Pond.3f7d.dnalsi_5b", 
+    "mods": [
+      {
+        "y": 16, 
+        "x": 60, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_5b"
+  }, 
+  {
+    "ref": "item-Pond.9571.dnalsi_5b", 
+    "mods": [
+      {
+        "y": 26, 
+        "x": 52, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_5b"
+  }, 
+  {
+    "ref": "item-Flat.54cf.dnalsi_5b", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_5b"
+  }, 
+  {
+    "ref": "item-Bush.0726.dnalsi_5b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_5b"
+  }, 
+  {
+    "ref": "item-Pond.6f6b.dnalsi_5b", 
+    "mods": [
+      {
+        "y": 9, 
+        "x": 60, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_5b"
+  }, 
+  {
+    "ref": "item-Bridge.b67d.dnalsi_5b", 
+    "mods": [
+      {
+        "y": 146, 
+        "x": 32, 
+        "type": "Bridge", 
+        "orientation": 80
+      }
+    ], 
+    "type": "item", 
+    "name": "Bridge", 
+    "in": "context-dnalsi_5b"
+  }
+]

--- a/db/Dnalsi/dnalsi_5c.json
+++ b/db/Dnalsi/dnalsi_5c.json
@@ -1,0 +1,174 @@
+[
+  {
+    "ref": "context-dnalsi_5c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_6c", 
+          "context-dnalsi_5b", 
+          "context-dnalsi_4c"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.f726.dnalsi_5c", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_5c"
+  }, 
+  {
+    "ref": "item-Wall.c19e.dnalsi_5c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_5c"
+  }, 
+  {
+    "ref": "item-Tree.697a.dnalsi_5c", 
+    "mods": [
+      {
+        "y": 22, 
+        "x": 28, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 237
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_5c"
+  }, 
+  {
+    "ref": "item-Pond.cad7.dnalsi_5c", 
+    "mods": [
+      {
+        "y": 7, 
+        "x": 24, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_5c"
+  }, 
+  {
+    "ref": "item-Pond.eb17.dnalsi_5c", 
+    "mods": [
+      {
+        "y": 5, 
+        "x": 48, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_5c"
+  }, 
+  {
+    "ref": "item-Tree.e509.dnalsi_5c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 120, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_5c"
+  }, 
+  {
+    "ref": "item-Tree.65cb.dnalsi_5c", 
+    "mods": [
+      {
+        "y": 134, 
+        "x": 92, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_5c"
+  }, 
+  {
+    "ref": "item-Ground.f47c.dnalsi_5c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_5c"
+  }, 
+  {
+    "ref": "item-Pond.7ff9.dnalsi_5c", 
+    "mods": [
+      {
+        "y": 15, 
+        "x": 40, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_5c"
+  }, 
+  {
+    "ref": "item-Tree.8520.dnalsi_5c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 3, 
+        "y": 77, 
+        "x": 120, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_5c"
+  }
+]

--- a/db/Dnalsi/dnalsi_60.json
+++ b/db/Dnalsi/dnalsi_60.json
@@ -1,0 +1,322 @@
+[
+  {
+    "ref": "context-dnalsi_60", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_61", 
+          "", 
+          "", 
+          "context-dnalsi_50"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.e8f1.dnalsi_60", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_60"
+  }, 
+  {
+    "ref": "item-Wall.4629.dnalsi_60", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_60"
+  }, 
+  {
+    "ref": "item-Flat.ef26.dnalsi_60", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 52, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_60"
+  }, 
+  {
+    "ref": "item-Hole.d0c1.dnalsi_60", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 159, 
+        "x": 96, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_60"
+  }, 
+  {
+    "ref": "item-Tree.883b.dnalsi_60", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 1, 
+        "gr_state": 2, 
+        "y": 91, 
+        "x": 132, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_60"
+  }, 
+  {
+    "ref": "item-Tree.6be2.dnalsi_60", 
+    "mods": [
+      {
+        "y": 128, 
+        "x": 60, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_60"
+  }, 
+  {
+    "ref": "item-Tree.e955.dnalsi_60", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 1, 
+        "gr_state": 4, 
+        "y": 21, 
+        "x": 128, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_60"
+  }, 
+  {
+    "ref": "item-Flat.3d24.dnalsi_60", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 52, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_60"
+  }, 
+  {
+    "ref": "item-Tree.e0d5.dnalsi_60", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 17, 
+        "gr_state": 3, 
+        "y": 111, 
+        "x": 116, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_60"
+  }, 
+  {
+    "ref": "item-Bush.3774.dnalsi_60", 
+    "mods": [
+      {
+        "y": 137, 
+        "x": 56, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_60"
+  }, 
+  {
+    "ref": "item-Knick_knack.6225.dnalsi_60", 
+    "mods": [
+      {
+        "y": 3, 
+        "x": 3, 
+        "type": "Knick_knack", 
+        "orientation": 0, 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Box.6a0a.dnalsi_60"
+  }, 
+  {
+    "ref": "item-Knick_knack.224d.dnalsi_60", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "type": "Knick_knack", 
+        "orientation": 0, 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Box.6a0a.dnalsi_60"
+  }, 
+  {
+    "ref": "item-Knick_knack.795c.dnalsi_60", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "y": 2, 
+        "x": 2, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Box.6a0a.dnalsi_60"
+  }, 
+  {
+    "ref": "item-Knick_knack.3b94.dnalsi_60", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "y": 1, 
+        "x": 1, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Box.6a0a.dnalsi_60"
+  }, 
+  {
+    "ref": "item-Box.6a0a.dnalsi_60", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 80, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Box", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Box", 
+    "in": "item-Hole.6922.dnalsi_60"
+  }, 
+  {
+    "ref": "item-Plant.b9d5.dnalsi_60", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 2, 
+        "mass": 1, 
+        "type": "Plant", 
+        "orientation": 32
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "item-Hole.6922.dnalsi_60"
+  }, 
+  {
+    "ref": "item-Plant.dc95.dnalsi_60", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 1, 
+        "mass": 1, 
+        "type": "Plant", 
+        "orientation": 32
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "item-Hole.6922.dnalsi_60"
+  }, 
+  {
+    "ref": "item-Knife.b561.dnalsi_60", 
+    "mods": [
+      {
+        "y": 3, 
+        "x": 3, 
+        "type": "Knife", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knife", 
+    "in": "item-Hole.6922.dnalsi_60"
+  }, 
+  {
+    "ref": "item-Hole.6922.dnalsi_60", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 144, 
+        "x": 104, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_60"
+  }
+]

--- a/db/Dnalsi/dnalsi_61.json
+++ b/db/Dnalsi/dnalsi_61.json
@@ -1,0 +1,221 @@
+[
+  {
+    "ref": "context-dnalsi_61", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_62", 
+          "context-dnalsi_71", 
+          "context-dnalsi_60", 
+          ""
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.de29.dnalsi_61", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_61"
+  }, 
+  {
+    "ref": "item-Wall.d569.dnalsi_61", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_61"
+  }, 
+  {
+    "ref": "item-Ground.b056.dnalsi_61", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 68, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_61"
+  }, 
+  {
+    "ref": "item-Tree.6c9c.dnalsi_61", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 48, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_61"
+  }, 
+  {
+    "ref": "item-Tree.4836.dnalsi_61", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 128, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_61"
+  }, 
+  {
+    "ref": "item-Tree.1622.dnalsi_61", 
+    "mods": [
+      {
+        "y": 136, 
+        "x": 92, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_61"
+  }, 
+  {
+    "ref": "item-Ground.a078.dnalsi_61", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_61"
+  }, 
+  {
+    "ref": "item-Sky.0fc1.dnalsi_61", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 68, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_61"
+  }, 
+  {
+    "ref": "item-Key.6bc5.dnalsi_61", 
+    "mods": [
+      {
+        "key_number_lo": 255, 
+        "orientation": 0, 
+        "key_number_hi": 255, 
+        "y": 1, 
+        "x": 1, 
+        "type": "Key"
+      }
+    ], 
+    "type": "item", 
+    "name": "Key", 
+    "in": "item-Hole.bb8a.dnalsi_61"
+  }, 
+  {
+    "ref": "item-Rock.2664.dnalsi_61", 
+    "mods": [
+      {
+        "y": 3, 
+        "x": 3, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.bb8a.dnalsi_61"
+  }, 
+  {
+    "ref": "item-Rock.c2cc.dnalsi_61", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.bb8a.dnalsi_61"
+  }, 
+  {
+    "ref": "item-Rock.e2b6.dnalsi_61", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 2, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.bb8a.dnalsi_61"
+  }, 
+  {
+    "ref": "item-Hole.bb8a.dnalsi_61", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 149, 
+        "x": 40, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_61"
+  }
+]

--- a/db/Dnalsi/dnalsi_62.json
+++ b/db/Dnalsi/dnalsi_62.json
@@ -1,0 +1,242 @@
+[
+  {
+    "ref": "context-dnalsi_62", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_63", 
+          "context-dnalsi_72", 
+          "context-dnalsi_61", 
+          "context-dnalsi_cave2_2c"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.edfe.dnalsi_62", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Flat.52e4.dnalsi_62", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Sky.d70f.dnalsi_62", 
+    "mods": [
+      {
+        "y": 48, 
+        "x": 44, 
+        "style": 8, 
+        "type": "Sky", 
+        "orientation": 204
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Trapezoid.bdc7.dnalsi_62", 
+    "mods": [
+      {
+        "lower_right_x": 12, 
+        "upper_left_x": 249, 
+        "upper_right_x": 250, 
+        "lower_left_x": 239, 
+        "trapezoid_type": 0, 
+        "y": 48, 
+        "x": 104, 
+        "height": 23, 
+        "type": "Trapezoid", 
+        "orientation": 204
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Sky.7c67.dnalsi_62", 
+    "mods": [
+      {
+        "y": 48, 
+        "x": 44, 
+        "style": 8, 
+        "type": "Sky", 
+        "orientation": 205
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Plant.31cf.dnalsi_62", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 44, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Bush.4a43.dnalsi_62", 
+    "mods": [
+      {
+        "y": 129, 
+        "x": 8, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 33
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Plant.7643.dnalsi_62", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 49, 
+        "mass": 1, 
+        "y": 142, 
+        "x": 112, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Flat.6170.dnalsi_62", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Bush.e45a.dnalsi_62", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 162, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Trapezoid.92a6.dnalsi_62", 
+    "mods": [
+      {
+        "lower_right_x": 17, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 244, 
+        "trapezoid_type": 0, 
+        "y": 48, 
+        "x": 128, 
+        "height": 23, 
+        "type": "Trapezoid", 
+        "orientation": 204
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Trapezoid.372d.dnalsi_62", 
+    "mods": [
+      {
+        "lower_right_x": 8, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 242, 
+        "trapezoid_type": 0, 
+        "y": 48, 
+        "x": 48, 
+        "height": 18, 
+        "type": "Trapezoid", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_62"
+  }, 
+  {
+    "ref": "item-Trapezoid.3a2e.dnalsi_62", 
+    "mods": [
+      {
+        "lower_right_x": 3, 
+        "upper_left_x": 1, 
+        "upper_right_x": 2, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 189, 
+        "x": 64, 
+        "height": 6, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_62"
+  }
+]

--- a/db/Dnalsi/dnalsi_63.json
+++ b/db/Dnalsi/dnalsi_63.json
@@ -1,0 +1,158 @@
+[
+  {
+    "ref": "context-dnalsi_63", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_64", 
+          "context-dnalsi_73", 
+          "context-dnalsi_62", 
+          ""
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.2b0f.dnalsi_63", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_63"
+  }, 
+  {
+    "ref": "item-Wall.2382.dnalsi_63", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_63"
+  }, 
+  {
+    "ref": "item-Ground.042f.dnalsi_63", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 84, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_63"
+  }, 
+  {
+    "ref": "item-Tree.eb9c.dnalsi_63", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 72, 
+        "gr_state": 1, 
+        "y": 28, 
+        "x": 44, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_63"
+  }, 
+  {
+    "ref": "item-Tree.ab01.dnalsi_63", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 0, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 72
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_63"
+  }, 
+  {
+    "ref": "item-Tree.1ef7.dnalsi_63", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 112, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 64
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_63"
+  }, 
+  {
+    "ref": "item-Tree.babc.dnalsi_63", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 72, 
+        "gr_state": 3, 
+        "y": 64, 
+        "x": 28, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_63"
+  }, 
+  {
+    "ref": "item-Ground.12fb.dnalsi_63", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_63"
+  }, 
+  {
+    "ref": "item-Sky.45e3.dnalsi_63", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 84, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_63"
+  }
+]

--- a/db/Dnalsi/dnalsi_64.json
+++ b/db/Dnalsi/dnalsi_64.json
@@ -1,0 +1,189 @@
+[
+  {
+    "ref": "context-dnalsi_64", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_65", 
+          "context-dnalsi_74", 
+          "context-dnalsi_63", 
+          ""
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.58f1.dnalsi_64", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 68, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_64"
+  }, 
+  {
+    "ref": "item-Wall.b89e.dnalsi_64", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 68, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_64"
+  }, 
+  {
+    "ref": "item-Ground.ad42.dnalsi_64", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_64"
+  }, 
+  {
+    "ref": "item-Tree.0b55.dnalsi_64", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 105, 
+        "x": 104, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_64"
+  }, 
+  {
+    "ref": "item-Plant.190c.dnalsi_64", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 24, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_64"
+  }, 
+  {
+    "ref": "item-Tree.5ad1.dnalsi_64", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 132, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_64"
+  }, 
+  {
+    "ref": "item-Tree.9d64.dnalsi_64", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 44, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_64"
+  }, 
+  {
+    "ref": "item-Ground.0a0f.dnalsi_64", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_64"
+  }, 
+  {
+    "ref": "item-Sky.2d1f.dnalsi_64", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_64"
+  }, 
+  {
+    "ref": "item-Plant.4550.dnalsi_64", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 142, 
+        "x": 12, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_64"
+  }, 
+  {
+    "ref": "item-Tree.1cee.dnalsi_64", 
+    "mods": [
+      {
+        "y": 105, 
+        "x": 60, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 140
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_64"
+  }
+]

--- a/db/Dnalsi/dnalsi_65.json
+++ b/db/Dnalsi/dnalsi_65.json
@@ -1,0 +1,209 @@
+[
+  {
+    "ref": "context-dnalsi_65", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_66", 
+          "context-dnalsi_75", 
+          "context-dnalsi_64", 
+          ""
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.64fd.dnalsi_65", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_65"
+  }, 
+  {
+    "ref": "item-Flat.7938.dnalsi_65", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_65"
+  }, 
+  {
+    "ref": "item-Bush.1a93.dnalsi_65", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 25, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 72, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_65"
+  }, 
+  {
+    "ref": "item-Bush.5a68.dnalsi_65", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 8, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_65"
+  }, 
+  {
+    "ref": "item-Bush.fd3d.dnalsi_65", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_65"
+  }, 
+  {
+    "ref": "item-Bush.230c.dnalsi_65", 
+    "mods": [
+      {
+        "y": 133, 
+        "x": 112, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 24
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_65"
+  }, 
+  {
+    "ref": "item-Bush.7f64.dnalsi_65", 
+    "mods": [
+      {
+        "y": 129, 
+        "x": 16, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 33
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_65"
+  }, 
+  {
+    "ref": "item-Rock.8bbe.dnalsi_65", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 48, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_65"
+  }, 
+  {
+    "ref": "item-Flat.3541.dnalsi_65", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_65"
+  }, 
+  {
+    "ref": "item-Bush.4a07.dnalsi_65", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_65"
+  }, 
+  {
+    "ref": "item-Rock.d3a9.dnalsi_65", 
+    "mods": [
+      {
+        "y": 137, 
+        "x": 52, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_65"
+  }, 
+  {
+    "ref": "item-Rock.1476.dnalsi_65", 
+    "mods": [
+      {
+        "y": 137, 
+        "x": 88, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_65"
+  }
+]

--- a/db/Dnalsi/dnalsi_66.json
+++ b/db/Dnalsi/dnalsi_66.json
@@ -1,0 +1,202 @@
+[
+  {
+    "ref": "context-dnalsi_66", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_67", 
+          "context-dnalsi_76", 
+          "context-dnalsi_65", 
+          ""
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.4474.dnalsi_66", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_66"
+  }, 
+  {
+    "ref": "item-Wall.6184.dnalsi_66", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_66"
+  }, 
+  {
+    "ref": "item-Ground.bc32.dnalsi_66", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 88, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_66"
+  }, 
+  {
+    "ref": "item-Rock.6e72.dnalsi_66", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 159, 
+        "x": 60, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_66"
+  }, 
+  {
+    "ref": "item-Tree.21aa.dnalsi_66", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 48, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_66"
+  }, 
+  {
+    "ref": "item-Tree.7f89.dnalsi_66", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 128, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_66"
+  }, 
+  {
+    "ref": "item-Plant.f2d1.dnalsi_66", 
+    "mods": [
+      {
+        "y": 131, 
+        "x": 96, 
+        "mass": 1, 
+        "type": "Plant", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_66"
+  }, 
+  {
+    "ref": "item-Ground.1f89.dnalsi_66", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_66"
+  }, 
+  {
+    "ref": "item-Sky.9fb6.dnalsi_66", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 88, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_66"
+  }, 
+  {
+    "ref": "item-Plant.7c7c.dnalsi_66", 
+    "mods": [
+      {
+        "y": 131, 
+        "x": 104, 
+        "mass": 1, 
+        "type": "Plant", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_66"
+  }, 
+  {
+    "ref": "item-Plant.62ae.dnalsi_66", 
+    "mods": [
+      {
+        "y": 131, 
+        "x": 120, 
+        "mass": 1, 
+        "type": "Plant", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_66"
+  }, 
+  {
+    "ref": "item-Plant.f13c.dnalsi_66", 
+    "mods": [
+      {
+        "y": 133, 
+        "x": 132, 
+        "mass": 1, 
+        "type": "Plant", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_66"
+  }
+]

--- a/db/Dnalsi/dnalsi_67.json
+++ b/db/Dnalsi/dnalsi_67.json
@@ -1,0 +1,302 @@
+[
+  {
+    "ref": "context-dnalsi_67", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_68", 
+          "", 
+          "context-dnalsi_66", 
+          "context-dnalsi_57"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.8b8b.dnalsi_67", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Wall.6bf7.dnalsi_67", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Tree.53dd.dnalsi_67", 
+    "mods": [
+      {
+        "y": 92, 
+        "x": 0, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 140
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Tree.8cc4.dnalsi_67", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 75, 
+        "x": 36, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Tree.af58.dnalsi_67", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 26, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Tree.4257.dnalsi_67", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Tree.514b.dnalsi_67", 
+    "mods": [
+      {
+        "y": 129, 
+        "x": 112, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Ground.52ce.dnalsi_67", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Tree.2d12.dnalsi_67", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 71, 
+        "x": 96, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Tree.e4f2.dnalsi_67", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 89, 
+        "x": 92, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Tree.aab1.dnalsi_67", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 106, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Tree.9891.dnalsi_67", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 3, 
+        "y": 120, 
+        "x": 76, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_67"
+  }, 
+  {
+    "ref": "item-Flashlight.5b1a.dnalsi_67", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "type": "Flashlight", 
+        "orientation": 8, 
+        "on": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flashlight", 
+    "in": "item-Hole.e7a0.dnalsi_67"
+  }, 
+  {
+    "ref": "item-Rock.2010.dnalsi_67", 
+    "mods": [
+      {
+        "y": 8, 
+        "x": 8, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.e7a0.dnalsi_67"
+  }, 
+  {
+    "ref": "item-Rock.755f.dnalsi_67", 
+    "mods": [
+      {
+        "y": 7, 
+        "x": 7, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.e7a0.dnalsi_67"
+  }, 
+  {
+    "ref": "item-Rock.2d40.dnalsi_67", 
+    "mods": [
+      {
+        "y": 6, 
+        "x": 6, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 32
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.e7a0.dnalsi_67"
+  }, 
+  {
+    "ref": "item-Rock.1bd6.dnalsi_67", 
+    "mods": [
+      {
+        "y": 5, 
+        "x": 5, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 56
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.e7a0.dnalsi_67"
+  }, 
+  {
+    "ref": "item-Hole.e7a0.dnalsi_67", 
+    "mods": [
+      {
+        "orientation": 16, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 148, 
+        "x": 64, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_67"
+  }
+]

--- a/db/Dnalsi/dnalsi_68.json
+++ b/db/Dnalsi/dnalsi_68.json
@@ -1,0 +1,205 @@
+[
+  {
+    "ref": "context-dnalsi_68", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_69", 
+          "context-dnalsi_78", 
+          "context-dnalsi_67", 
+          "context-dnalsi_58"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.938c.dnalsi_68", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_68"
+  }, 
+  {
+    "ref": "item-Wall.8b40.dnalsi_68", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_68"
+  }, 
+  {
+    "ref": "item-Ground.a898.dnalsi_68", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 68, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_68"
+  }, 
+  {
+    "ref": "item-Rock.2cb8.dnalsi_68", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 159, 
+        "x": 60, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_68"
+  }, 
+  {
+    "ref": "item-Tree.99e0.dnalsi_68", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 48, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_68"
+  }, 
+  {
+    "ref": "item-Tree.da06.dnalsi_68", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 128, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_68"
+  }, 
+  {
+    "ref": "item-Tree.9f79.dnalsi_68", 
+    "mods": [
+      {
+        "y": 136, 
+        "x": 92, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_68"
+  }, 
+  {
+    "ref": "item-Ground.1874.dnalsi_68", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_68"
+  }, 
+  {
+    "ref": "item-Sky.307f.dnalsi_68", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 68, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_68"
+  }, 
+  {
+    "ref": "item-Head.08c4.dnalsi_68", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 1, 
+        "style": 18, 
+        "type": "Head", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Head", 
+    "in": "item-Hole.a0da.dnalsi_68"
+  }, 
+  {
+    "ref": "item-Head.67b5.dnalsi_68", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 18, 
+        "type": "Head", 
+        "orientation": 17
+      }
+    ], 
+    "type": "item", 
+    "name": "Head", 
+    "in": "item-Hole.a0da.dnalsi_68"
+  }, 
+  {
+    "ref": "item-Hole.a0da.dnalsi_68", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 160, 
+        "x": 88, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_68"
+  }
+]

--- a/db/Dnalsi/dnalsi_69.json
+++ b/db/Dnalsi/dnalsi_69.json
@@ -1,0 +1,132 @@
+[
+  {
+    "ref": "context-dnalsi_69", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_6a", 
+          "context-dnalsi_79", 
+          "context-dnalsi_68", 
+          "context-dnalsi_59"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.da6d.dnalsi_69", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_69"
+  }, 
+  {
+    "ref": "item-Flat.4d20.dnalsi_69", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_69"
+  }, 
+  {
+    "ref": "item-Bush.bc7d.dnalsi_69", 
+    "mods": [
+      {
+        "y": 29, 
+        "x": 12, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_69"
+  }, 
+  {
+    "ref": "item-Flat.e886.dnalsi_69", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 12, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_69"
+  }, 
+  {
+    "ref": "item-Flat.5473.dnalsi_69", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_69"
+  }, 
+  {
+    "ref": "item-Bush.73cd.dnalsi_69", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 100, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_69"
+  }, 
+  {
+    "ref": "item-Bush.1699.dnalsi_69", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "y": 35, 
+        "x": 128, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_69"
+  }
+]

--- a/db/Dnalsi/dnalsi_6a.json
+++ b/db/Dnalsi/dnalsi_6a.json
@@ -1,0 +1,192 @@
+[
+  {
+    "ref": "context-dnalsi_6a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_6b", 
+          "context-dnalsi_7a", 
+          "context-dnalsi_69", 
+          "context-dnalsi_5a"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.f1fb.dnalsi_6a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_6a"
+  }, 
+  {
+    "ref": "item-Flat.3d97.dnalsi_6a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_6a"
+  }, 
+  {
+    "ref": "item-Bush.e219.dnalsi_6a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 25, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 72, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_6a"
+  }, 
+  {
+    "ref": "item-Bush.baa6.dnalsi_6a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 8, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_6a"
+  }, 
+  {
+    "ref": "item-Bush.9261.dnalsi_6a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_6a"
+  }, 
+  {
+    "ref": "item-Tree.4a66.dnalsi_6a", 
+    "mods": [
+      {
+        "y": 33, 
+        "x": 80, 
+        "style": 6, 
+        "type": "Tree", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_6a"
+  }, 
+  {
+    "ref": "item-Bush.09f7.dnalsi_6a", 
+    "mods": [
+      {
+        "y": 129, 
+        "x": 8, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 33
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_6a"
+  }, 
+  {
+    "ref": "item-Fence.3c79.dnalsi_6a", 
+    "mods": [
+      {
+        "y": 155, 
+        "x": 68, 
+        "type": "Fence", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Fence", 
+    "in": "context-dnalsi_6a"
+  }, 
+  {
+    "ref": "item-Flat.1231.dnalsi_6a", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_6a"
+  }, 
+  {
+    "ref": "item-Bush.0271.dnalsi_6a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_6a"
+  }, 
+  {
+    "ref": "item-Fence.8dfc.dnalsi_6a", 
+    "mods": [
+      {
+        "y": 155, 
+        "x": 96, 
+        "type": "Fence", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Fence", 
+    "in": "context-dnalsi_6a"
+  }
+]

--- a/db/Dnalsi/dnalsi_6b.json
+++ b/db/Dnalsi/dnalsi_6b.json
@@ -1,0 +1,179 @@
+[
+  {
+    "ref": "context-dnalsi_6b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_6c", 
+          "context-dnalsi_7b", 
+          "context-dnalsi_6a", 
+          "context-dnalsi_5b"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.dbd1.dnalsi_6b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_6b"
+  }, 
+  {
+    "ref": "item-Flat.9635.dnalsi_6b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 188, 
+        "flat_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_6b"
+  }, 
+  {
+    "ref": "item-Bush.94a9.dnalsi_6b", 
+    "mods": [
+      {
+        "y": 38, 
+        "x": 48, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 25
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_6b"
+  }, 
+  {
+    "ref": "item-Bush.509f.dnalsi_6b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 56, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 8, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_6b"
+  }, 
+  {
+    "ref": "item-Bush.548e.dnalsi_6b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_6b"
+  }, 
+  {
+    "ref": "item-Plant.bc68.dnalsi_6b", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 44, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_6b"
+  }, 
+  {
+    "ref": "item-Bush.a6ea.dnalsi_6b", 
+    "mods": [
+      {
+        "y": 129, 
+        "x": 8, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 33
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_6b"
+  }, 
+  {
+    "ref": "item-Plant.4775.dnalsi_6b", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 49, 
+        "mass": 1, 
+        "y": 142, 
+        "x": 112, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_6b"
+  }, 
+  {
+    "ref": "item-Flat.c665.dnalsi_6b", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_6b"
+  }, 
+  {
+    "ref": "item-Bush.ce79.dnalsi_6b", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 24, 
+        "gr_state": 2, 
+        "y": 45, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_6b"
+  }
+]

--- a/db/Dnalsi/dnalsi_6c.json
+++ b/db/Dnalsi/dnalsi_6c.json
@@ -1,0 +1,286 @@
+[
+  {
+    "ref": "context-dnalsi_6c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_7c", 
+          "context-dnalsi_6b", 
+          "context-dnalsi_5c"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.19e8.dnalsi_6c", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Wall.2116.dnalsi_6c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Tree.ff5b.dnalsi_6c", 
+    "mods": [
+      {
+        "y": 72, 
+        "x": 20, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 140
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Tree.346c.dnalsi_6c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Tree.54fa.dnalsi_6c", 
+    "mods": [
+      {
+        "y": 21, 
+        "x": 112, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Ground.dafc.dnalsi_6c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Tree.c7de.dnalsi_6c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 71, 
+        "x": 96, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Tree.af51.dnalsi_6c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 89, 
+        "x": 92, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Tree.230b.dnalsi_6c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 106, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Tree.b398.dnalsi_6c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 3, 
+        "y": 120, 
+        "x": 76, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Knick_knack.3e04.dnalsi_6c", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 80, 
+        "y": 2, 
+        "x": 2, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Hole.f458.dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Knick_knack.ff1b.dnalsi_6c", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 104, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Hole.f458.dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Shovel.5ae1.dnalsi_6c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 4, 
+        "type": "Shovel", 
+        "orientation": 56
+      }
+    ], 
+    "type": "item", 
+    "name": "Shovel", 
+    "in": "item-Hole.f458.dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Rock.f7f6.dnalsi_6c", 
+    "mods": [
+      {
+        "y": 8, 
+        "x": 8, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.f458.dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Rock.72db.dnalsi_6c", 
+    "mods": [
+      {
+        "y": 7, 
+        "x": 7, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.f458.dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Rock.d2de.dnalsi_6c", 
+    "mods": [
+      {
+        "y": 6, 
+        "x": 6, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 32
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "item-Hole.f458.dnalsi_6c"
+  }, 
+  {
+    "ref": "item-Hole.f458.dnalsi_6c", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 148, 
+        "x": 8, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_6c"
+  }
+]

--- a/db/Dnalsi/dnalsi_71.json
+++ b/db/Dnalsi/dnalsi_71.json
@@ -1,0 +1,158 @@
+[
+  {
+    "ref": "context-dnalsi_71", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_72", 
+          "", 
+          "", 
+          "context-dnalsi_61"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.7f63.dnalsi_71", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_71"
+  }, 
+  {
+    "ref": "item-Wall.11d1.dnalsi_71", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_71"
+  }, 
+  {
+    "ref": "item-Tree.3a9a.dnalsi_71", 
+    "mods": [
+      {
+        "y": 78, 
+        "x": 24, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 140
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_71"
+  }, 
+  {
+    "ref": "item-Tree.8a6b.dnalsi_71", 
+    "mods": [
+      {
+        "y": 88, 
+        "x": 52, 
+        "style": 9, 
+        "type": "Tree", 
+        "orientation": 140
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_71"
+  }, 
+  {
+    "ref": "item-Flat.648e.dnalsi_71", 
+    "mods": [
+      {
+        "flat_type": 2, 
+        "style": 1, 
+        "orientation": 188, 
+        "y": 4, 
+        "x": 184, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_71"
+  }, 
+  {
+    "ref": "item-Tree.25e5.dnalsi_71", 
+    "mods": [
+      {
+        "y": 10, 
+        "x": 48, 
+        "style": 7, 
+        "type": "Tree", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_71"
+  }, 
+  {
+    "ref": "item-Pond.da86.dnalsi_71", 
+    "mods": [
+      {
+        "y": 9, 
+        "x": 12, 
+        "type": "Pond", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_71"
+  }, 
+  {
+    "ref": "item-Pond.d338.dnalsi_71", 
+    "mods": [
+      {
+        "y": 5, 
+        "x": 32, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_71"
+  }, 
+  {
+    "ref": "item-Pond.93a6.dnalsi_71", 
+    "mods": [
+      {
+        "y": 5, 
+        "x": 16, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_71"
+  }
+]

--- a/db/Dnalsi/dnalsi_72.json
+++ b/db/Dnalsi/dnalsi_72.json
@@ -1,0 +1,190 @@
+[
+  {
+    "ref": "context-dnalsi_72", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_73", 
+          "", 
+          "context-dnalsi_71", 
+          "context-dnalsi_62"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.ceaa.dnalsi_72", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_72"
+  }, 
+  {
+    "ref": "item-Wall.4508.dnalsi_72", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_72"
+  }, 
+  {
+    "ref": "item-Bush.0ef2.dnalsi_72", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_72"
+  }, 
+  {
+    "ref": "item-Bush.dba8.dnalsi_72", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 104, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_72"
+  }, 
+  {
+    "ref": "item-Bush.4c92.dnalsi_72", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 19, 
+        "x": 64, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_72"
+  }, 
+  {
+    "ref": "item-Bush.d0f1.dnalsi_72", 
+    "mods": [
+      {
+        "y": 19, 
+        "x": 32, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_72"
+  }, 
+  {
+    "ref": "item-Short_sign.319d.dnalsi_72", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 148, 
+        "ascii": [
+          32, 
+          79, 
+          78, 
+          69, 
+          128, 
+          87, 
+          65, 
+          89, 
+          32, 
+          32
+        ], 
+        "gr_state": 5, 
+        "y": 138, 
+        "x": 24, 
+        "type": "Short_sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Short_sign", 
+    "in": "context-dnalsi_72"
+  }, 
+  {
+    "ref": "item-Ground.aab1.dnalsi_72", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_72"
+  }, 
+  {
+    "ref": "item-Bush.8cab.dnalsi_72", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 152, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_72"
+  }, 
+  {
+    "ref": "item-Bush.d233.dnalsi_72", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 24, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_72"
+  }
+]

--- a/db/Dnalsi/dnalsi_73.json
+++ b/db/Dnalsi/dnalsi_73.json
@@ -1,0 +1,133 @@
+[
+  {
+    "ref": "context-dnalsi_73", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-dnalsi_72", 
+          "context-dnalsi_63"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.4dd6.dnalsi_73", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_73"
+  }, 
+  {
+    "ref": "item-Wall.1a2f.dnalsi_73", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_73"
+  }, 
+  {
+    "ref": "item-Garbage_can.a804.dnalsi_73", 
+    "mods": [
+      {
+        "orientation": 228, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 144, 
+        "x": 100, 
+        "type": "Garbage_can", 
+        "open_flags": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Garbage_can", 
+    "in": "context-dnalsi_73"
+  }, 
+  {
+    "ref": "item-Plant.f6f4.dnalsi_73", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 148, 
+        "x": 76, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_73"
+  }, 
+  {
+    "ref": "item-Plant.1f48.dnalsi_73", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 92, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_73"
+  }, 
+  {
+    "ref": "item-Plant.773f.dnalsi_73", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 148, 
+        "x": 116, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_73"
+  }, 
+  {
+    "ref": "item-Ground.6d8f.dnalsi_73", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 80, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_73"
+  }
+]

--- a/db/Dnalsi/dnalsi_74.json
+++ b/db/Dnalsi/dnalsi_74.json
@@ -1,0 +1,208 @@
+[
+  {
+    "ref": "context-dnalsi_74", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_75", 
+          "context-dnalsi_84", 
+          "", 
+          "context-dnalsi_64"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.9c33.dnalsi_74", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_74"
+  }, 
+  {
+    "ref": "item-Wall.bea7.dnalsi_74", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_74"
+  }, 
+  {
+    "ref": "item-Hole.28e2.dnalsi_74", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 158, 
+        "x": 24, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_74"
+  }, 
+  {
+    "ref": "item-Pond.8677.dnalsi_74", 
+    "mods": [
+      {
+        "y": 10, 
+        "x": 60, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_74"
+  }, 
+  {
+    "ref": "item-Pond.f74f.dnalsi_74", 
+    "mods": [
+      {
+        "y": 6, 
+        "x": 80, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_74"
+  }, 
+  {
+    "ref": "item-Pond.46fc.dnalsi_74", 
+    "mods": [
+      {
+        "y": 11, 
+        "x": 80, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_74"
+  }, 
+  {
+    "ref": "item-Pond.d2fb.dnalsi_74", 
+    "mods": [
+      {
+        "y": 16, 
+        "x": 88, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_74"
+  }, 
+  {
+    "ref": "item-Ground.46b4.dnalsi_74", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_74"
+  }, 
+  {
+    "ref": "item-Knick_knack.db9c.dnalsi_74", 
+    "mods": [
+      {
+        "style": 7, 
+        "orientation": 16, 
+        "y": 142, 
+        "x": 96, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "context-dnalsi_74"
+  }, 
+  {
+    "ref": "item-Plant.1795.dnalsi_74", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 72, 
+        "mass": 1, 
+        "y": 149, 
+        "x": 60, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_74"
+  }, 
+  {
+    "ref": "item-Plant.0dcf.dnalsi_74", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 73, 
+        "mass": 1, 
+        "y": 24, 
+        "x": 80, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_74"
+  }, 
+  {
+    "ref": "item-Bush.f00e.dnalsi_74", 
+    "mods": [
+      {
+        "y": 22, 
+        "x": 116, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 9
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_74"
+  }
+]

--- a/db/Dnalsi/dnalsi_75.json
+++ b/db/Dnalsi/dnalsi_75.json
@@ -1,0 +1,205 @@
+[
+  {
+    "ref": "context-dnalsi_75", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_76", 
+          "context-dnalsi_85", 
+          "context-dnalsi_74", 
+          ""
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.0eae.dnalsi_75", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 68, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_75"
+  }, 
+  {
+    "ref": "item-Wall.d120.dnalsi_75", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 68, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_75"
+  }, 
+  {
+    "ref": "item-Ground.734b.dnalsi_75", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_75"
+  }, 
+  {
+    "ref": "item-Knife.563f.dnalsi_75", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "type": "Knife", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Knife", 
+    "in": "item-Hole.0f8e.dnalsi_75"
+  }, 
+  {
+    "ref": "item-Head.4096.dnalsi_75", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 1, 
+        "style": 18, 
+        "type": "Head", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Head", 
+    "in": "item-Hole.0f8e.dnalsi_75"
+  }, 
+  {
+    "ref": "item-Hole.0f8e.dnalsi_75", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 146, 
+        "x": 12, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_75"
+  }, 
+  {
+    "ref": "item-Plant.a799.dnalsi_75", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 24, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_75"
+  }, 
+  {
+    "ref": "item-Tree.4940.dnalsi_75", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 116, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_75"
+  }, 
+  {
+    "ref": "item-Tree.b3d4.dnalsi_75", 
+    "mods": [
+      {
+        "y": 135, 
+        "x": 44, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_75"
+  }, 
+  {
+    "ref": "item-Ground.1741.dnalsi_75", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_75"
+  }, 
+  {
+    "ref": "item-Sky.f077.dnalsi_75", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Sky", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_75"
+  }, 
+  {
+    "ref": "item-Plant.be0c.dnalsi_75", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 32, 
+        "mass": 1, 
+        "y": 142, 
+        "x": 12, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-dnalsi_75"
+  }
+]

--- a/db/Dnalsi/dnalsi_76.json
+++ b/db/Dnalsi/dnalsi_76.json
@@ -1,0 +1,145 @@
+[
+  {
+    "ref": "context-dnalsi_76", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-dnalsi_75", 
+          "context-dnalsi_66"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.5b5c.dnalsi_76", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_76"
+  }, 
+  {
+    "ref": "item-Wall.0f57.dnalsi_76", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_76"
+  }, 
+  {
+    "ref": "item-Rock.7eea.dnalsi_76", 
+    "mods": [
+      {
+        "y": 148, 
+        "x": 32, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_76"
+  }, 
+  {
+    "ref": "item-Rock.923f.dnalsi_76", 
+    "mods": [
+      {
+        "y": 148, 
+        "x": 112, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_76"
+  }, 
+  {
+    "ref": "item-Ground.bc5f.dnalsi_76", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 244, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_76"
+  }, 
+  {
+    "ref": "item-Bush.3d84.dnalsi_76", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 120, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_76"
+  }, 
+  {
+    "ref": "item-Bush.8fb5.dnalsi_76", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 17, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_76"
+  }, 
+  {
+    "ref": "item-Bush.a0da.dnalsi_76", 
+    "mods": [
+      {
+        "y": 17, 
+        "x": 48, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_76"
+  }
+]

--- a/db/Dnalsi/dnalsi_78.json
+++ b/db/Dnalsi/dnalsi_78.json
@@ -1,0 +1,98 @@
+[
+  {
+    "ref": "context-dnalsi_78", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_79", 
+          "", 
+          "", 
+          "context-dnalsi_68"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.ed52.dnalsi_78", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_78"
+  }, 
+  {
+    "ref": "item-Wall.b211.dnalsi_78", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_78"
+  }, 
+  {
+    "ref": "item-Tree.9a7a.dnalsi_78", 
+    "mods": [
+      {
+        "y": 22, 
+        "x": 28, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 237
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_78"
+  }, 
+  {
+    "ref": "item-Tree.0911.dnalsi_78", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 72, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_78"
+  }, 
+  {
+    "ref": "item-Ground.84ba.dnalsi_78", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 204, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_78"
+  }
+]

--- a/db/Dnalsi/dnalsi_79.json
+++ b/db/Dnalsi/dnalsi_79.json
@@ -1,0 +1,159 @@
+[
+  {
+    "ref": "context-dnalsi_79", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_7a", 
+          "", 
+          "context-dnalsi_78", 
+          "context-dnalsi_69"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.dc87.dnalsi_79", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_79"
+  }, 
+  {
+    "ref": "item-Wall.7b72.dnalsi_79", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_79"
+  }, 
+  {
+    "ref": "item-Tree.f823.dnalsi_79", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "gr_state": 4, 
+        "y": 24, 
+        "x": 112, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_79"
+  }, 
+  {
+    "ref": "item-Tree.6d10.dnalsi_79", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "gr_state": 3, 
+        "y": 24, 
+        "x": 112, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_79"
+  }, 
+  {
+    "ref": "item-Tree.e734.dnalsi_79", 
+    "mods": [
+      {
+        "y": 10, 
+        "x": 0, 
+        "style": 7, 
+        "type": "Tree", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_79"
+  }, 
+  {
+    "ref": "item-Tree.5876.dnalsi_79", 
+    "mods": [
+      {
+        "y": 10, 
+        "x": 8, 
+        "style": 7, 
+        "type": "Tree", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_79"
+  }, 
+  {
+    "ref": "item-Tree.5b60.dnalsi_79", 
+    "mods": [
+      {
+        "y": 139, 
+        "x": 16, 
+        "style": 7, 
+        "type": "Tree", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_79"
+  }, 
+  {
+    "ref": "item-Ground.66db.dnalsi_79", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_79"
+  }, 
+  {
+    "ref": "item-Tree.6237.dnalsi_79", 
+    "mods": [
+      {
+        "y": 148, 
+        "x": 12, 
+        "style": 7, 
+        "type": "Tree", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_79"
+  }
+]

--- a/db/Dnalsi/dnalsi_7a.json
+++ b/db/Dnalsi/dnalsi_7a.json
@@ -1,0 +1,162 @@
+[
+  {
+    "ref": "context-dnalsi_7a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_7b", 
+          "", 
+          "context-dnalsi_79", 
+          "context-dnalsi_6a"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.28f3.dnalsi_7a", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_7a"
+  }, 
+  {
+    "ref": "item-Wall.45b4.dnalsi_7a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_7a"
+  }, 
+  {
+    "ref": "item-Bush.f278.dnalsi_7a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_7a"
+  }, 
+  {
+    "ref": "item-Bush.6e6b.dnalsi_7a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 104, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_7a"
+  }, 
+  {
+    "ref": "item-Bush.a8eb.dnalsi_7a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 19, 
+        "x": 64, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_7a"
+  }, 
+  {
+    "ref": "item-Bush.c052.dnalsi_7a", 
+    "mods": [
+      {
+        "y": 19, 
+        "x": 32, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_7a"
+  }, 
+  {
+    "ref": "item-Ground.d791.dnalsi_7a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_7a"
+  }, 
+  {
+    "ref": "item-Bush.240d.dnalsi_7a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 22, 
+        "x": 152, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_7a"
+  }, 
+  {
+    "ref": "item-Bush.5f60.dnalsi_7a", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 24, 
+        "x": 24, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_7a"
+  }
+]

--- a/db/Dnalsi/dnalsi_7b.json
+++ b/db/Dnalsi/dnalsi_7b.json
@@ -1,0 +1,175 @@
+[
+  {
+    "ref": "context-dnalsi_7b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_7c", 
+          "", 
+          "context-dnalsi_7a", 
+          "context-dnalsi_6b"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.8371.dnalsi_7b", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_7b"
+  }, 
+  {
+    "ref": "item-Wall.68ab.dnalsi_7b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_7b"
+  }, 
+  {
+    "ref": "item-Sign.732c.dnalsi_7b", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "type": "Sign", 
+        "gr_state": 1, 
+        "y": 0, 
+        "x": 0, 
+        "ascii": [
+          133, 
+          89, 
+          79, 
+          85, 
+          32, 
+          65, 
+          82, 
+          69, 
+          32, 
+          84, 
+          79, 
+          79, 
+          32, 
+          76, 
+          65, 
+          84, 
+          69, 
+          33, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ]
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "item-Box.db75.dnalsi_7b"
+  }, 
+  {
+    "ref": "item-Box.db75.dnalsi_7b", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 140, 
+        "x": 24, 
+        "type": "Box", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Box", 
+    "in": "context-dnalsi_7b"
+  }, 
+  {
+    "ref": "item-Tree.a5f8.dnalsi_7b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 78, 
+        "x": 100, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_7b"
+  }, 
+  {
+    "ref": "item-Tree.5534.dnalsi_7b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 28, 
+        "x": 112, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_7b"
+  }, 
+  {
+    "ref": "item-Ground.db10.dnalsi_7b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_7b"
+  }
+]

--- a/db/Dnalsi/dnalsi_7c.json
+++ b/db/Dnalsi/dnalsi_7c.json
@@ -1,0 +1,233 @@
+[
+  {
+    "ref": "context-dnalsi_7c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-dnalsi_7b", 
+          "context-dnalsi_6c"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.4a00.dnalsi_7c", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 60, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Wall.dd93.dnalsi_7c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 60, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Hole.03d5.dnalsi_7c", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 143, 
+        "x": 124, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Hole.d068.dnalsi_7c", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 159, 
+        "x": 96, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Tree.b802.dnalsi_7c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 1, 
+        "gr_state": 2, 
+        "y": 91, 
+        "x": 132, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Pond.f9f6.dnalsi_7c", 
+    "mods": [
+      {
+        "y": 40, 
+        "x": 28, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 4
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Tree.fb2a.dnalsi_7c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 1, 
+        "gr_state": 4, 
+        "y": 21, 
+        "x": 128, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Ground.9efd.dnalsi_7c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 60, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Tree.917e.dnalsi_7c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 17, 
+        "gr_state": 3, 
+        "y": 111, 
+        "x": 116, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Bush.c35e.dnalsi_7c", 
+    "mods": [
+      {
+        "y": 137, 
+        "x": 64, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Flat.6bad.dnalsi_7c", 
+    "mods": [
+      {
+        "flat_type": 3, 
+        "style": 4, 
+        "orientation": 0, 
+        "y": 0, 
+        "x": 160, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Flat.a734.dnalsi_7c", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 160, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_7c"
+  }, 
+  {
+    "ref": "item-Trapezoid.3019.dnalsi_7c", 
+    "mods": [
+      {
+        "lower_right_x": 30, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "upper_right_x": 30, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 3, 
+        "y": 164, 
+        "x": 24, 
+        "height": 24, 
+        "type": "Trapezoid", 
+        "upper_left_x": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_7c"
+  }
+]

--- a/db/Dnalsi/dnalsi_82.json
+++ b/db/Dnalsi/dnalsi_82.json
@@ -1,0 +1,246 @@
+[
+  {
+    "ref": "context-dnalsi_82", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_83", 
+          "context-dnalsi_92", 
+          "", 
+          ""
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.7da8.dnalsi_82", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_82"
+  }, 
+  {
+    "ref": "item-Wall.a2b5.dnalsi_82", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_82"
+  }, 
+  {
+    "ref": "item-Tree.3faf.dnalsi_82", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 237, 
+        "gr_state": 1, 
+        "y": 22, 
+        "x": 28, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_82"
+  }, 
+  {
+    "ref": "item-Tree.1564.dnalsi_82", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 1, 
+        "gr_state": 2, 
+        "y": 74, 
+        "x": 96, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_82"
+  }, 
+  {
+    "ref": "item-Tree.4e5c.dnalsi_82", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 139, 
+        "x": 48, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_82"
+  }, 
+  {
+    "ref": "item-Tree.f3d0.dnalsi_82", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_82"
+  }, 
+  {
+    "ref": "item-Tree.5fa5.dnalsi_82", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "gr_state": 1, 
+        "y": 21, 
+        "x": 112, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_82"
+  }, 
+  {
+    "ref": "item-Ground.f2a2.dnalsi_82", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 244, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_82"
+  }, 
+  {
+    "ref": "item-Knick_knack.9cb1.dnalsi_82", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Knick_knack", 
+        "magic_type": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Knick_knack", 
+    "in": "item-Hole.6767.dnalsi_82"
+  }, 
+  {
+    "ref": "item-Tree.d418.dnalsi_82", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 72, 
+        "gr_state": 3, 
+        "y": 1, 
+        "x": 1, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "item-Hole.6767.dnalsi_82"
+  }, 
+  {
+    "ref": "item-Tree.8167.dnalsi_82", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 33, 
+        "gr_state": 3, 
+        "y": 2, 
+        "x": 2, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "item-Hole.6767.dnalsi_82"
+  }, 
+  {
+    "ref": "item-Hole.6767.dnalsi_82", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 145, 
+        "x": 68, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_82"
+  }, 
+  {
+    "ref": "item-Tree.b778.dnalsi_82", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "gr_state": 2, 
+        "y": 70, 
+        "x": 120, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_82"
+  }, 
+  {
+    "ref": "item-Tree.f837.dnalsi_82", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "gr_state": 2, 
+        "y": 90, 
+        "x": 124, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_82"
+  }
+]

--- a/db/Dnalsi/dnalsi_83.json
+++ b/db/Dnalsi/dnalsi_83.json
@@ -1,0 +1,210 @@
+[
+  {
+    "ref": "context-dnalsi_83", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_84", 
+          "context-dnalsi_93", 
+          "context-dnalsi_82", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.b43b.dnalsi_83", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_83"
+  }, 
+  {
+    "ref": "item-Wall.f391.dnalsi_83", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_83"
+  }, 
+  {
+    "ref": "item-Tree.79c5.dnalsi_83", 
+    "mods": [
+      {
+        "y": 22, 
+        "x": 28, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 236
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_83"
+  }, 
+  {
+    "ref": "item-Pond.db7c.dnalsi_83", 
+    "mods": [
+      {
+        "y": 7, 
+        "x": 24, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_83"
+  }, 
+  {
+    "ref": "item-Pond.cc26.dnalsi_83", 
+    "mods": [
+      {
+        "y": 5, 
+        "x": 48, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_83"
+  }, 
+  {
+    "ref": "item-Tree.e8c9.dnalsi_83", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 120, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_83"
+  }, 
+  {
+    "ref": "item-Tree.773b.dnalsi_83", 
+    "mods": [
+      {
+        "y": 134, 
+        "x": 92, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_83"
+  }, 
+  {
+    "ref": "item-Ground.3a2c.dnalsi_83", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_83"
+  }, 
+  {
+    "ref": "item-Pond.3af6.dnalsi_83", 
+    "mods": [
+      {
+        "y": 15, 
+        "x": 40, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_83"
+  }, 
+  {
+    "ref": "item-Tree.49fd.dnalsi_83", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 3, 
+        "y": 77, 
+        "x": 120, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_83"
+  }, 
+  {
+    "ref": "item-Aquarium.daa2.dnalsi_83", 
+    "mods": [
+      {
+        "y": 140, 
+        "x": 52, 
+        "type": "Aquarium", 
+        "orientation": 0, 
+        "gr_state": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Aquarium", 
+    "in": "context-dnalsi_83"
+  }, 
+  {
+    "ref": "item-Trapezoid.937c.dnalsi_83", 
+    "mods": [
+      {
+        "lower_right_x": 38, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "upper_right_x": 38, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 2, 
+        "y": 138, 
+        "x": 44, 
+        "height": 22, 
+        "type": "Trapezoid", 
+        "upper_left_x": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_83"
+  }
+]

--- a/db/Dnalsi/dnalsi_84.json
+++ b/db/Dnalsi/dnalsi_84.json
@@ -1,0 +1,130 @@
+[
+  {
+    "ref": "context-dnalsi_84", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_85", 
+          "context-dnalsi_94", 
+          "context-dnalsi_83", 
+          "context-dnalsi_74"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.0cd3.dnalsi_84", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_84"
+  }, 
+  {
+    "ref": "item-Flat.6700.dnalsi_84", 
+    "mods": [
+      {
+        "flat_type": 0, 
+        "style": 4, 
+        "orientation": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Flat"
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_84"
+  }, 
+  {
+    "ref": "item-Bush.5102.dnalsi_84", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "y": 29, 
+        "x": 76, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_84"
+  }, 
+  {
+    "ref": "item-Bush.4bac.dnalsi_84", 
+    "mods": [
+      {
+        "y": 128, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_84"
+  }, 
+  {
+    "ref": "item-Bush.66ad.dnalsi_84", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 2, 
+        "y": 25, 
+        "x": 72, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_84"
+  }, 
+  {
+    "ref": "item-Ground.165d.dnalsi_84", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_84"
+  }, 
+  {
+    "ref": "item-Bush.9361.dnalsi_84", 
+    "mods": [
+      {
+        "y": 22, 
+        "x": 136, 
+        "style": 4, 
+        "type": "Bush", 
+        "orientation": 17
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-dnalsi_84"
+  }
+]

--- a/db/Dnalsi/dnalsi_85.json
+++ b/db/Dnalsi/dnalsi_85.json
@@ -1,0 +1,104 @@
+[
+  {
+    "ref": "context-dnalsi_85", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-dnalsi_84", 
+          "context-dnalsi_75"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.f422.dnalsi_85", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_85"
+  }, 
+  {
+    "ref": "item-Wall.814f.dnalsi_85", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_85"
+  }, 
+  {
+    "ref": "item-Trapezoid.d98e.dnalsi_85", 
+    "mods": [
+      {
+        "lower_right_x": 27, 
+        "orientation": 8, 
+        "gr_state": 2, 
+        "upper_right_x": 27, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 3, 
+        "y": 164, 
+        "x": 116, 
+        "height": 35, 
+        "type": "Trapezoid", 
+        "upper_left_x": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_85"
+  }, 
+  {
+    "ref": "item-Head.c2a6.dnalsi_85", 
+    "mods": [
+      {
+        "y": 38, 
+        "x": 136, 
+        "style": 12, 
+        "type": "Head", 
+        "orientation": 17
+      }
+    ], 
+    "type": "item", 
+    "name": "Head", 
+    "in": "context-dnalsi_85"
+  }, 
+  {
+    "ref": "item-Ground.cbcf.dnalsi_85", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 200, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_85"
+  }
+]

--- a/db/Dnalsi/dnalsi_92.json
+++ b/db/Dnalsi/dnalsi_92.json
@@ -1,0 +1,219 @@
+[
+  {
+    "ref": "context-dnalsi_92", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_93", 
+          "", 
+          "", 
+          "context-dnalsi_82"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.1aaa.dnalsi_92", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_92"
+  }, 
+  {
+    "ref": "item-Wall.d3cd.dnalsi_92", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_92"
+  }, 
+  {
+    "ref": "item-Tree.d1d4.dnalsi_92", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 236, 
+        "gr_state": 3, 
+        "y": 110, 
+        "x": 108, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_92"
+  }, 
+  {
+    "ref": "item-Fountain.620f.dnalsi_92", 
+    "mods": [
+      {
+        "y": 133, 
+        "x": 40, 
+        "type": "Fountain", 
+        "orientation": 16, 
+        "gr_state": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Fountain", 
+    "in": "context-dnalsi_92"
+  }, 
+  {
+    "ref": "item-Sign.30c3.dnalsi_92", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 252, 
+        "ascii": [
+          128, 
+          65, 
+          115, 
+          107, 
+          32, 
+          111, 
+          102, 
+          134, 
+          77, 
+          101, 
+          32, 
+          119, 
+          104, 
+          97, 
+          116, 
+          134, 
+          121, 
+          111, 
+          117, 
+          128, 
+          119, 
+          105, 
+          108, 
+          108, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ], 
+        "y": 22, 
+        "x": 40, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-dnalsi_92"
+  }, 
+  {
+    "ref": "item-Tree.0e1a.dnalsi_92", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 88, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_92"
+  }, 
+  {
+    "ref": "item-Tree.0be7.dnalsi_92", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "gr_state": 1, 
+        "y": 21, 
+        "x": 112, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_92"
+  }, 
+  {
+    "ref": "item-Ground.8dc6.dnalsi_92", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 16, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_92"
+  }, 
+  {
+    "ref": "item-Tree.e6d9.dnalsi_92", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "gr_state": 2, 
+        "y": 70, 
+        "x": 120, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_92"
+  }, 
+  {
+    "ref": "item-Tree.e175.dnalsi_92", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 0, 
+        "gr_state": 2, 
+        "y": 90, 
+        "x": 124, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_92"
+  }
+]

--- a/db/Dnalsi/dnalsi_93.json
+++ b/db/Dnalsi/dnalsi_93.json
@@ -1,0 +1,301 @@
+[
+  {
+    "ref": "context-dnalsi_93", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_94", 
+          "", 
+          "context-dnalsi_92", 
+          "context-dnalsi_83"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.e0c5.dnalsi_93", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 0, 
+        "type": "Ground", 
+        "orientation": 244
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Wall.4638.dnalsi_93", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Sign.6176.dnalsi_93", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "type": "Sign", 
+        "gr_state": 1, 
+        "y": 0, 
+        "x": 0, 
+        "ascii": [
+          133, 
+          131, 
+          78, 
+          79, 
+          84, 
+          32, 
+          72, 
+          69, 
+          82, 
+          69, 
+          32, 
+          69, 
+          73, 
+          84, 
+          72, 
+          69, 
+          82, 
+          33, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ]
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "item-Box.6ece.dnalsi_93"
+  }, 
+  {
+    "ref": "item-Box.6ece.dnalsi_93", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 0, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Box", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Box", 
+    "in": "item-Hole.7716.dnalsi_93"
+  }, 
+  {
+    "ref": "item-Hole.7716.dnalsi_93", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 156, 
+        "x": 60, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Tree.148c.dnalsi_93", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 4, 
+        "y": 23, 
+        "x": 40, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Tree.66c1.dnalsi_93", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 48, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Tree.2cb1.dnalsi_93", 
+    "mods": [
+      {
+        "y": 27, 
+        "x": 88, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 173
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Tree.c565.dnalsi_93", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 4, 
+        "y": 27, 
+        "x": 92, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Ground.a11e.dnalsi_93", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Bottle.d884.dnalsi_93", 
+    "mods": [
+      {
+        "y": 158, 
+        "x": 16, 
+        "type": "Bottle", 
+        "orientation": 0, 
+        "filled": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Bottle", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Tree.9a6d.dnalsi_93", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 2, 
+        "y": 97, 
+        "x": 104, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Tree.bdaf.dnalsi_93", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 172, 
+        "gr_state": 3, 
+        "y": 115, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Tree.f492.dnalsi_93", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 93, 
+        "x": 44, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_93"
+  }, 
+  {
+    "ref": "item-Tree.ccc2.dnalsi_93", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 3, 
+        "y": 113, 
+        "x": 28, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_93"
+  }
+]

--- a/db/Dnalsi/dnalsi_94.json
+++ b/db/Dnalsi/dnalsi_94.json
@@ -1,0 +1,193 @@
+[
+  {
+    "ref": "context-dnalsi_94", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Island", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-dnalsi_93", 
+          "context-dnalsi_84"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Flat.c394.dnalsi_94", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "type": "Flat", 
+        "orientation": 244, 
+        "flat_type": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Flat", 
+    "in": "context-dnalsi_94"
+  }, 
+  {
+    "ref": "item-Wall.9f16.dnalsi_94", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_94"
+  }, 
+  {
+    "ref": "item-Tree.849f.dnalsi_94", 
+    "mods": [
+      {
+        "y": 150, 
+        "x": 28, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 237
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_94"
+  }, 
+  {
+    "ref": "item-Tree.3cf2.dnalsi_94", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 36, 
+        "style": 7, 
+        "type": "Tree", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_94"
+  }, 
+  {
+    "ref": "item-Tree.faee.dnalsi_94", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 1, 
+        "y": 27, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_94"
+  }, 
+  {
+    "ref": "item-Tree.d9c3.dnalsi_94", 
+    "mods": [
+      {
+        "y": 21, 
+        "x": 112, 
+        "style": 2, 
+        "type": "Tree", 
+        "orientation": 172
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_94"
+  }, 
+  {
+    "ref": "item-Ground.6e49.dnalsi_94", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 224, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 188
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_94"
+  }, 
+  {
+    "ref": "item-Tree.3d2e.dnalsi_94", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 71, 
+        "x": 96, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_94"
+  }, 
+  {
+    "ref": "item-Tree.7390.dnalsi_94", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 89, 
+        "x": 92, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_94"
+  }, 
+  {
+    "ref": "item-Tree.a01e.dnalsi_94", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 106, 
+        "x": 88, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_94"
+  }, 
+  {
+    "ref": "item-Tree.384d.dnalsi_94", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 173, 
+        "gr_state": 3, 
+        "y": 120, 
+        "x": 72, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-dnalsi_94"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave1_0a.json
+++ b/db/Dnalsi/dnalsi_cave1_0a.json
@@ -1,0 +1,225 @@
+[
+  {
+    "ref": "context-dnalsi_cave1_0a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave1_0b", 
+          "context-dnalsi_cave1_1a", 
+          "context-dnalsi_21", 
+          ""
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.637f.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave1_0a"
+  }, 
+  {
+    "ref": "item-Trapezoid.bab9.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 0, 
+        "y": 86, 
+        "x": 68, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_0a"
+  }, 
+  {
+    "ref": "item-Wall.51e3.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave1_0a"
+  }, 
+  {
+    "ref": "item-Trapezoid.7b75.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 99, 
+        "x": 92, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_0a"
+  }, 
+  {
+    "ref": "item-Trapezoid.9632.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "lower_right_x": 13, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 12, 
+        "trapezoid_type": 0, 
+        "y": 90, 
+        "x": 116, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_0a"
+  }, 
+  {
+    "ref": "item-Sky.d536.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 24, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave1_0a"
+  }, 
+  {
+    "ref": "item-Trapezoid.e13a.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 0, 
+        "y": 98, 
+        "x": 28, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_0a"
+  }, 
+  {
+    "ref": "item-Rock.efae.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 24, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_0a"
+  }, 
+  {
+    "ref": "item-Rock.b829.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "y": 145, 
+        "x": 52, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_0a"
+  }, 
+  {
+    "ref": "item-Rock.0917.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "y": 146, 
+        "x": 56, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 72
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_0a"
+  }, 
+  {
+    "ref": "item-Rock.d223.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 228, 
+        "mass": 1, 
+        "y": 145, 
+        "x": 12, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_0a"
+  }, 
+  {
+    "ref": "item-Rock.dac8.dnalsi_cave1_0a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 228, 
+        "mass": 1, 
+        "y": 144, 
+        "x": 104, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_0a"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave1_0b.json
+++ b/db/Dnalsi/dnalsi_cave1_0b.json
@@ -1,0 +1,214 @@
+[
+  {
+    "ref": "context-dnalsi_cave1_0b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_cave1_1b", 
+          "context-dnalsi_cave1_0a", 
+          ""
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.8f3e.dnalsi_cave1_0b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave1_0b"
+  }, 
+  {
+    "ref": "item-Trapezoid.ab6b.dnalsi_cave1_0b", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 20, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_0b"
+  }, 
+  {
+    "ref": "item-Wall.168d.dnalsi_cave1_0b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave1_0b"
+  }, 
+  {
+    "ref": "item-Trapezoid.5639.dnalsi_cave1_0b", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 99, 
+        "x": 72, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_0b"
+  }, 
+  {
+    "ref": "item-Trapezoid.7ca4.dnalsi_cave1_0b", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 116, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_0b"
+  }, 
+  {
+    "ref": "item-Trapezoid.f63a.dnalsi_cave1_0b", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 245, 
+        "trapezoid_type": 2, 
+        "y": 140, 
+        "x": 136, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_0b"
+  }, 
+  {
+    "ref": "item-Trapezoid.f13c.dnalsi_cave1_0b", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 36, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_0b"
+  }, 
+  {
+    "ref": "item-Rock.ec7f.dnalsi_cave1_0b", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 16, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_0b"
+  }, 
+  {
+    "ref": "item-Sky.c225.dnalsi_cave1_0b", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 64, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave1_0b"
+  }, 
+  {
+    "ref": "item-Rock.2ec8.dnalsi_cave1_0b", 
+    "mods": [
+      {
+        "y": 146, 
+        "x": 28, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 72
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_0b"
+  }, 
+  {
+    "ref": "item-Rock.1067.dnalsi_cave1_0b", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 124, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_0b"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave1_1a.json
+++ b/db/Dnalsi/dnalsi_cave1_1a.json
@@ -1,0 +1,250 @@
+[
+  {
+    "ref": "context-dnalsi_cave1_1a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave1_1b", 
+          "", 
+          "", 
+          "context-dnalsi_cave1_0a"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.1bab.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.1a6b.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 0, 
+        "y": 86, 
+        "x": 124, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Wall.096a.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.6603.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 99, 
+        "x": 40, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.8340.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "lower_right_x": 13, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 12, 
+        "trapezoid_type": 0, 
+        "y": 90, 
+        "x": 116, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Sky.448c.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 52, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.b180.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 0, 
+        "y": 98, 
+        "x": 28, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Rock.dc01.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 24, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.9b21.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 0, 
+        "upper_right_x": 13, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 33, 
+        "x": 0, 
+        "height": 95, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Rock.7985.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "y": 146, 
+        "x": 56, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 72
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Rock.2c5d.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 228, 
+        "mass": 1, 
+        "y": 145, 
+        "x": 12, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Rock.9740.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 228, 
+        "mass": 1, 
+        "y": 144, 
+        "x": 104, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.0d89.dnalsi_cave1_1a", 
+    "mods": [
+      {
+        "lower_right_x": 3, 
+        "upper_left_x": 243, 
+        "upper_right_x": 3, 
+        "lower_left_x": 239, 
+        "trapezoid_type": 0, 
+        "y": 32, 
+        "x": 156, 
+        "height": 96, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1a"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave1_1b.json
+++ b/db/Dnalsi/dnalsi_cave1_1b.json
@@ -1,0 +1,259 @@
+[
+  {
+    "ref": "context-dnalsi_cave1_1b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-dnalsi_cave1_0b", 
+          "context-dnalsi_cave1_1b"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.40bc.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.b302.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 0, 
+        "y": 86, 
+        "x": 124, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Wall.aa2f.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.16fc.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 76, 
+        "x": 80, 
+        "height": 181, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.c1cd.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "lower_right_x": 13, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 12, 
+        "trapezoid_type": 0, 
+        "y": 90, 
+        "x": 32, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Sky.61d7.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 72, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.8245.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "lower_right_x": 255, 
+        "upper_left_x": 245, 
+        "upper_right_x": 16, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 0, 
+        "y": 78, 
+        "x": 28, 
+        "height": 178, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Rock.53dc.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 72, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.0c9e.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 0, 
+        "upper_right_x": 13, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 33, 
+        "x": 0, 
+        "height": 95, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.aac9.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 231, 
+        "upper_right_x": 0, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 72, 
+        "x": 156, 
+        "height": 56, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Rock.4ed4.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 145, 
+        "x": 92, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.92aa.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 246, 
+        "upper_right_x": 247, 
+        "lower_left_x": 245, 
+        "trapezoid_type": 0, 
+        "y": 32, 
+        "x": 12, 
+        "height": 28, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.e0d6.dnalsi_cave1_1b", 
+    "mods": [
+      {
+        "lower_right_x": 3, 
+        "upper_left_x": 243, 
+        "upper_right_x": 3, 
+        "lower_left_x": 239, 
+        "trapezoid_type": 0, 
+        "y": 32, 
+        "x": 156, 
+        "height": 96, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave1_1b"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_0c.json
+++ b/db/Dnalsi/dnalsi_cave2_0c.json
@@ -1,0 +1,244 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_0c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave2_0d", 
+          "context-dnalsi_cave2_1c", 
+          "", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.721b.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.5164.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 63, 
+        "x": 56, 
+        "height": 193, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_0c"
+  }, 
+  {
+    "ref": "item-Wall.92b7.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_0c"
+  }, 
+  {
+    "ref": "item-Wall.da53.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 56, 
+        "style": 9, 
+        "type": "Wall", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.e139.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 254, 
+        "upper_right_x": 50, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 80, 
+        "x": 56, 
+        "height": 139, 
+        "type": "Trapezoid", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.fd9d.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "lower_right_x": 51, 
+        "upper_left_x": 49, 
+        "upper_right_x": 50, 
+        "lower_left_x": 251, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 56, 
+        "height": 11, 
+        "type": "Trapezoid", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.c548.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 92, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.8c16.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 0, 
+        "upper_right_x": 16, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 88, 
+        "x": 0, 
+        "height": 40, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.e8d5.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "lower_right_x": 12, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 32, 
+        "x": 0, 
+        "height": 66, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.a340.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "lower_right_x": 56, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 255, 
+        "trapezoid_type": 0, 
+        "y": 65, 
+        "x": 56, 
+        "height": 10, 
+        "type": "Trapezoid", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_0c"
+  }, 
+  {
+    "ref": "item-Rock.6da5.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 28, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.8bce.dnalsi_cave2_0c", 
+    "mods": [
+      {
+        "lower_right_x": 51, 
+        "upper_left_x": 0, 
+        "upper_right_x": 51, 
+        "lower_left_x": 49, 
+        "trapezoid_type": 1, 
+        "y": 57, 
+        "x": 56, 
+        "height": 8, 
+        "type": "Trapezoid", 
+        "orientation": 16
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_0c"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_0d.json
+++ b/db/Dnalsi/dnalsi_cave2_0d.json
@@ -1,0 +1,129 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_0d", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_cave2_1d", 
+          "context-dnalsi_cave2_0c", 
+          ""
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.0730.dnalsi_cave2_0d", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_0d"
+  }, 
+  {
+    "ref": "item-Trapezoid.813d.dnalsi_cave2_0d", 
+    "mods": [
+      {
+        "lower_right_x": 254, 
+        "upper_left_x": 240, 
+        "upper_right_x": 242, 
+        "lower_left_x": 236, 
+        "trapezoid_type": 1, 
+        "y": 131, 
+        "x": 116, 
+        "height": 191, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_0d"
+  }, 
+  {
+    "ref": "item-Wall.3c4a.dnalsi_cave2_0d", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_0d"
+  }, 
+  {
+    "ref": "item-Trapezoid.f59c.dnalsi_cave2_0d", 
+    "mods": [
+      {
+        "lower_right_x": 13, 
+        "upper_left_x": 0, 
+        "upper_right_x": 26, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 88, 
+        "x": 0, 
+        "height": 40, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_0d"
+  }, 
+  {
+    "ref": "item-Trapezoid.473d.dnalsi_cave2_0d", 
+    "mods": [
+      {
+        "lower_right_x": 12, 
+        "upper_left_x": 0, 
+        "upper_right_x": 13, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 32, 
+        "x": 0, 
+        "height": 66, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_0d"
+  }, 
+  {
+    "ref": "item-Rock.3509.dnalsi_cave2_0d", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 80, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_0d"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_1a.json
+++ b/db/Dnalsi/dnalsi_cave2_1a.json
@@ -1,0 +1,220 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_1a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave2_1b", 
+          "context-dnalsi_cave2_2a", 
+          "", 
+          ""
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.d3d5.dnalsi_cave2_1a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 192, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.182e.dnalsi_cave2_1a", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 63, 
+        "x": 36, 
+        "height": 193, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1a"
+  }, 
+  {
+    "ref": "item-Wall.6187.dnalsi_cave2_1a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.7416.dnalsi_cave2_1a", 
+    "mods": [
+      {
+        "lower_right_x": 10, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 6, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 88, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.0b8b.dnalsi_cave2_1a", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 48, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1a"
+  }, 
+  {
+    "ref": "item-Rock.ef07.dnalsi_cave2_1a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 141, 
+        "x": 28, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.3c19.dnalsi_cave2_1a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 12, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1a"
+  }, 
+  {
+    "ref": "item-Wall.97f5.dnalsi_cave2_1a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 96, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.d488.dnalsi_cave2_1a", 
+    "mods": [
+      {
+        "lower_right_x": 8, 
+        "upper_left_x": 6, 
+        "upper_right_x": 12, 
+        "lower_left_x": 247, 
+        "trapezoid_type": 1, 
+        "y": 4, 
+        "x": 88, 
+        "height": 70, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1a"
+  }, 
+  {
+    "ref": "item-Rock.187b.dnalsi_cave2_1a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 150, 
+        "x": 20, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.a01a.dnalsi_cave2_1a", 
+    "mods": [
+      {
+        "lower_right_x": 10, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 251, 
+        "trapezoid_type": 2, 
+        "y": 129, 
+        "x": 52, 
+        "height": 26, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1a"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_1b.json
+++ b/db/Dnalsi/dnalsi_cave2_1b.json
@@ -1,0 +1,235 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_1b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_cave2_2b", 
+          "context-dnalsi_cave2_1a", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.418c.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.904b.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 63, 
+        "x": 36, 
+        "height": 193, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1b"
+  }, 
+  {
+    "ref": "item-Wall.dd2d.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.62f5.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "lower_right_x": 15, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 6, 
+        "trapezoid_type": 1, 
+        "y": 74, 
+        "x": 144, 
+        "height": 182, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.4451.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 84, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1b"
+  }, 
+  {
+    "ref": "item-Rock.33bc.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 141, 
+        "x": 28, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.b247.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 12, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1b"
+  }, 
+  {
+    "ref": "item-Shovel.3838.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "y": 163, 
+        "x": 76, 
+        "type": "Shovel", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Shovel", 
+    "in": "context-dnalsi_cave2_1b"
+  }, 
+  {
+    "ref": "item-Rock.e794.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 133, 
+        "x": 0, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.5120.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "lower_right_x": 16, 
+        "upper_left_x": 6, 
+        "upper_right_x": 16, 
+        "lower_left_x": 247, 
+        "trapezoid_type": 1, 
+        "y": 4, 
+        "x": 144, 
+        "height": 70, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1b"
+  }, 
+  {
+    "ref": "item-Rock.c6f9.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 76, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_1b"
+  }, 
+  {
+    "ref": "item-Trapezoid.ffb5.dnalsi_cave2_1b", 
+    "mods": [
+      {
+        "lower_right_x": 10, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 251, 
+        "trapezoid_type": 2, 
+        "y": 129, 
+        "x": 52, 
+        "height": 26, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1b"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_1c.json
+++ b/db/Dnalsi/dnalsi_cave2_1c.json
@@ -1,0 +1,180 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_1c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave2_1d", 
+          "context-dnalsi_cave2_2d", 
+          "", 
+          "context-dnalsi_cave2_0c"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.28ef.dnalsi_cave2_1c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_1c"
+  }, 
+  {
+    "ref": "item-Trapezoid.996d.dnalsi_cave2_1c", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 253, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 20, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1c"
+  }, 
+  {
+    "ref": "item-Wall.526c.dnalsi_cave2_1c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_1c"
+  }, 
+  {
+    "ref": "item-Trapezoid.f096.dnalsi_cave2_1c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 99, 
+        "x": 72, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1c"
+  }, 
+  {
+    "ref": "item-Trapezoid.1bc3.dnalsi_cave2_1c", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 136, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1c"
+  }, 
+  {
+    "ref": "item-Rock.1d8d.dnalsi_cave2_1c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 141, 
+        "x": 12, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_1c"
+  }, 
+  {
+    "ref": "item-Trapezoid.78f3.dnalsi_cave2_1c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 84, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1c"
+  }, 
+  {
+    "ref": "item-Sky.85b5.dnalsi_cave2_1c", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 60, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave2_1c"
+  }, 
+  {
+    "ref": "item-Rock.0233.dnalsi_cave2_1c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 149, 
+        "x": 100, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_1c"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_1d.json
+++ b/db/Dnalsi/dnalsi_cave2_1d.json
@@ -1,0 +1,220 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_1d", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave2_1e", 
+          "context-dnalsi_cave2_2d", 
+          "context-dnalsi_cave2_1c", 
+          ""
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.9ccc.dnalsi_cave2_1d", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_1d"
+  }, 
+  {
+    "ref": "item-Trapezoid.753e.dnalsi_cave2_1d", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 63, 
+        "x": 68, 
+        "height": 193, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1d"
+  }, 
+  {
+    "ref": "item-Wall.a4a0.dnalsi_cave2_1d", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_1d"
+  }, 
+  {
+    "ref": "item-Trapezoid.7a5e.dnalsi_cave2_1d", 
+    "mods": [
+      {
+        "lower_right_x": 15, 
+        "upper_left_x": 243, 
+        "upper_right_x": 15, 
+        "lower_left_x": 7, 
+        "trapezoid_type": 1, 
+        "y": 32, 
+        "x": 144, 
+        "height": 228, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1d"
+  }, 
+  {
+    "ref": "item-Trapezoid.8d41.dnalsi_cave2_1d", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 84, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1d"
+  }, 
+  {
+    "ref": "item-Rock.5b40.dnalsi_cave2_1d", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 141, 
+        "x": 28, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_1d"
+  }, 
+  {
+    "ref": "item-Trapezoid.ab11.dnalsi_cave2_1d", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 116, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1d"
+  }, 
+  {
+    "ref": "item-Trapezoid.d299.dnalsi_cave2_1d", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 0, 
+        "upper_right_x": 16, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 88, 
+        "x": 0, 
+        "height": 40, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1d"
+  }, 
+  {
+    "ref": "item-Rock.ca18.dnalsi_cave2_1d", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 76, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_1d"
+  }, 
+  {
+    "ref": "item-Trapezoid.53c4.dnalsi_cave2_1d", 
+    "mods": [
+      {
+        "lower_right_x": 10, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 251, 
+        "trapezoid_type": 2, 
+        "y": 142, 
+        "x": 72, 
+        "height": 26, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1d"
+  }, 
+  {
+    "ref": "item-Sky.217d.dnalsi_cave2_1d", 
+    "mods": [
+      {
+        "y": 31, 
+        "x": 64, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave2_1d"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_1e.json
+++ b/db/Dnalsi/dnalsi_cave2_1e.json
@@ -1,0 +1,200 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_1e", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_cave2_2e", 
+          "context-dnalsi_cave2_1d", 
+          ""
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.79d5.dnalsi_cave2_1e", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 192, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_1e"
+  }, 
+  {
+    "ref": "item-Trapezoid.68d0.dnalsi_cave2_1e", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 63, 
+        "x": 36, 
+        "height": 193, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1e"
+  }, 
+  {
+    "ref": "item-Wall.280d.dnalsi_cave2_1e", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_1e"
+  }, 
+  {
+    "ref": "item-Trapezoid.056b.dnalsi_cave2_1e", 
+    "mods": [
+      {
+        "lower_right_x": 10, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 6, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 88, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1e"
+  }, 
+  {
+    "ref": "item-Trapezoid.39d8.dnalsi_cave2_1e", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 48, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1e"
+  }, 
+  {
+    "ref": "item-Rock.b687.dnalsi_cave2_1e", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 141, 
+        "x": 20, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_1e"
+  }, 
+  {
+    "ref": "item-Trapezoid.2380.dnalsi_cave2_1e", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 12, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1e"
+  }, 
+  {
+    "ref": "item-Wall.8b84.dnalsi_cave2_1e", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 96, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_1e"
+  }, 
+  {
+    "ref": "item-Trapezoid.fe2d.dnalsi_cave2_1e", 
+    "mods": [
+      {
+        "lower_right_x": 8, 
+        "upper_left_x": 6, 
+        "upper_right_x": 12, 
+        "lower_left_x": 247, 
+        "trapezoid_type": 1, 
+        "y": 4, 
+        "x": 88, 
+        "height": 70, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_1e"
+  }, 
+  {
+    "ref": "item-Rock.43f7.dnalsi_cave2_1e", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 150, 
+        "x": 8, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_1e"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_2a.json
+++ b/db/Dnalsi/dnalsi_cave2_2a.json
@@ -1,0 +1,326 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_2a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_cave2_3a", 
+          "", 
+          "context-dnalsi_cave2_1a"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.318d.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.a9e7.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 124, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Wall.b20f.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.e8da.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 76, 
+        "x": 80, 
+        "height": 181, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.07d0.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "lower_right_x": 13, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 12, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 32, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Rock.20b6.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 145, 
+        "x": 116, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.0152.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "lower_right_x": 255, 
+        "upper_left_x": 245, 
+        "upper_right_x": 16, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 78, 
+        "x": 28, 
+        "height": 178, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Rock.4cc5.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "y": 152, 
+        "x": 104, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.5c44.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 0, 
+        "upper_right_x": 13, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 33, 
+        "x": 0, 
+        "height": 95, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.2d2d.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 231, 
+        "upper_right_x": 0, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 72, 
+        "x": 156, 
+        "height": 56, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Rock.718f.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 145, 
+        "x": 92, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.1de3.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 246, 
+        "upper_right_x": 247, 
+        "lower_left_x": 245, 
+        "trapezoid_type": 0, 
+        "y": 32, 
+        "x": 12, 
+        "height": 28, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.08d4.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "lower_right_x": 3, 
+        "upper_left_x": 243, 
+        "upper_right_x": 3, 
+        "lower_left_x": 239, 
+        "trapezoid_type": 0, 
+        "y": 32, 
+        "x": 156, 
+        "height": 96, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Short_sign.0f46.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "type": "Short_sign", 
+        "gr_state": 1, 
+        "y": 0, 
+        "x": 0, 
+        "ascii": [
+          133, 
+          129, 
+          32, 
+          87, 
+          82, 
+          79, 
+          78, 
+          71, 
+          33, 
+          32
+        ]
+      }
+    ], 
+    "type": "item", 
+    "name": "Short_sign", 
+    "in": "item-Hole.e0b3.dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Hole.e0b3.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "orientation": 16, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 146, 
+        "x": 96, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_cave2_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.dcea.dnalsi_cave2_2a", 
+    "mods": [
+      {
+        "lower_right_x": 26, 
+        "orientation": 16, 
+        "gr_state": 2, 
+        "upper_right_x": 26, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 34, 
+        "x": 88, 
+        "height": 55, 
+        "type": "Trapezoid", 
+        "upper_left_x": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2a"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_2b.json
+++ b/db/Dnalsi/dnalsi_cave2_2b.json
@@ -1,0 +1,199 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_2b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave2_2c", 
+          "", 
+          "", 
+          "context-dnalsi_cave2_1b"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.4161.dnalsi_cave2_2b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.c6ff.dnalsi_cave2_2b", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 63, 
+        "x": 56, 
+        "height": 193, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2b"
+  }, 
+  {
+    "ref": "item-Wall.3e64.dnalsi_cave2_2b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.f59b.dnalsi_cave2_2b", 
+    "mods": [
+      {
+        "lower_right_x": 8, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 7, 
+        "trapezoid_type": 1, 
+        "y": 214, 
+        "x": 144, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2b"
+  }, 
+  {
+    "ref": "item-Pond.dd8d.dnalsi_cave2_2b", 
+    "mods": [
+      {
+        "y": 6, 
+        "x": 72, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_cave2_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.00a0.dnalsi_cave2_2b", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 92, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.793a.dnalsi_cave2_2b", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 0, 
+        "upper_right_x": 16, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 88, 
+        "x": 0, 
+        "height": 40, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.f872.dnalsi_cave2_2b", 
+    "mods": [
+      {
+        "lower_right_x": 12, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 32, 
+        "x": 0, 
+        "height": 66, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2b"
+  }, 
+  {
+    "ref": "item-Rock.19ca.dnalsi_cave2_2b", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 133, 
+        "x": 108, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2b"
+  }, 
+  {
+    "ref": "item-Sky.f72b.dnalsi_cave2_2b", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 60, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave2_2b"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_2c.json
+++ b/db/Dnalsi/dnalsi_cave2_2c.json
@@ -1,0 +1,196 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_2c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave2_2d", 
+          "context-dnalsi_62", 
+          "context-dnalsi_cave2_2b", 
+          "context-dnalsi_cave2_1c"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.0399.dnalsi_cave2_2c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_2c"
+  }, 
+  {
+    "ref": "item-Trapezoid.4647.dnalsi_cave2_2c", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 36, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2c"
+  }, 
+  {
+    "ref": "item-Wall.8f6d.dnalsi_cave2_2c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_2c"
+  }, 
+  {
+    "ref": "item-Trapezoid.2c67.dnalsi_cave2_2c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 99, 
+        "x": 80, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2c"
+  }, 
+  {
+    "ref": "item-Trapezoid.a261.dnalsi_cave2_2c", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 116, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2c"
+  }, 
+  {
+    "ref": "item-Rock.ea73.dnalsi_cave2_2c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 141, 
+        "x": 12, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2c"
+  }, 
+  {
+    "ref": "item-Trapezoid.4a63.dnalsi_cave2_2c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 104, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2c"
+  }, 
+  {
+    "ref": "item-Rock.e9af.dnalsi_cave2_2c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 153, 
+        "x": 64, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2c"
+  }, 
+  {
+    "ref": "item-Sky.aa3b.dnalsi_cave2_2c", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 16, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave2_2c"
+  }, 
+  {
+    "ref": "item-Rock.3bda.dnalsi_cave2_2c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 149, 
+        "x": 76, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2c"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_2d.json
+++ b/db/Dnalsi/dnalsi_cave2_2d.json
@@ -1,0 +1,230 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_2d", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave2_2e", 
+          "", 
+          "context-dnalsi_cave2_2c", 
+          "context-dnalsi_cave2_1d"
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.0f82.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_2d"
+  }, 
+  {
+    "ref": "item-Trapezoid.da2a.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 0, 
+        "y": 86, 
+        "x": 68, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2d"
+  }, 
+  {
+    "ref": "item-Wall.69ae.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_2d"
+  }, 
+  {
+    "ref": "item-Trapezoid.0dac.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 99, 
+        "x": 92, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2d"
+  }, 
+  {
+    "ref": "item-Trapezoid.6ac3.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "lower_right_x": 13, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 12, 
+        "trapezoid_type": 0, 
+        "y": 90, 
+        "x": 116, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2d"
+  }, 
+  {
+    "ref": "item-Trapezoid.0517.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 239, 
+        "upper_right_x": 8, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 99, 
+        "x": 112, 
+        "height": 157, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2d"
+  }, 
+  {
+    "ref": "item-Trapezoid.71f0.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 0, 
+        "y": 98, 
+        "x": 28, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2d"
+  }, 
+  {
+    "ref": "item-Rock.dd6b.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 24, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2d"
+  }, 
+  {
+    "ref": "item-Rock.4f3e.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "y": 145, 
+        "x": 52, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2d"
+  }, 
+  {
+    "ref": "item-Rock.0573.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "y": 146, 
+        "x": 56, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 72
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2d"
+  }, 
+  {
+    "ref": "item-Rock.d3b7.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 228, 
+        "mass": 1, 
+        "y": 145, 
+        "x": 12, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2d"
+  }, 
+  {
+    "ref": "item-Rock.b415.dnalsi_cave2_2d", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 228, 
+        "mass": 1, 
+        "y": 144, 
+        "x": 104, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2d"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_2e.json
+++ b/db/Dnalsi/dnalsi_cave2_2e.json
@@ -1,0 +1,240 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_2e", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-dnalsi_cave2_2d", 
+          "context-dnalsi_cave2_1e"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.4e37.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_2e"
+  }, 
+  {
+    "ref": "item-Trapezoid.048d.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 63, 
+        "x": 48, 
+        "height": 193, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2e"
+  }, 
+  {
+    "ref": "item-Wall.d836.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_2e"
+  }, 
+  {
+    "ref": "item-Trapezoid.028f.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "lower_right_x": 15, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 7, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 144, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2e"
+  }, 
+  {
+    "ref": "item-Trapezoid.ce84.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 64, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2e"
+  }, 
+  {
+    "ref": "item-Rock.f216.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 141, 
+        "x": 28, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2e"
+  }, 
+  {
+    "ref": "item-Trapezoid.b0ea.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 128, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2e"
+  }, 
+  {
+    "ref": "item-Trapezoid.d47c.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 0, 
+        "upper_right_x": 16, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 88, 
+        "x": 0, 
+        "height": 40, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2e"
+  }, 
+  {
+    "ref": "item-Trapezoid.0909.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "lower_right_x": 12, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 32, 
+        "x": 0, 
+        "height": 66, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2e"
+  }, 
+  {
+    "ref": "item-Trapezoid.f8ed.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "lower_right_x": 15, 
+        "upper_left_x": 10, 
+        "upper_right_x": 15, 
+        "lower_left_x": 247, 
+        "trapezoid_type": 1, 
+        "y": 20, 
+        "x": 144, 
+        "height": 70, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_2e"
+  }, 
+  {
+    "ref": "item-Rock.1057.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 76, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_2e"
+  }, 
+  {
+    "ref": "item-Sky.00ef.dnalsi_cave2_2e", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 76, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave2_2e"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave2_3a.json
+++ b/db/Dnalsi/dnalsi_cave2_3a.json
@@ -1,0 +1,299 @@
+[
+  {
+    "ref": "context-dnalsi_cave2_3a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "", 
+          "context-dnalsi_cave2_2a"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.1cfe.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Trapezoid.3fb4.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 132, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Wall.91c0.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Trapezoid.ed2b.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 76, 
+        "x": 52, 
+        "height": 181, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Trapezoid.743a.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "lower_right_x": 13, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 12, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 24, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Rock.48b8.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 145, 
+        "x": 32, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Trapezoid.ed14.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "lower_right_x": 255, 
+        "upper_left_x": 245, 
+        "upper_right_x": 16, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 78, 
+        "x": 104, 
+        "height": 178, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Trapezoid.1a81.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 0, 
+        "upper_right_x": 13, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 33, 
+        "x": 0, 
+        "height": 95, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Trapezoid.6f0e.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 231, 
+        "upper_right_x": 0, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 72, 
+        "x": 156, 
+        "height": 56, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Trapezoid.21a4.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "lower_right_x": 11, 
+        "upper_left_x": 246, 
+        "upper_right_x": 247, 
+        "lower_left_x": 245, 
+        "trapezoid_type": 0, 
+        "y": 32, 
+        "x": 12, 
+        "height": 28, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Trapezoid.8545.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "lower_right_x": 3, 
+        "upper_left_x": 243, 
+        "upper_right_x": 3, 
+        "lower_left_x": 231, 
+        "trapezoid_type": 0, 
+        "y": 32, 
+        "x": 156, 
+        "height": 96, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Amulet.2353.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "type": "Amulet", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Amulet", 
+    "in": "item-Box.02c9.dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Box.02c9.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 0, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Box", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Box", 
+    "in": "item-Hole.25d4.dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Hole.25d4.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "orientation": 16, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 155, 
+        "x": 96, 
+        "type": "Hole", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Hole", 
+    "in": "context-dnalsi_cave2_3a"
+  }, 
+  {
+    "ref": "item-Trapezoid.ff02.dnalsi_cave2_3a", 
+    "mods": [
+      {
+        "lower_right_x": 26, 
+        "upper_left_x": 0, 
+        "upper_right_x": 26, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 33, 
+        "x": 36, 
+        "height": 55, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave2_3a"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave3_0c.json
+++ b/db/Dnalsi/dnalsi_cave3_0c.json
@@ -1,0 +1,196 @@
+[
+  {
+    "ref": "context-dnalsi_cave3_0c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_cave3_1c", 
+          "", 
+          ""
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.7739.dnalsi_cave3_0c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave3_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.03e9.dnalsi_cave3_0c", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 152, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_0c"
+  }, 
+  {
+    "ref": "item-Wall.0efb.dnalsi_cave3_0c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave3_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.020e.dnalsi_cave3_0c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 99, 
+        "x": 32, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.101f.dnalsi_cave3_0c", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 108, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_0c"
+  }, 
+  {
+    "ref": "item-Rock.5bfd.dnalsi_cave3_0c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 142, 
+        "x": 44, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_0c"
+  }, 
+  {
+    "ref": "item-Trapezoid.c9e7.dnalsi_cave3_0c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 68, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_0c"
+  }, 
+  {
+    "ref": "item-Rock.3c27.dnalsi_cave3_0c", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 116, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_0c"
+  }, 
+  {
+    "ref": "item-Rock.15d9.dnalsi_cave3_0c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 136, 
+        "x": 4, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_0c"
+  }, 
+  {
+    "ref": "item-Rock.1c27.dnalsi_cave3_0c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 76, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_0c"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave3_1a.json
+++ b/db/Dnalsi/dnalsi_cave3_1a.json
@@ -1,0 +1,240 @@
+[
+  {
+    "ref": "context-dnalsi_cave3_1a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_cave3_2a", 
+          "", 
+          ""
+        ], 
+        "orientation": 2, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.4281.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave3_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.1c64.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 63, 
+        "x": 48, 
+        "height": 193, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1a"
+  }, 
+  {
+    "ref": "item-Wall.cabd.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave3_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.e61c.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "lower_right_x": 15, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 7, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 144, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.6fb0.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 64, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1a"
+  }, 
+  {
+    "ref": "item-Rock.402c.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 141, 
+        "x": 28, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.1191.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 128, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.8cbd.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 0, 
+        "upper_right_x": 16, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 88, 
+        "x": 0, 
+        "height": 40, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.9f6c.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "lower_right_x": 12, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 32, 
+        "x": 0, 
+        "height": 66, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1a"
+  }, 
+  {
+    "ref": "item-Trapezoid.311d.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "lower_right_x": 15, 
+        "upper_left_x": 10, 
+        "upper_right_x": 15, 
+        "lower_left_x": 247, 
+        "trapezoid_type": 1, 
+        "y": 20, 
+        "x": 144, 
+        "height": 70, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1a"
+  }, 
+  {
+    "ref": "item-Rock.ec3f.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 76, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_1a"
+  }, 
+  {
+    "ref": "item-Sky.0cf8.dnalsi_cave3_1a", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 24, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave3_1a"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave3_1c.json
+++ b/db/Dnalsi/dnalsi_cave3_1c.json
@@ -1,0 +1,199 @@
+[
+  {
+    "ref": "context-dnalsi_cave3_1c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "context-dnalsi_cave3_2c", 
+          "", 
+          "context-dnalsi_cave3_0c"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.c009.dnalsi_cave3_1c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave3_1c"
+  }, 
+  {
+    "ref": "item-Trapezoid.ab56.dnalsi_cave3_1c", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 20, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1c"
+  }, 
+  {
+    "ref": "item-Wall.de8e.dnalsi_cave3_1c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave3_1c"
+  }, 
+  {
+    "ref": "item-Trapezoid.3016.dnalsi_cave3_1c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 99, 
+        "x": 80, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1c"
+  }, 
+  {
+    "ref": "item-Trapezoid.df37.dnalsi_cave3_1c", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 116, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1c"
+  }, 
+  {
+    "ref": "item-Trapezoid.f2db.dnalsi_cave3_1c", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 245, 
+        "trapezoid_type": 2, 
+        "y": 140, 
+        "x": 136, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1c"
+  }, 
+  {
+    "ref": "item-Trapezoid.0ba7.dnalsi_cave3_1c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 36, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_1c"
+  }, 
+  {
+    "ref": "item-Rock.2277.dnalsi_cave3_1c", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 16, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_1c"
+  }, 
+  {
+    "ref": "item-Rock.86f8.dnalsi_cave3_1c", 
+    "mods": [
+      {
+        "y": 146, 
+        "x": 28, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 72
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_1c"
+  }, 
+  {
+    "ref": "item-Rock.8337.dnalsi_cave3_1c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 124, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_1c"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave3_2a.json
+++ b/db/Dnalsi/dnalsi_cave3_2a.json
@@ -1,0 +1,219 @@
+[
+  {
+    "ref": "context-dnalsi_cave3_2a", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave3_2b", 
+          "", 
+          "", 
+          "context-dnalsi_cave3_1a"
+        ], 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.857c.dnalsi_cave3_2a", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave3_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.cdba.dnalsi_cave3_2a", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 63, 
+        "x": 56, 
+        "height": 193, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2a"
+  }, 
+  {
+    "ref": "item-Wall.57a8.dnalsi_cave3_2a", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave3_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.d65b.dnalsi_cave3_2a", 
+    "mods": [
+      {
+        "lower_right_x": 15, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 7, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 144, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2a"
+  }, 
+  {
+    "ref": "item-Pond.d233.dnalsi_cave3_2a", 
+    "mods": [
+      {
+        "y": 10, 
+        "x": 24, 
+        "type": "Pond", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Pond", 
+    "in": "context-dnalsi_cave3_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.9dee.dnalsi_cave3_2a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 92, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.bedd.dnalsi_cave3_2a", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 0, 
+        "upper_right_x": 16, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 88, 
+        "x": 0, 
+        "height": 40, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.33e4.dnalsi_cave3_2a", 
+    "mods": [
+      {
+        "lower_right_x": 12, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 32, 
+        "x": 0, 
+        "height": 66, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2a"
+  }, 
+  {
+    "ref": "item-Trapezoid.5738.dnalsi_cave3_2a", 
+    "mods": [
+      {
+        "lower_right_x": 15, 
+        "upper_left_x": 10, 
+        "upper_right_x": 15, 
+        "lower_left_x": 247, 
+        "trapezoid_type": 1, 
+        "y": 20, 
+        "x": 144, 
+        "height": 70, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2a"
+  }, 
+  {
+    "ref": "item-Rock.b42f.dnalsi_cave3_2a", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 28, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_2a"
+  }, 
+  {
+    "ref": "item-Sky.ec36.dnalsi_cave3_2a", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 60, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave3_2a"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave3_2b.json
+++ b/db/Dnalsi/dnalsi_cave3_2b.json
@@ -1,0 +1,256 @@
+[
+  {
+    "ref": "context-dnalsi_cave3_2b", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_cave3_2c", 
+          "", 
+          "context-dnalsi_cave3_2a", 
+          ""
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.cb4d.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.b2dc.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 63, 
+        "x": 36, 
+        "height": 193, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Wall.4dbb.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.0380.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "lower_right_x": 15, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 7, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 144, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.1d07.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 48, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Rock.60f5.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 141, 
+        "x": 28, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.0cf2.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 128, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.00b1.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 0, 
+        "upper_right_x": 16, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "y": 88, 
+        "x": 0, 
+        "height": 40, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Rock.2484.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 133, 
+        "x": 0, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.591c.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "lower_right_x": 15, 
+        "upper_left_x": 10, 
+        "upper_right_x": 15, 
+        "lower_left_x": 247, 
+        "trapezoid_type": 1, 
+        "y": 20, 
+        "x": 144, 
+        "height": 70, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Rock.2ad9.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 76, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Trapezoid.5ee5.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "lower_right_x": 10, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 251, 
+        "trapezoid_type": 2, 
+        "y": 129, 
+        "x": 52, 
+        "height": 26, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2b"
+  }, 
+  {
+    "ref": "item-Sky.b1f1.dnalsi_cave3_2b", 
+    "mods": [
+      {
+        "y": 31, 
+        "x": 64, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave3_2b"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave3_2c.json
+++ b/db/Dnalsi/dnalsi_cave3_2c.json
@@ -1,0 +1,211 @@
+[
+  {
+    "ref": "context-dnalsi_cave3_2c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "context-dnalsi_36", 
+          "context-dnalsi_cave3_3c", 
+          "context-dnalsi_cave3_2b", 
+          "context-dnalsi_cave3_1c"
+        ], 
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.00ff.dnalsi_cave3_2c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave3_2c"
+  }, 
+  {
+    "ref": "item-Trapezoid.1fa4.dnalsi_cave3_2c", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 36, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2c"
+  }, 
+  {
+    "ref": "item-Wall.7614.dnalsi_cave3_2c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave3_2c"
+  }, 
+  {
+    "ref": "item-Trapezoid.60dc.dnalsi_cave3_2c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 1, 
+        "y": 99, 
+        "x": 80, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2c"
+  }, 
+  {
+    "ref": "item-Trapezoid.f4d0.dnalsi_cave3_2c", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 116, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2c"
+  }, 
+  {
+    "ref": "item-Rock.aa24.dnalsi_cave3_2c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 141, 
+        "x": 12, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_2c"
+  }, 
+  {
+    "ref": "item-Trapezoid.0ffd.dnalsi_cave3_2c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 104, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_2c"
+  }, 
+  {
+    "ref": "item-Rock.9645.dnalsi_cave3_2c", 
+    "mods": [
+      {
+        "y": 138, 
+        "x": 116, 
+        "mass": 1, 
+        "type": "Rock", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_2c"
+  }, 
+  {
+    "ref": "item-Rock.95b9.dnalsi_cave3_2c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 138, 
+        "x": 124, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_2c"
+  }, 
+  {
+    "ref": "item-Sky.9045.dnalsi_cave3_2c", 
+    "mods": [
+      {
+        "y": 32, 
+        "x": 24, 
+        "style": 9, 
+        "type": "Sky", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-dnalsi_cave3_2c"
+  }, 
+  {
+    "ref": "item-Rock.da87.dnalsi_cave3_2c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 76, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_2c"
+  }
+]

--- a/db/Dnalsi/dnalsi_cave3_3c.json
+++ b/db/Dnalsi/dnalsi_cave3_3c.json
@@ -1,0 +1,236 @@
+[
+  {
+    "ref": "context-dnalsi_cave3_3c", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "D'nalsi Caves", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "", 
+          "context-dnalsi_cave3_3c"
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.0ac0.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 192, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-dnalsi_cave3_3c"
+  }, 
+  {
+    "ref": "item-Trapezoid.b3d6.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "lower_right_x": 248, 
+        "upper_left_x": 240, 
+        "upper_right_x": 0, 
+        "lower_left_x": 248, 
+        "trapezoid_type": 1, 
+        "y": 63, 
+        "x": 36, 
+        "height": 193, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_3c"
+  }, 
+  {
+    "ref": "item-Wall.cf54.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 6, 
+        "type": "Wall", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave3_3c"
+  }, 
+  {
+    "ref": "item-Trapezoid.5b6b.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "lower_right_x": 10, 
+        "upper_left_x": 244, 
+        "upper_right_x": 15, 
+        "lower_left_x": 6, 
+        "trapezoid_type": 1, 
+        "y": 86, 
+        "x": 88, 
+        "height": 170, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_3c"
+  }, 
+  {
+    "ref": "item-Trapezoid.f568.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "lower_right_x": 7, 
+        "upper_left_x": 0, 
+        "upper_right_x": 17, 
+        "lower_left_x": 5, 
+        "trapezoid_type": 1, 
+        "y": 90, 
+        "x": 48, 
+        "height": 166, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_3c"
+  }, 
+  {
+    "ref": "item-Rock.79f0.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 141, 
+        "x": 28, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_3c"
+  }, 
+  {
+    "ref": "item-Trapezoid.03ab.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "lower_right_x": 0, 
+        "upper_left_x": 245, 
+        "upper_right_x": 6, 
+        "lower_left_x": 253, 
+        "trapezoid_type": 1, 
+        "y": 98, 
+        "x": 12, 
+        "height": 158, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_3c"
+  }, 
+  {
+    "ref": "item-Wall.4278.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 96, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-dnalsi_cave3_3c"
+  }, 
+  {
+    "ref": "item-Rock.3fa1.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 16, 
+        "mass": 1, 
+        "y": 133, 
+        "x": 0, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_3c"
+  }, 
+  {
+    "ref": "item-Trapezoid.518c.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "lower_right_x": 8, 
+        "upper_left_x": 6, 
+        "upper_right_x": 12, 
+        "lower_left_x": 247, 
+        "trapezoid_type": 1, 
+        "y": 4, 
+        "x": 88, 
+        "height": 70, 
+        "type": "Trapezoid", 
+        "orientation": 8
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_3c"
+  }, 
+  {
+    "ref": "item-Rock.fff4.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 220, 
+        "mass": 1, 
+        "y": 139, 
+        "x": 76, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-dnalsi_cave3_3c"
+  }, 
+  {
+    "ref": "item-Trapezoid.e483.dnalsi_cave3_3c", 
+    "mods": [
+      {
+        "lower_right_x": 10, 
+        "upper_left_x": 0, 
+        "upper_right_x": 0, 
+        "lower_left_x": 251, 
+        "trapezoid_type": 2, 
+        "y": 129, 
+        "x": 52, 
+        "height": 26, 
+        "type": "Trapezoid", 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Trapezoid", 
+    "in": "context-dnalsi_cave3_3c"
+  }
+]

--- a/db/Text/text-welcomecenterext.json
+++ b/db/Text/text-welcomecenterext.json
@@ -1,0 +1,20 @@
+{
+	"ref": "text-welcomecenterext",
+	"pages": [
+		 "----------------------------------------" +
+		 "          THE WELCOME CENTER            " + 
+		 "                                        " +
+		 "  The Welcome Center is where all new   " +
+		 "  arrivals to Populopolis appear. The   " +
+		 "  Oracle has been known to look         " +
+		 "  favorably upon avatars that hang      " +
+		 "  out here and take newbies under       " +
+		 "  their wing.                           " +
+		 "                                        " +
+		 "  If you are a newbie, please check     " +
+		 "  out the Habitat manual, which you     " +
+		 "  can find here:                        " +
+		 "                                        " +
+		 "         http://goo.gl/fRaLzx           " +
+		 "                                        "]
+}

--- a/db/Welcome/welcomecenterext.json
+++ b/db/Welcome/welcomecenterext.json
@@ -1,0 +1,169 @@
+[
+  {
+    "ref": "context-welcomecenterext", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "the Welcome Center", 
+    "mods": [
+      {
+        "town_dir": RIGHT,
+        "port_dir": RIGHT,
+        "type": "Region",
+        "orientation": 3,
+        "neighbors": [
+          "",
+          "context-Woods_5x",
+          "context-welcomecenterint",
+          "context-Downtown_7f"
+        ], 
+        "nitty_bits": 3
+      }
+    ]
+  }, 
+  {
+    "ref": "item-wallff5e.welcomecenterext", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 5, 
+        "type": "Wall", 
+        "orientation": 148
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-welcomecenterext"
+  }, 
+  {
+    "ref": "item-ground5x44.welcomecenterext", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-welcomecenterext"
+  }, 
+  {
+    "ref": "item-doorl8k0.welcomecenterext", 
+    "mods": [
+      {
+        "orientation": 176, 
+        "type": "Door", 
+        "y": 33, 
+        "x": 68,
+		"open_flags": 0,
+		"style": 1,
+		"gr_state": 0,
+		"connection": "context-welcomecenterint"
+      }
+    ], 
+    "type": "item", 
+    "name": "Door", 
+    "in": "context-welcomecenterext"
+  },
+  {
+	"ref": "item-window1.welcomecenterext",
+	"mods": [
+	  {
+		"type": "Window",
+		"style": 1,
+		"x": 132,
+		"y": 49,
+		"orientation": 0,
+		"gr_width": 20
+	  }
+	],
+	"type": "item",
+	"name": "Window",
+	"in": "context-welcomecenterext"	
+	},
+  {
+	"ref": "item-window2.welcomecenterext",
+	"mods": [
+	  {
+		"type": "Window",
+		"style": 1,
+		"x": 8,
+		"y": 49,
+		"orientation": 0,
+		"gr_width": 20
+	  }
+	],
+	"type": "item",
+	"name": "Window",
+	"in": "context-welcomecenterext"	
+	},
+  {
+    "ref": "item-sign8k9h.welcomecenterext", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "ascii": [
+		  32,
+		  32,
+		  32,
+		  32,
+          87,
+		  101,
+		  108,
+		  99,
+		  111,
+		  109,
+		  101,
+		  32,
+		  67,
+		  101,
+		  110,
+		  116,
+		  101,
+		  114
+        ], 
+        "gr_state": 2, 
+        "y": 108, 
+        "x": 38, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-welcomecenterext"
+  },
+  {
+    "ref": "item-atm4b43.welcomecenterext", 
+    "mods": [
+      {
+        "y": 56, 
+        "x": 46, 
+        "type": "Atm", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Atm", 
+    "in": "context-welcomecenterext"
+  },   
+  {
+    "ref": "item-streetk0f3.welcomecenterext", 
+    "mods": [
+      {
+        "orientation": 8, 
+        "type": "Street", 
+        "gr_state": 6, 
+        "y": 10, 
+        "x": 68
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-welcomecenterext"
+  }
+]

--- a/db/Welcome/welcomecenterint.json
+++ b/db/Welcome/welcomecenterint.json
@@ -1,0 +1,282 @@
+[
+  {
+    "capacity": 64, 
+    "mods": [
+      {
+        "town_dir": UP, 
+        "neighbors": [
+          "context-welcomecenterext", 
+          "context-welcomecenterintvendo", 
+          "", 
+          "context-welcomecenterinthatch"
+        ],
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": UP, 
+        "type": "Region"
+      }
+    ], 
+    "ref": "context-welcomecenterint", 
+    "name": "the Welcome Center", 
+    "type": "context"
+  }, 
+  {
+    "type": "item", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 176
+      }
+    ], 
+    "ref": "item-wall.welcomecenterint", 
+    "name": "Wall", 
+    "in": "context-welcomecenterint"
+  }, 
+  {
+    "type": "item", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 56
+      }
+    ], 
+    "ref": "item-ground.welcomecenterint", 
+    "name": "Ground", 
+    "in": "context-welcomecenterint"
+  },
+  {
+    "ref": "item-countertop41c0.welcomecenterint", 
+    "mods": [
+      {
+        "y": 132, 
+        "x": 108, 
+        "open_flags": 3, 
+        "type": "Countertop", 
+        "orientation": 80
+      }
+    ], 
+    "type": "item", 
+    "name": "Countertop", 
+    "in": "context-welcomecenterint"
+  },
+  {
+    "ref": "item-sign1.welcomecenterint", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 216, 
+        "ascii": [
+          32, 
+          32, 
+          32, 
+          32, 
+          133, 
+          129,
+          130,
+		  131,
+		  132,
+          78,
+		  101,
+		  111,
+		  134,
+		  72,
+		  97,
+		  98,
+		  105,
+		  116,
+		  97,
+		  116
+        ], 
+        "gr_state": 4, 
+        "y": 54, 
+        "x": 10, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-welcomecenterint"
+  },
+  {
+    "ref": "item-sign2.welcomecenterint", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 216, 
+        "ascii": [
+          133, 
+          129,
+          130,
+		  131,
+		  132,
+          87,
+		  101,
+		  108,
+		  99,
+		  111,
+		  109,
+		  101,
+		  134,
+		  32,
+		  32,
+		  128,
+		  116,
+		  111
+        ], 
+        "gr_state": 4, 
+        "y": 110, 
+        "x": 10, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-welcomecenterint"
+  },
+  {
+    "ref": "item-picturek309.welcomecenterint", 
+    "mods": [
+      {
+        "orientation": 16, 
+        "type": "Picture",
+		"mass": 1,
+        "style": 1, 
+        "y": 106, 
+        "x": 76
+      }
+    ], 
+    "type": "item", 
+    "name": "Picture", 
+    "in": "context-welcomecenterint"
+  },
+  {
+    "ref": "item-picture2d9j.welcomecenterint", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "type": "Picture",
+		"mass": 1,
+        "style": 2, 
+        "y": 88, 
+        "x": 104
+      }
+    ], 
+    "type": "item", 
+    "name": "Picture", 
+    "in": "context-welcomecenterint"
+  }, 
+{
+	"type": "item",
+	"ref": "item-head1.welcomecenterint",
+	"name": "Chipmonk Head",
+	"in": "item-glue.welcomecenterint",
+	"mods": [
+		{
+			"type": "Head",
+			"style": 108,
+			"x": 0,
+			"y": 0,
+			"orientation": 0,
+			"gr_state": 1
+		}
+	]
+},
+{
+	"type": "item",
+	"ref": "item-head2.welcomecenterint",
+	"name": "Cool Cat Head",
+	"in": "item-glue.welcomecenterint",
+	"mods": [
+		{
+			"type": "Head",
+			"style": 28,
+			"x": 1,
+			"y": 1,
+			"orientation": 16,
+			"gr_state": 1
+		}
+	]
+},
+  {
+    "ref": "item-chair1.welcomecenterint", 
+    "mods": [
+      {
+        "y": 7, 
+        "x": 112,
+        "open_flags": 3,
+		"style": 2,
+        "type": "Chair", 
+        "orientation": 88
+      }
+    ], 
+    "type": "item", 
+    "name": "Chair", 
+    "in": "context-welcomecenterint"
+  },
+  {
+    "ref": "item-chair2.welcomecenterint", 
+    "mods": [
+      {
+        "y": 7, 
+        "x": 132,
+        "open_flags": 3,
+		"style": 2,
+        "type": "Chair", 
+        "orientation": 88
+      }
+    ], 
+    "type": "item", 
+    "name": "Chair", 
+    "in": "context-welcomecenterint"
+  },   
+  {
+    "type": "item",
+    "ref": "item-glue.welcomecenterint",
+    "in": "context-welcomecenterint",
+    "name": ".",
+    "mods": [
+      {
+        "type": "Glue",
+        "x": 88,
+        "y": 124,
+        "gr_state": 1,
+		"open_flags": 3,
+        "x_offset_1": 234,
+        "y_offset_1": 55,
+        "x_offset_2": 242,
+        "y_offset_2": 55,
+        "x_offset_3": 0,
+        "y_offset_3": 0,
+        "x_offset_4": 0,
+        "y_offset_4": 0,
+        "x_offset_5": 0,
+        "y_offset_5": 0,
+        "x_offset_6": 0,
+        "y_offset_6": 0
+      }
+    ]
+  },    
+  {
+    "ref": "item-door.welcomecenterint", 
+    "mods": [
+      {
+        "orientation": 176, 
+        "connection": "context-welcomecenterext", 
+        "y": 32, 
+        "x": 68,
+        "style": 1,		
+        "type": "Door", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": ".", 
+    "in": "context-welcomecenterint"
+  }
+]

--- a/db/Welcome/welcomecenterinthatch.json
+++ b/db/Welcome/welcomecenterinthatch.json
@@ -1,0 +1,85 @@
+[
+  {
+    "capacity": 64, 
+    "mods": [
+      {
+        "town_dir": RIGHT, 
+        "neighbors": [
+          "", 
+          "context-welcomecenterint", 
+          "", 
+          ""
+        ],
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": RIGHT, 
+        "type": "Region"
+      }
+    ], 
+    "ref": "context-welcomecenterinthatch", 
+    "name": "the Welcome Center", 
+    "type": "context"
+  }, 
+  {
+    "type": "item", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 176
+      }
+    ], 
+    "ref": "item-wall.welcomecenterinthatch", 
+    "name": "Wall", 
+    "in": "context-welcomecenterinthatch"
+  }, 
+  {
+    "type": "item", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 56
+      }
+    ], 
+    "ref": "item-ground.welcomecenterinthatch", 
+    "name": "Ground", 
+    "in": "context-welcomecenterinthatch"
+  },
+  {
+    "ref": "item-couch1j8j.welcomecenterinthatch", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 0, 
+        "y": 152, 
+        "x": 4, 
+        "type": "Couch"
+      }
+    ], 
+    "type": "item", 
+    "name": "Couch", 
+    "in": "context-welcomecenterinthatch"
+  },
+  {
+    "ref": "item-couch2h6j.welcomecenterinthatch", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 0, 
+        "y": 152, 
+        "x": 100, 
+        "type": "Couch"
+      }
+    ], 
+    "type": "item", 
+    "name": "Couch", 
+    "in": "context-welcomecenterinthatch"
+  }
+]

--- a/db/Welcome/welcomecenterintvendo.json
+++ b/db/Welcome/welcomecenterintvendo.json
@@ -1,0 +1,475 @@
+[
+  {
+    "capacity": 64, 
+    "mods": [
+      {
+        "town_dir": LEFT, 
+        "neighbors": [
+          "", 
+          "", 
+          "", 
+          "context-welcomecenterint"
+        ],
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": LEFT, 
+        "type": "Region"
+      }
+    ], 
+    "ref": "context-welcomecenterintvendo", 
+    "name": "the Welcome Center", 
+    "type": "context"
+  }, 
+  {
+    "type": "item", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 176
+      }
+    ], 
+    "ref": "item-wall.welcomecenterintvendo", 
+    "name": "Wall", 
+    "in": "context-welcomecenterintvendo"
+  }, 
+  {
+    "type": "item", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 56
+      }
+    ], 
+    "ref": "item-ground.welcomecenterintvendo", 
+    "name": "Ground", 
+    "in": "context-welcomecenterintvendo"
+  },
+  {
+    "ref": "item-gemstone.e77d.welcomecenterintvendo", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 2, 
+        "type": "Gemstone", 
+        "orientation": 0, 
+        "gr_state": 1,
+		"magic_type": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Gemstone", 
+    "in": "item-vendo_front.77de.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-escape_device.b2c7.welcomecenterintvendo", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 1, 
+        "charge": 10, 
+        "type": "Escape_device", 
+        "orientation": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Escape_device", 
+    "in": "item-vendo_front.77de.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-ring.b006.welcomecenterintvendo", 
+    "mods": [
+      {
+        "y": 3, 
+        "x": 3, 
+        "type": "Ring", 
+        "orientation": 0,
+		"magic_type": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Ring", 
+    "in": "item-vendo_front.77de.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-gemstone.69df.welcomecenterintvendo", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 4, 
+        "type": "Gemstone", 
+        "orientation": 8, 
+        "gr_state": 1,
+		"magic_type": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Gemstone", 
+    "in": "item-vendo_front.77de.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-gemstone.3e7e.welcomecenterintvendo", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "type": "Gemstone", 
+        "orientation": 252, 
+        "gr_state": 1,
+		"magic_type": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Gemstone", 
+    "in": "item-vendo_front.77de.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-vendo_front.77de.welcomecenterintvendo", 
+    "mods": [
+      {
+        "display_item": 5, 
+        "orientation": 16, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 0, 
+        "x": 184, 
+        "type": "Vendo_front",
+        "prices": [5000, 1145, 4500, 3200, 8500, 1200],		
+        "open_flags": 0, 
+        "item_price": 1200
+      }
+    ], 
+    "type": "item", 
+    "name": "Vendo_front", 
+    "in": "item-vendo_inside.27d8.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-amulet.e89e.welcomecenterintvendo", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 1, 
+        "type": "Amulet", 
+        "orientation": 0,
+		"magic_type": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Amulet", 
+    "in": "item-vendo_inside.27d8.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-vendo_inside.27d8.welcomecenterintvendo", 
+    "mods": [
+      {
+        "orientation": 164, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 24, 
+        "x": 4, 
+        "type": "Vendo_inside", 
+        "open_flags": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Vendo_inside", 
+    "in": "context-welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-crystal_ball.2941.welcomecenterintvendo", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 1, 
+        "type": "Crystal_ball", 
+        "orientation": 0, 
+        "gr_state": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Crystal_ball", 
+    "in": "item-vendo_front.522d.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-magic_lamp.f831.welcomecenterintvendo", 
+    "mods": [
+      {
+        "y": 2, 
+        "x": 2, 
+        "type": "Magic_lamp", 
+        "orientation": 0,
+		"magic_type": 11
+      }
+    ], 
+    "type": "item", 
+    "name": "Magic_lamp", 
+    "in": "item-vendo_front.522d.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-magic_staff.591d.welcomecenterintvendo", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "type": "Magic_staff", 
+        "orientation": 0,
+		"magic_type": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Magic_staff", 
+    "in": "item-vendo_front.522d.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-vendo_front.522d.welcomecenterintvendo", 
+    "mods": [
+      {
+        "display_item": 3, 
+        "orientation": 16, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 0, 
+        "x": 181, 
+        "type": "Vendo_front",
+        "prices": [999, 30000, 1495, 1800],		
+        "open_flags": 0, 
+        "item_price": 1800
+      }
+    ], 
+    "type": "item", 
+    "name": "Vendo_front", 
+    "in": "item-vendo_inside.9a50.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-magic_wand.b4e9.welcomecenterintvendo", 
+    "mods": [
+      {
+        "y": 1, 
+        "x": 1, 
+        "type": "Magic_wand", 
+        "orientation": 0,
+		"magic_type": 1
+      }
+    ], 
+    "type": "item", 
+    "name": "Magic_wand", 
+    "in": "item-vendo_inside.9a50.welcomecenterintvendo"
+  }, 
+  {
+    "ref": "item-vendo_inside.9a50.welcomecenterintvendo", 
+    "mods": [
+      {
+        "orientation": 188, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 24, 
+        "x": 116, 
+        "type": "Vendo_inside", 
+        "open_flags": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Vendo_inside", 
+    "in": "context-welcomecenterintvendo"
+  },
+  {
+    "ref": "item-sign1.d8k3.welcomecenterintvendo", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "type": "Sign", 
+        "gr_state": 1, 
+        "y": 107, 
+        "x": 8, 
+        "ascii": [
+          131,
+          32,		  
+          72,
+		  101,
+		  97,
+		  100,
+		  115,
+          32,
+          32,
+          32,		  
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32,		  
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32,
+          32,
+          32,		  
+          78,
+		  105,
+		  99,
+		  107,
+		  110,
+		  97,
+		  99,
+		  107,
+		  115, 
+          32, 
+          32, 
+          32, 
+          32
+        ]
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-welcomecenterintvendo"
+  },
+  {
+    "ref": "item-sign2.d3k1.welcomecenterintvendo", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 216, 
+        "ascii": [
+          133, 
+          129,
+          130,
+		  131,
+		  132,
+		  32,
+          86,
+		  101,
+		  110,
+		  100,
+		  105,
+		  110,
+		  103,
+		  32,
+		  77,
+		  97,
+		  99,
+		  104,
+		  105,
+		  110,
+		  101,
+		  115
+        ], 
+        "gr_state": 4, 
+        "y": 118, 
+        "x": 8, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-welcomecenterintvendo"
+  },
+  {
+    "ref": "item-sign3.g5p3.welcomecenterintvendo", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 216, 
+        "ascii": [
+          77,
+		  111,
+		  118,
+		  101,
+		  32,
+		  121,
+		  111,
+		  117,
+		  114,
+		  32,
+		  99,
+		  117,
+		  114,
+		  115,
+		  111,
+		  114,
+		  134,
+		  32,
+		  111,
+		  110,
+		  116,
+		  111,
+		  32,
+		  116,
+		  104,
+		  101,
+		  32,
+		  118,
+		  101,
+		  110,
+		  100,
+		  111
+        ], 
+        "gr_state": 4, 
+        "y": 81, 
+        "x": 48, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-welcomecenterintvendo"
+  },
+  {
+    "ref": "item-sign4.l6k3.welcomecenterintvendo", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 216, 
+        "ascii": [
+		  32,
+		  32,
+          97,
+		  110,
+		  100,
+		  32,
+		  112,
+		  114,
+		  101,
+		  115,
+		  115,
+		  32,
+		  70,
+		  55,
+		  134,
+		  32,
+		  32,
+		  32,
+		  32,
+		  102,
+		  111,
+		  114,
+		  32,
+		  104,
+		  101,
+		  108,
+		  112
+        ], 
+        "gr_state": 4, 
+        "y": 65, 
+        "x": 48, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-welcomecenterintvendo"
+  }
+]

--- a/db/Woods/Woods_5x.json
+++ b/db/Woods/Woods_5x.json
@@ -12,7 +12,7 @@
           "context-Woods_5y", 
           "context-Popustop.aprominade2.line1107",
           "context-beach_2f", 
-          "context-Downtown_7f"
+          "context-welcomecenterext"
         ], 
         "orientation": 0, 
         "nitty_bits": 1, 

--- a/db/new_Downtown/Downtown_2c.json
+++ b/db/new_Downtown/Downtown_2c.json
@@ -12,7 +12,7 @@
         "orientation": 0,		
         "neighbors": [
           "",
-          "context-Downtown_3c", 
+          "context-sheriff_front", 
           "",
           ""
         ], 

--- a/db/new_Downtown/Downtown_3b.json
+++ b/db/new_Downtown/Downtown_3b.json
@@ -12,7 +12,7 @@
         "type": "Region",
         "orientation": 3,		
         "neighbors": [
-          "context-Downtown_3c",
+          "context-sheriff_front",
           "context-Downtown_4b", 
           "", 
           ""         

--- a/db/new_Downtown/Downtown_3c.json
+++ b/db/new_Downtown/Downtown_3c.json
@@ -11,10 +11,10 @@
         "type": "Region",
         "orientation": 0,
         "neighbors": [
-          "context-Downtown_3d",
-          "context-Downtown_4c",
-          "context-Downtown_3b",
-          "context-Downtown_2c"
+          "",
+          "",
+          "",
+          ""
         ], 
         "nitty_bits": 3
       }

--- a/db/new_Downtown/Downtown_3d.json
+++ b/db/new_Downtown/Downtown_3d.json
@@ -13,7 +13,7 @@
         "neighbors": [
           "context-Downtown_3e",
           "context-Downtown_4d",
-          "context-Downtown_3c",
+          "context-sheriff_front",
           "context-Downtown_2d"
         ], 
         "nitty_bits": 3

--- a/db/new_Downtown/Downtown_3h.json
+++ b/db/new_Downtown/Downtown_3h.json
@@ -12,7 +12,7 @@
         "orientation": 0,		
         "neighbors": [
           "context-Downtown_3i",   
-          "context-Downtown_4h",
+          "context-holy_walnut_front",
           "context-Downtown_3g", 
           "context-Downtown_1h"
         ], 

--- a/db/new_Downtown/Downtown_3i.json
+++ b/db/new_Downtown/Downtown_3i.json
@@ -11,7 +11,7 @@
         "type": "Region",
         "orientation": 0,
         "neighbors": [
-          "context-Downtown_3j",
+          "context-rant_front",
           "",
           "context-Downtown_3h",
           "context-Downtown_2i"

--- a/db/new_Downtown/Downtown_3j.json
+++ b/db/new_Downtown/Downtown_3j.json
@@ -9,8 +9,8 @@
         "town_dir": "", 
         "neighbors": [
           "", 
-          "context-Downtown_4j", 
-          "context-Downtown_3i", 
+          "", 
+          "", 
           ""
         ], 
         "orientation": 1, 

--- a/db/new_Downtown/Downtown_4g.json
+++ b/db/new_Downtown/Downtown_4g.json
@@ -11,7 +11,7 @@
         "type": "Region",
         "orientation": 0,		
         "neighbors": [
-          "context-Downtown_4h", 
+          "context-holy_walnut_front", 
           "context-Downtown_5g", 
           "context-Downtown_4f", 
           "context-Downtown_3g"

--- a/db/new_Downtown/Downtown_4h.json
+++ b/db/new_Downtown/Downtown_4h.json
@@ -11,10 +11,10 @@
         "type": "Region",
         "orientation": 1,		
         "neighbors": [
-          "context-Downtown_4i",
-          "context-Downtown_5h",
-          "context-Downtown_4g",
-          "context-Downtown_3h"
+          "",
+          "",
+          "",
+          ""
         ], 
         "nitty_bits": 3
       }

--- a/db/new_Downtown/Downtown_4j.json
+++ b/db/new_Downtown/Downtown_4j.json
@@ -11,7 +11,7 @@
           "context-Downtown_4k", 
           "context-Downtown_5j", 
           "", 
-          "context-Downtown_3j"
+          "context-rant_front"
         ], 
         "orientation": 1, 
         "nitty_bits": 3, 

--- a/db/new_Downtown/Downtown_5h.json
+++ b/db/new_Downtown/Downtown_5h.json
@@ -14,7 +14,7 @@
           "context-Downtown_5i",
           "context-Downtown_6h", 
           "context-Downtown_5g",
-          "context-Downtown_4h"
+          "context-holy_walnut_front"
         ], 
         "nitty_bits": 3
       }

--- a/db/new_Downtown/Downtown_6h.json
+++ b/db/new_Downtown/Downtown_6h.json
@@ -97,7 +97,7 @@
       {
         "y": 33, 
         "x": 68, 
-        "open_flags": 0, 
+        "open_flags": 2, 
         "type": "Door", 
         "orientation": 220,
 		"connection": "context-Downtown_6i"

--- a/db/new_Downtown/Downtown_6i.json
+++ b/db/new_Downtown/Downtown_6i.json
@@ -1,0 +1,289 @@
+[
+  {
+    "ref": "context-Downtown_6i", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "City Hall interior", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "neighbors": [
+          "", 
+          "", 
+          "context-Downtown_6h", 
+          ""
+        ], 
+        "orientation": 1, 
+        "nitty_bits": 3, 
+        "port_dir": "", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.8661.Downtown_6i", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 228
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-Downtown_6i"
+  }, 
+  {
+    "ref": "item-Super_trapezoid.c263.Downtown_6i", 
+    "mods": [
+      {
+        "pattern_x_size": 1, 
+        "lower_right_x": 0, 
+        "upper_left_x": 96, 
+        "pattern": [
+          170, 
+          170, 
+          149, 
+          85, 
+          149, 
+          85, 
+          149, 
+          85, 
+          149, 
+          85, 
+          149, 
+          85, 
+          149, 
+          85, 
+          149, 
+          85, 
+          170, 
+          170, 
+          85, 
+          149, 
+          85, 
+          149, 
+          85, 
+          149, 
+          85, 
+          149, 
+          85, 
+          149, 
+          85, 
+          149, 
+          85, 
+          149
+        ], 
+        "upper_right_x": 255, 
+        "lower_left_x": 96, 
+        "trapezoid_type": 1, 
+        "y": 1, 
+        "x": 160, 
+        "height": 127, 
+        "type": "Super_trapezoid", 
+        "pattern_y_size": 15, 
+        "orientation": 220
+      }
+    ], 
+    "type": "item", 
+    "name": "Super_trapezoid", 
+    "in": "context-Downtown_6i"
+  }, 
+  {
+    "ref": "item-Sign.7316.Downtown_6i", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "type": "Sign", 
+        "gr_state": 5, 
+        "y": 126, 
+        "x": 12, 
+        "ascii": [
+          131, 
+          133, 
+          32, 
+          65, 
+          108, 
+          108, 
+          32, 
+          102, 
+          111, 
+          114, 
+          109, 
+          115, 
+          32, 
+          77, 
+          85, 
+          83, 
+          84, 
+          134, 
+          98, 
+          101, 
+          32, 
+          105, 
+          110, 
+          32, 
+          116, 
+          114, 
+          105, 
+          112, 
+          108, 
+          105, 
+          99, 
+          97, 
+          116, 
+          101, 
+          46, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ]
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-Downtown_6i"
+  }, 
+  {
+    "ref": "item-Sign.717d.Downtown_6i", 
+    "mods": [
+      {
+        "orientation": 0, 
+        "type": "Sign", 
+        "gr_state": 3, 
+        "y": 8, 
+        "x": 8, 
+        "ascii": [
+          80, 
+          114, 
+          111, 
+          112, 
+          101, 
+          114, 
+          116, 
+          121, 
+          32, 
+          32, 
+          32, 
+          32, 
+          76, 
+          105, 
+          99, 
+          101, 
+          110, 
+          115, 
+          101, 
+          115, 
+          32, 
+          32, 
+          32, 
+          32, 
+          67, 
+          111, 
+          109, 
+          112, 
+          108, 
+          97, 
+          105, 
+          110, 
+          116, 
+          115, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32, 
+          32
+        ]
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-Downtown_6i"
+},
+	{
+		"type": "item",
+		"ref": "item-Downtown_6i.bureaucrat1",
+		"name": "Bureaucrat",
+		"in": "context-Downtown_6i",
+		"mods": [ {
+			"type" : "Bureaucrat",
+			"x": 16, 
+			"y": 145,
+			"gr_state" : 0,
+			"style" : 0,
+			"orientation" : 48
+    } ]
+},
+{
+		"type": "item",
+		"ref": "item-Downtown_6i.head1.bureaucrat",
+		"name": "Head",
+		"in": "item-Downtown_6i.bureaucrat1",
+		"mods": [ {
+			"type": "Head",
+			"style": 86,
+			"y": 0,
+			"orientation": 0,
+			"gr_state": 1
+    } ]
+},
+	{
+		"type": "item",
+		"ref": "item-Downtown_6i.bureaucrat2",
+		"name": "Bureaucrat",
+		"in": "context-Downtown_6i",
+		"mods": [ {
+			"type" : "Bureaucrat",
+			"x": 64, 
+			"y": 145,
+			"gr_state" : 0,
+			"style" : 0,
+			"orientation" : 56
+    } ]
+},
+{
+		"type": "item",
+		"ref": "item-Downtown_6i.head2.bureaucrat",
+		"name": "Head",
+		"in": "item-Downtown_6i.bureaucrat2",
+		"mods": [ {
+			"type": "Head",
+			"style": 64,
+			"y": 0,
+			"orientation": 0,
+			"gr_state": 1
+    } ]
+},
+	{
+		"type": "item",
+		"ref": "item-Downtown_6i.bureaucrat3",
+		"name": "Bureaucrat",
+		"in": "context-Downtown_6i",
+		"mods": [ {
+			"type" : "Bureaucrat",
+			"x": 116, 
+			"y": 145,
+			"gr_state" : 0,
+			"style" : 0,
+			"orientation" : 40
+    } ]
+},
+{
+		"type": "item",
+		"ref": "item-Downtown_6i.head3.bureaucrat",
+		"name": "Head",
+		"in": "item-Downtown_6i.bureaucrat3",
+		"mods": [ {
+			"type": "Head",
+			"style": 6,
+			"y": 0,
+			"orientation": 0,
+			"gr_state": 1
+    } ]
+}
+]

--- a/db/new_Downtown/Downtown_7f.json
+++ b/db/new_Downtown/Downtown_7f.json
@@ -12,7 +12,7 @@
 				"orientation": 0,
 				"neighbors": [
 					"context-Downtown_7g",
-					"context-Woods_5x", 
+					"context-welcomecenterext", 
 					"context-Downtown_7e", 
 					"context-Downtown_6f"
 					], 

--- a/db/new_Downtown/holy_walnut_front.json
+++ b/db/new_Downtown/holy_walnut_front.json
@@ -1,0 +1,257 @@
+[
+  {
+	"ref": "context-holy_walnut_front",
+	"capacity": 64,
+    "type": "context",
+    "name": "The Order of the Holy Walnut",
+    "mods": [
+      {
+        "town_dir": "",
+        "port_dir": DOWN,
+        "type": "Region",
+		"orientation": 1,
+        "neighbors": [
+          "context-holy_walnut_int",
+          "context-Downtown_5h",
+          "context-Downtown_4g",
+          "context-Downtown_3h"
+        ],
+		"nitty_bits": 3
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-ground.holy_walnut_front",
+    "in": "context-holy_walnut_front",
+    "name": "Ground",
+    "mods": [
+      {
+        "type": "Ground",
+        "x": 0,
+        "y": 4,
+        "orientation": 220,
+        "style": 1
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-wall.holy_walnut_front",
+    "in": "context-holy_walnut_front",
+    "name": "Wall",
+    "mods": [
+      {
+        "type": "Wall",
+        "x": 0,
+        "y": 0,
+        "orientation": 140,
+        "style": 4
+      }
+    ]
+  },
+{
+	"type": "item",
+	"ref": "item-sign1.holy_walnut_front",
+	"name": "Holy Walnut Sign",
+	"in": "context-holy_walnut_front",
+	"mods": [
+		{
+			"type": "Sign",
+			"style": 0,
+			"x": 0,
+			"y": 19,
+			"orientation": 0,
+			"gr_state": 1,
+			"ascii": [
+			133,
+            79,
+			114,
+			100,
+			101,
+			114,
+			133,
+			32,
+			111,
+			102,
+			32,
+			116,
+			104,
+			101,
+			32,
+			133,
+			72,
+			111,
+			108,
+			121,
+			133,
+			32,
+			133,
+			87,
+			97,
+			108,
+			110,
+			117,
+			116
+			]
+		}
+	]
+},
+{
+  "type": "item",
+  "ref": "item-window1.holy_walnut_front",
+  "name": "Window 1",
+  "in": "context-holy_walnut_front",
+  "mods": [
+    {
+      "type": "Window",
+      "style": 1,
+      "x": 144,
+      "y": 39,
+      "orientation": 0,
+      "gr_state": 0,
+	  "gr_width": 20
+    }
+  ]
+},
+{
+  "type": "item",
+  "ref": "item-window2.holy_walnut_front",
+  "name": "Window 2",
+  "in": "context-holy_walnut_front",
+  "mods": [
+    {
+      "type": "Window",
+      "style": 1,
+      "x": 44,
+      "y": 59,
+      "orientation": 0,
+      "gr_state": 0,
+	  "gr_width": 20
+    }
+  ]
+},
+{
+  "type": "item",
+  "ref": "item-door.holy_walnut_front",
+  "name": "Door to the Holy Walnut",
+  "in": "context-holy_walnut_front",
+  "mods": [
+    {
+      "type": "Door",
+      "style": 1,
+      "x": 84,
+      "y": 32,
+      "orientation": 205,
+      "gr_state": 0,
+      "open_flags": 2,
+      "connection": "context-holy_walnut_int"
+    }
+  ]
+},
+{
+  "type": "item",
+  "ref": "item-window3.holy_walnut_front",
+  "name": "Window 3",
+  "in": "context-holy_walnut_front",
+  "mods": [
+    {
+      "type": "Window",
+      "style": 1,
+      "x": 120,
+      "y": 49,
+      "orientation": 0,
+      "gr_state": 0,
+	  "gr_width": 20
+    }
+  ]
+},
+{
+	"type": "item",
+	"ref": "item-street.holy_walnut_front",
+	"name": "Street",
+	"in": "context-holy_walnut_front",
+	"mods": [
+		{
+			"type": "Street",
+			"style": 0,
+			"x": 68,
+			"y": 7,
+			"orientation": 16,
+			"gr_state": 13
+		}
+	]
+},
+{
+  "type": "item",
+  "ref": "item-window4.holy_walnut_front",
+  "name": "Window 4",
+  "in": "context-holy_walnut_front",
+  "mods": [
+    {
+      "type": "Window",
+      "style": 1,
+      "x": 20,
+      "y": 49,
+      "orientation": 0,
+      "gr_state": 0,
+	  "gr_width": 20
+    }
+  ]
+},
+{
+  "type": "item",
+  "ref": "item-window5.holy_walnut_front",
+  "name": "Window 5",
+  "in": "context-holy_walnut_front",
+  "mods": [
+    {
+      "type": "Window",
+      "style": 1,
+      "x": 96,
+      "y": 59,
+      "orientation": 0,
+      "gr_state": 0,
+	  "gr_width": 20
+    }
+  ]
+},
+{
+  "type": "item",
+  "ref": "item-window6.holy_walnut_front",
+  "name": "Window 6",
+  "in": "context-holy_walnut_front",
+  "mods": [
+    {
+      "type": "Window",
+      "style": 1,
+      "x": 252,
+      "y": 39,
+      "orientation": 0,
+      "gr_state": 0,
+	  "gr_width": 20
+    }
+  ]
+},
+{
+	"type": "item",
+	"ref": "item-shortsign.holy_walnut_front",
+	"name": "Holy Walnut Sign",
+	"in": "context-holy_walnut_front",
+	"mods": [
+		{
+			"type": "Short_sign",
+			"style": 0,
+			"x": 76,
+			"y": 122,
+			"gr_state": 1,
+			"orientation": 0,
+			"ascii": [
+			133,
+			131,
+			28
+			]
+		}
+	]
+}
+]

--- a/db/new_Downtown/holy_walnut_int.json
+++ b/db/new_Downtown/holy_walnut_int.json
@@ -1,0 +1,257 @@
+[
+  {
+	"ref": "context-holy_walnut_int",
+	"capacity": 64,
+    "type": "context",
+    "name": "The Order of the Holy Walnut",
+    "mods": [
+      {
+        "town_dir": "",
+        "port_dir": DOWN,
+        "type": "Region",
+		"orientation": 1,
+        "neighbors": [
+          "",
+          "",
+          "context-holy_walnut_front",
+          ""
+        ],
+		"nitty_bits": 3
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-ground.holy_walnut_int",
+    "in": "context-holy_walnut_int",
+    "name": ".",
+    "mods": [
+      {
+        "type": "Ground",
+        "x": 0,
+        "y": 4,
+        "orientation": 112,
+        "style": 1
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-trap1.holy_walnut_int",
+    "in": "context-holy_walnut_int",
+    "name": "Trapezoid 1",
+    "mods": [
+      {
+        "type": "Trapezoid",
+        "x": 8,
+        "y": 30,
+        "orientation": 48,
+        "trapezoid_type": 0,
+        "upper_left_x": 0,
+        "upper_right_x": 19,
+        "lower_left_x": 0,
+        "lower_right_x": 19,
+        "height": 168
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-wall.holy_walnut_int",
+    "in": "context-holy_walnut_int",
+    "name": "Wall",
+    "mods": [
+      {
+        "type": "Wall",
+        "x": 0,
+        "y": 0,
+        "orientation": 204,
+        "style": 4
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-glue.holy_walnut_int",
+    "in": "context-holy_walnut_int",
+    "name": "Glue",
+    "mods": [
+      {
+        "type": "Glue",
+        "x": 44,
+        "y": 70,
+        "gr_state": 1,
+		"open_flags": 3,
+        "x_offset_1": 245,
+        "y_offset_1": 0,
+        "x_offset_2": 20,
+        "y_offset_2": 0,
+        "x_offset_3": 5,
+        "y_offset_3": 227,
+        "x_offset_4": 4,
+        "y_offset_4": 239,
+        "x_offset_5": 0,
+        "y_offset_5": 0,
+        "x_offset_6": 0,
+        "y_offset_6": 0
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-chair1.holy_walnut_int",
+    "name": "Chair 1",
+    "in": "context-holy_walnut_int",
+    "mods": [
+    {
+        "type": "Chair",
+        "style": 1,
+        "x": 132,
+        "y": 128,
+        "orientation": 245,
+		"open_flags": 3,
+        "gr_width": 24
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-chair2.holy_walnut_int",
+    "name": "Chair 2",
+    "in": "context-holy_walnut_int",
+    "mods": [
+    {
+        "type": "Chair",
+        "style": 1,
+        "x": 104,
+        "y": 135,
+        "orientation": 17,
+		"open_flags": 3,
+        "gr_width": 24
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-chair3.holy_walnut_int",
+    "name": "Chair 3",
+    "in": "context-holy_walnut_int",
+    "mods": [
+    {
+        "type": "Chair",
+        "style": 1,
+        "x": 8,
+        "y": 128,
+        "orientation": 244,
+		"open_flags": 3,
+        "gr_width": 24
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-chair4.holy_walnut_int",
+    "name": "Chair 4",
+    "in": "context-holy_walnut_int",
+    "mods": [
+    {
+        "type": "Chair",
+        "style": 1,
+        "x": 36,
+        "y": 134,
+        "orientation": 16,
+		"open_flags": 3,
+        "gr_width": 24
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-trap2.holy_walnut_int",
+    "in": "context-holy_walnut_int",
+    "name": "Trapezoid 2",
+    "mods": [
+      {
+        "type": "Trapezoid",
+        "x": 132,
+        "y": 30,
+        "orientation": 48,
+        "trapezoid_type": 0,
+        "upper_left_x": 0,
+        "upper_right_x": 19,
+        "lower_left_x": 0,
+        "lower_right_x": 19,
+        "height": 168
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-knick_knack1.holy_walnut_int",
+    "in": "item-glue.holy_walnut_int",
+    "name": "Knicknack 1",
+    "mods": [
+      {
+        "type": "Knick_knack",
+        "y": 0,
+		"gr_width": 3,
+        "orientation": 48
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-knick_knack2.holy_walnut_int",
+    "in": "item-glue.holy_walnut_int",
+    "name": "Knicknack 2",
+    "mods": [
+      {
+        "type": "Knick_knack",
+        "y": 1,
+		"gr_width": 3,
+        "orientation": 48
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-trap3.holy_walnut_int",
+    "in": "context-holy_walnut_int",
+    "name": "Trapezoid 3",
+    "mods": [
+      {
+        "type": "Trapezoid",
+        "x": 68,
+        "y": 144,
+        "orientation": 236,
+        "trapezoid_type": 0,
+        "upper_left_x": 0,
+        "upper_right_x": 19,
+        "lower_left_x": 0,
+        "lower_right_x": 19,
+        "height": 168
+      }
+    ]
+  },
+  {
+	"type": "item",
+	"ref": "item-shortsign.holy_walnut_int",
+	"name": "Holy Walnut Sign",
+	"in": "context-holy_walnut_int",
+	"mods": [
+		{
+			"type": "Short_sign",
+			"style": 0,
+			"x": 72,
+			"y": 122,
+			"gr_state": 1,
+			"orientation": 0,
+			"ascii": [
+			133,
+			131,
+			28
+			]
+		}
+	]
+  }
+]

--- a/db/new_Downtown/item-Downtown.plaque.json
+++ b/db/new_Downtown/item-Downtown.plaque.json
@@ -94,5 +94,21 @@
         "path" : "text-teleporterhelp"
       } 
     ]
+  },
+  {
+    "type" : "item",
+    "ref" : "item-welcomecenter.plaque1",
+    "name" : "Welcome Center Plaque",
+    "in" : "context-welcomecenterext",
+    "mods" : [ 
+      {
+        "type" : "Plaque",
+        "x" : 100,
+        "y" : 66,
+        "style": 2, 
+        "last_page" : 2,
+        "path" : "text-welcomecenterext"
+      } 
+    ]
   }
 ]     

--- a/db/new_Downtown/rant_front.json
+++ b/db/new_Downtown/rant_front.json
@@ -1,0 +1,207 @@
+[
+  {
+	"ref": "context-rant_front",
+	"capacity": 64,
+    "type": "context",
+    "name": "Rant N Rave Inc",
+    "mods": [
+      {
+        "town_dir": "",
+        "port_dir": LEFT,
+        "type": "Region",
+		"orientation": 1,
+        "neighbors": [
+          "",
+          "context-Downtown_4j",
+          "context-Downtown_3i",
+          ""
+        ],
+		"nitty_bits": 3
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-wall.rant_front",
+    "in": "context-rant_front",
+    "name": "Wall",
+    "mods": [
+      {
+        "type": "Wall",
+        "x": 0,
+        "y": 0,
+        "orientation": 204,
+        "style": 5
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-ground.rant_front",
+    "in": "context-rant_front",
+    "name": "Ground",
+    "mods": [
+      {
+        "type": "Ground",
+        "x": 0,
+        "y": 4,
+        "orientation": 220,
+        "style": 1
+      }
+    ]
+  },
+{
+  "type": "item",
+  "ref": "item-door.rant_front",
+  "name": "Door to the Rant",
+  "in": "context-rant_front",
+  "mods": [
+    {
+      "type": "Door",
+      "style": 0,
+      "x": 72,
+      "y": 33,
+      "orientation": 244,
+      "gr_state": 0,
+      "open_flags": 2,
+      "connection": "context-rant_int"
+    }
+  ]
+},
+{
+	"type": "item",
+	"ref": "item-shortsign.rant_front",
+	"name": "The Rant Sign",
+	"in": "context-rant_front",
+	"mods": [
+		{
+			"type": "Short_sign",
+			"style": 4,
+			"x": 64,
+			"y": 104,
+			"gr_state": 0,
+			"orientation": 140,
+			"ascii": [
+			32,
+			84,
+			104,
+			101,
+			32,
+			82,
+			65,
+			78,
+			84,
+			32
+			]
+		}
+	]
+},
+{
+	"type": "item",
+	"ref": "item-plaque.rant_front",
+	"name": "Rant Plaque",
+	"in": "context-rant_front",
+	"mods": [
+		{
+			"type": "Plaque",
+			"style": 2,
+			"orientation": 16,
+			"x": 120,
+			"y": 60,
+			"last_page": 1,
+			"path": "text-bookofrecords"
+		}
+	]
+},
+  {
+    "ref": "item-vendo_inside.55d2.rant_front", 
+    "mods": [
+      {
+        "orientation": 8,
+		"style": 1,
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 27, 
+        "x": 20, 
+        "type": "Vendo_inside", 
+        "open_flags": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Vendo_inside", 
+    "in": "context-rant_front"
+  },
+{
+	"type": "item",
+	"ref": "item-street.rant_front",
+	"name": "Sheriffs Office Street",
+	"in": "context-rant_front",
+	"mods": [
+		{
+			"type": "Street",
+			"style": 0,
+			"x": 68,
+			"y": 7,
+			"orientation": 8,
+			"gr_state": 8
+		}
+	]
+},
+  {
+    "ref": "item-vendo_front.0065.rant_front", 
+    "mods": [
+      {
+        "display_item": 1,
+		"style": 1,
+        "orientation": 140, 
+        "key_lo": 0, 
+        "key_hi": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Vendo_front", 
+        "open_flags": 0,
+		"prices": [20, 5],
+        "item_price": 5
+      }
+    ], 
+    "type": "item", 
+    "name": "Vendo_front", 
+    "in": "item-vendo_inside.55d2.rant_front"
+  },
+  {
+    "ref": "item-book.f9k3.rant_front", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 16, 
+        "last_page": 0, 
+        "y": 0, 
+        "x": 0, 
+		"path": "text-weeklyrant.current",
+		"title": "Weekly Rant, Perpetual Current Issue",
+        "type": "Book"
+      }
+    ], 
+    "type": "item", 
+    "name": "Book", 
+    "in": "item-vendo_front.0065.rant_front"
+  },
+  {
+    "ref": "item-book.n49d.rant_front", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 16, 
+        "last_page": 0, 
+        "y": 1, 
+        "x": 1, 
+		"path": "text-weeklyrant.1",
+		"title": "Weekly Rant, Commemorative First Issue",
+        "type": "Book"
+      }
+    ], 
+    "type": "item", 
+    "name": "Book", 
+    "in": "item-vendo_inside.55d2.rant_front"
+  }
+]

--- a/db/new_Downtown/rant_int.json
+++ b/db/new_Downtown/rant_int.json
@@ -1,0 +1,337 @@
+[
+  {
+    "ref": "context-rant_int", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "The Rant Office", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "port_dir": DOWN, 
+        "type": "Region",
+        "orientation": 1,		
+        "neighbors": [
+          "",
+          "",
+          "context-rant_front",
+          ""        
+        ], 
+        "nitty_bits": 3
+      }
+    ]
+  },
+  {
+    "ref": "item-wall.rant_int", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 58
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-rant_int"
+  }, 
+  {
+    "ref": "item-ground.rant_int", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 80
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-chair1.rant_int", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 16,
+        "open_flags": 3,
+        "type": "Chair", 
+        "orientation": 204
+      }
+    ], 
+    "type": "item", 
+    "name": "Chair", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-chair2.rant_int", 
+    "mods": [
+      {
+        "y": 28, 
+        "x": 120,
+        "open_flags": 3,
+        "type": "Chair", 
+        "orientation": 204
+      }
+    ], 
+    "type": "item", 
+    "name": "Chair", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-countertop1.rant_int", 
+    "mods": [
+      {
+        "y": 143, 
+        "x": 10,
+		"open_flags": 3,
+        "type": "Countertop", 
+        "orientation": 252
+      }
+    ], 
+    "type": "item", 
+    "name": "Countertop", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-countertop2.rant_int", 
+    "mods": [
+      {
+        "y": 143, 
+        "x": 108,
+		"open_flags": 3,
+        "type": "Countertop", 
+        "orientation": 252
+      }
+    ], 
+    "type": "item", 
+    "name": "Countertop", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-chest1.rant_int", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 220, 
+        "gr_state": 0, 
+        "y": 27, 
+        "x": 56, 
+        "type": "Chest", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Chest", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-chest2.rant_int", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 220, 
+        "gr_state": 0, 
+        "y": 27, 
+        "x": 80, 
+        "type": "Chest", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Chest", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-chest3.rant_int", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 220, 
+        "gr_state": 0, 
+        "y": 50, 
+        "x": 80, 
+        "type": "Chest", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Chest", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-chest4.rant_int", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 220, 
+        "gr_state": 0, 
+        "y": 50, 
+        "x": 56, 
+        "type": "Chest", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Chest", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-chest5.rant_int", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 220, 
+        "gr_state": 0, 
+        "y": 73, 
+        "x": 56, 
+        "type": "Chest", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Chest", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-chest6.rant_int", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 220, 
+        "gr_state": 0, 
+        "y": 73, 
+        "x": 80, 
+        "type": "Chest", 
+        "open_flags": 2
+      }
+    ], 
+    "type": "item", 
+    "name": "Chest", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-chair3.rant_int", 
+    "mods": [
+      {
+        "y": 133, 
+        "x": 0,
+		"style": 1,
+        "open_flags": 3,
+        "type": "Chair", 
+        "orientation": 204
+      }
+    ], 
+    "type": "item", 
+    "name": "Chair", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-chair4.rant_int", 
+    "mods": [
+      {
+        "y": 133, 
+        "x": 140,
+		"style": 1,
+        "open_flags": 3,
+        "type": "Chair", 
+        "orientation": 205
+      }
+    ], 
+    "type": "item", 
+    "name": "Chair", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-sign1.rant_int", 
+    "mods": [
+      {
+        "orientation": 188, 
+        "type": "Sign",
+        "style": 1,		
+        "gr_state": 1, 
+        "y": 82, 
+        "x": 16, 
+        "ascii": [
+		  32,
+          74,
+		  101,
+		  110,
+		  110,
+		  121,
+		  134,
+		  32,
+		  32,
+		  56,
+		  54,
+		  55,
+		  134,
+		  32,
+		  53,
+		  51,
+		  48,
+		  57
+        ]
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-sign2.rant_int", 
+    "mods": [
+      {
+        "orientation": 244, 
+        "type": "Sign",
+		"style": 1,
+        "gr_state": 1, 
+        "y": 82, 
+        "x": 116, 
+        "ascii": [
+          133,
+		  133,
+		  128,
+		  128,
+		  78,
+		  101,
+		  119,
+		  115,
+		  134,
+		  32,
+		  115,
+		  105,
+		  110,
+		  99,
+		  101,
+		  134,
+		  32,
+		  49,
+		  57,
+		  56,
+		  55
+        ]
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-rant_int"
+  },
+  {
+    "ref": "item-countertop3.rant_int", 
+    "mods": [
+      {
+        "y": 143, 
+        "x": 62,
+		"open_flags": 3,
+        "type": "Countertop", 
+        "orientation": 252
+      }
+    ], 
+    "type": "item", 
+    "name": "Countertop", 
+    "in": "context-rant_int"
+  }
+]

--- a/db/new_Downtown/sheriff_front.json
+++ b/db/new_Downtown/sheriff_front.json
@@ -1,0 +1,178 @@
+[
+  {
+    "type": "context",
+    "ref": "context-sheriff_front",
+    "capacity": 64,
+    "name": "Sheriffs Office",
+    "mods": [
+      {
+        "town_dir": "",
+        "port_dir": LEFT,
+        "type": "Region",
+		"orientation": 0,
+        "nitty_bits": 3,
+        "neighbors": [
+          "context-Downtown_3d",
+          "",
+          "context-Downtown_3b",
+          "context-Downtown_2c"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-wall.sheriff_front",
+    "in": "context-sheriff_front",
+    "name": "Wall",
+    "mods": [
+      {
+        "type": "Wall",
+        "x": 0,
+        "y": 1,
+        "orientation": 204,
+        "style": 6
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-ground.sheriff_front",
+    "in": "context-sheriff_front",
+    "name": "Ground",
+    "mods": [
+      {
+        "type": "Ground",
+        "x": 0,
+        "y": 4,
+        "orientation": 220,
+        "style": 1
+      }
+    ]
+  },
+{
+  "type": "item",
+  "ref": "item-window1.sheriff_front",
+  "name": "Window 1",
+  "in": "context-sheriff_front",
+  "mods": [
+    {
+      "type": "Window",
+      "style": 3,
+      "x": 56,
+      "y": 85,
+      "orientation": 204,
+      "gr_state": 0,
+	  "gr_width": 20
+    }
+  ]
+},
+{
+  "type": "item",
+  "ref": "item-window2.sheriff_front",
+  "name": "Window 2",
+  "in": "context-sheriff_front",
+  "mods": [
+    {
+      "type": "Window",
+      "style": 3,
+      "x": 92,
+      "y": 85,
+      "orientation": 204,
+      "gr_state": 0,
+	  "gr_width": 20
+    }
+  ]
+},
+{
+  "type": "item",
+  "ref": "item-door.sheriff_front",
+  "name": "Door to the Sheriffs Office",
+  "in": "context-sheriff_front",
+  "mods": [
+    {
+      "type": "Door",
+      "style": 0,
+      "x": 16,
+      "y": 33,
+      "orientation": 252,
+      "gr_state": 0,
+      "open_flags": 2,
+      "connection": "context-sheriff_int"
+    }
+  ]
+},
+{
+  "type": "item",
+  "ref": "item-window3.sheriff_front",
+  "name": "Window 3",
+  "in": "context-sheriff_front",
+  "mods": [
+    {
+      "type": "Window",
+      "style": 3,
+      "x": 128,
+      "y": 85,
+      "orientation": 204,
+      "gr_state": 0,
+	  "gr_width": 20
+    }
+  ]
+},
+{
+	"type": "item",
+	"ref": "item-street.sheriff_front",
+	"name": "Street",
+	"in": "context-sheriff_front",
+	"mods": [
+		{
+			"type": "Street",
+			"style": 0,
+			"x": 68,
+			"y": 8,
+			"orientation": 8,
+			"gr_state": 6
+		}
+	]
+},
+{
+	"type": "item",
+	"ref": "item-sign1.sheriff_front",
+	"name": "Populopolis Sheriff Sign",
+	"in": "context-sheriff_front",
+	"mods": [
+		{
+			"type": "Sign",
+			"style": 6,
+			"x": 48,
+			"y": 40,
+			"orientation": 164,
+			"gr_state": 2,
+			"ascii": [
+			80,
+			111,
+			112,
+			117,
+			108,
+			111,
+			112,
+			111,
+			108,
+			105,
+			115,
+			131,
+			134,
+			32,
+			32,
+			83,
+			104,
+			101,
+			114,
+			105,
+			102,
+			102
+			]
+		}
+	]
+}
+]

--- a/db/new_Downtown/sheriff_int.json
+++ b/db/new_Downtown/sheriff_int.json
@@ -1,0 +1,68 @@
+[
+  {
+    "type": "context",
+    "ref": "context-sheriff_int",
+    "capacity": 64,
+    "name": "Sheriffs Office",
+    "mods": [
+      {
+        "town_dir": "",
+        "port_dir": DOWN,
+        "type": "Region",
+		"orientation": 0,
+        "nitty_bits": 3,
+        "neighbors": [
+          "",
+          "context-sheriff_front",
+          "",
+          ""
+        ]
+      }
+    ]
+  },
+  {
+    "type": "item",
+    "ref": "item-ground.sheriff_int",
+    "in": "context-sheriff_int",
+    "name": ".",
+    "mods": [
+      {
+        "type": "Ground",
+        "x": 0,
+        "y": 4,
+        "orientation": 188,
+        "style": 1
+      }
+    ]
+  },
+  {
+    "ref": "item-countertop.sheriff_int", 
+    "mods": [
+      {
+        "y": 144, 
+        "x": 56,
+		"open_flags": 3,
+        "type": "Countertop", 
+        "orientation": 252
+      }
+    ], 
+    "type": "item", 
+    "name": "Countertop", 
+    "in": "context-sheriff_int"
+  },
+  {
+    "type": "item",
+    "ref": "item-wall.sheriff_int",
+    "in": "context-sheriff_int",
+    "name": ".",
+    "mods": [
+      {
+        "type": "Wall",
+        "x": 0,
+        "y": 0,
+        "orientation": 236,
+        "style": 4
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- Added the Church of the Holy Walnut, the Sheriffs office and the Rant office

![walnut](https://user-images.githubusercontent.com/25211663/28992029-084d6652-798a-11e7-8be5-7fc672f557d2.png)

![sheriff](https://user-images.githubusercontent.com/25211663/28992030-0ad2eea6-798a-11e7-978a-09bb3d67c5e1.png)

![rant](https://user-images.githubusercontent.com/25211663/28992032-0e975c3e-798a-11e7-8357-b82a6ca68dfc.png)

- Disconnected Meeting Hall (4h), Geeks Rule (3j) and For Rent (3c)

- Unlocked City Hall and added the interior, complete with Bureaucrats-in-a-box(TM)

![cityhall](https://user-images.githubusercontent.com/25211663/28992033-13a7710a-798a-11e7-8152-e8698c755eac.png)

- Added Welcome center in between broadway cross and woods road (locked whilst the interior is finalized)

![welcome](https://user-images.githubusercontent.com/25211663/28992035-16e30546-798a-11e7-8fc3-889a396bbd7d.png)

- D'nalsi island!
There are still some issues here, specifically lighting levels in caves but I've not encountered anything that causes crashes. I believe D'nalsi to be safe enough to traverse (for now). It would benefit from having live testers to see if they can spot anything though.

Currently, the only way to access D'nalsi island is via teleport address: dnalsi

![dnalsi](https://user-images.githubusercontent.com/25211663/28992037-19d84bc6-798a-11e7-8588-a3cd4b3d7570.png)
