### PR TITLE
Adds the Hand of God

### DIFF
--- a/bridge/Habitat2ElkoBridge.js
+++ b/bridge/Habitat2ElkoBridge.js
@@ -1071,6 +1071,11 @@ var encodeState = {
 			buf.add(state.state || 0);
 			return buf; 
 		},
+		Hand_of_god: function(state, container, buf) {
+			buf = this.common(state, container, buf);
+			buf.add(state.state || 0);
+			return buf; 
+		},
 		Flat: function(state, container, buf) {
 			buf = this.common(state, container, buf);
 			buf.add(state.flat_type || 0);

--- a/bridge/hcode.js
+++ b/bridge/hcode.js
@@ -132,7 +132,11 @@ this.SERVER_OPS = {
 			}
 		},
 		"BEEP$": 				{ reqno: 8 },
-		"BLAST$": 				{ reqno: 8 },
+		"BLAST$": 				{ reqno: 8 
+			//toClient: function (o, b) {
+				//b.add(o.state);
+			//},
+		},
 		"CAUGHT_UP_$":	 		{ reqno: 17,
 			toClient: function (o, b) {
 				b.add(o.err);
@@ -1381,6 +1385,12 @@ this.Hole = {
 			0:{ op:"HELP" },
 			4:{ op:"CLOSECONTAINER" },
 			5:{ op:"OPENCONTAINER" }
+		}
+};
+
+this.Hand_of_god = {
+		clientMessages: {
+			0:{ op:"HELP" }
 		}
 };
 

--- a/bridge/hcode.js
+++ b/bridge/hcode.js
@@ -132,11 +132,7 @@ this.SERVER_OPS = {
 			}
 		},
 		"BEEP$": 				{ reqno: 8 },
-		"BLAST$": 				{ reqno: 8 
-			//toClient: function (o, b) {
-				//b.add(o.state);
-			//},
-		},
+		"BLAST$": 				{ reqno: 8 },
 		"CAUGHT_UP_$":	 		{ reqno: 17,
 			toClient: function (o, b) {
 				b.add(o.err);

--- a/db/classes-habitat.json
+++ b/db/classes-habitat.json
@@ -50,6 +50,7 @@
 		{ "type": "class", "tag": "Ground", "name": "org.made.neohabitat.mods.Ground" },
 		{ "type": "class", "tag": "Gun", "name": "org.made.neohabitat.mods.Gun" },
 		{ "type": "class", "tag": "Head", "name": "org.made.neohabitat.mods.Head" },
+		{ "type": "class", "tag": "Hand_of_god", "name": "org.made.neohabitat.mods.Hand_of_god" },
 		{ "type": "class", "tag": "Hole", "name": "org.made.neohabitat.mods.Hole" },
 		{ "type": "class", "tag": "Hot_tub", "name": "org.made.neohabitat.mods.Hot_tub" },
 		{ "type": "class", "tag": "House_cat", "name": "org.made.neohabitat.mods.House_cat" },

--- a/src/main/java/org/made/neohabitat/HabitatMod.java
+++ b/src/main/java/org/made/neohabitat/HabitatMod.java
@@ -3506,6 +3506,11 @@ public abstract class HabitatMod extends Mod implements HabitatVerbs, ObjectComp
 		context().send(msg);
 	}
 	
+	public void modify_variable(User from, HabitatMod target, int offset, int new_value) {
+		target.gen_flags[MODIFIED] = true;
+		send_fiddle_msg(THE_REGION, target.noid, offset, new_value);
+	}
+	
 	
 	/**
 	 * Pays the provided amount of Tokens to the specified Avatar.

--- a/src/main/java/org/made/neohabitat/Magical.java
+++ b/src/main/java/org/made/neohabitat/Magical.java
@@ -16,9 +16,11 @@ import org.elkoserver.foundation.timer.Timer;
 import org.elkoserver.json.EncodeControl;
 import org.elkoserver.json.JSONLiteral;
 import org.elkoserver.server.context.BasicObject;
+import org.elkoserver.server.context.ContextShutdownWatcher;
 import org.elkoserver.server.context.Contextor;
 import org.elkoserver.server.context.Item;
 import org.elkoserver.server.context.User;
+import org.elkoserver.server.context.UserWatcher;
 import org.made.neohabitat.mods.Avatar;
 import org.made.neohabitat.mods.Game_piece;
 import org.made.neohabitat.mods.Hand_of_god;
@@ -502,6 +504,7 @@ public abstract class Magical extends HabitatMod {
 	static public boolean isGodTool(Magical magic) {
 		return (magic.magic_type == MAGIC_GOD_TOOL);
 	}
+	
 
 	/**
 	 * CALLBACK for the GOD TOOL - it must reconstruct the context for
@@ -654,24 +657,31 @@ public abstract class Magical extends HabitatMod {
 				break;
 			case 'g': // Summons the Hand of God
 			case 'G': // G turns the victim into a ghost
-				String text = request_string.substring(1); 
-				User   victimUser = Region.getUserByName(text);
-				Avatar victim = avatar(victimUser);
-				Region.tellEveryone("The sky begins to turn dark.");
-				Hand_of_god god = new Hand_of_god(0, victim.x, 208, 0, 0, false, 0);
-				Hand_of_god godAnimation = new Hand_of_god(1, victim.x, victim.y, 0, 3, false, 0);
-				Item item = create_object("Hand of God", god, null, true);
-				announce_object(item, victim.current_region());
-				checkpoint_object(god);
-				trace_msg(from.name() + " used the Hand of God on " + victimUser.name());
-				GodTimer gt = new GodTimer(god, godAnimation, victimUser, command);
-				send_broadcast_msg(THE_REGION, "PLAY_$", "sfx_number", 44, "from_noid", noid);
-				break;
+			    for(int i = 1; i <= 255; i++){
+			        HabitatMod obj = current_region().noids[i];
+		            if(obj != null && obj.HabitatClass() == CLASS_HAND_OF_GOD){
+		                object_say(from, "A Hand of God has already been summoned.");
+		                return;       
+		            }
+	           }
+		       String text = request_string.substring(1); 
+		       User   victimUser = Region.getUserByName(text);
+		       Avatar victim = avatar(victimUser);
+		       Region.tellEveryone("The sky begins to turn dark.");
+		       Hand_of_god god = new Hand_of_god(0, victim.x, 208, 0, 0, false, 0);
+		       Hand_of_god godAnimation = new Hand_of_god(1, victim.x, victim.y, 0, 3, false, 0);
+		       Item item = create_object("Hand of God", god, null, true);
+		       announce_object(item, victim.current_region());
+		       checkpoint_object(god);
+		       trace_msg(from.name() + " used the Hand of God on " + victimUser.name());
+		       GodTimer gt = new GodTimer(god, godAnimation, victimUser, command);
+		       break;
 			case 'a': //Allows you to send messages as the Hand of God
-                for(int i = 1; i <= 255; i++){
+                for(int i = 1; i <= 255; i++) {
                     HabitatMod obj = current_region().noids[i];
                     if(obj != null && obj.HabitatClass() == CLASS_HAND_OF_GOD){
-                        object_broadcast(obj.noid, request_string.substring(1)); 
+                        object_broadcast(obj.noid, request_string.substring(1));
+                        break;
                     }
                 }
 			    break;
@@ -810,12 +820,14 @@ public abstract class Magical extends HabitatMod {
 			return (magic_help[magic_type - 1]);
 	}
         
-    private class GodTimer implements TimeoutNoticer, TickNoticer {
+    private class GodTimer implements TimeoutNoticer, TickNoticer, ContextShutdownWatcher, UserWatcher {
+       
         private HabitatMod mod;
         private HabitatMod modAnimation;
         private User victim;
         private char text;
-        private Clock clockTimer = Timer.theTimer().every(3000, this);
+        private boolean didDelete = false;
+        private Clock clockTimer = Timer.theTimer().every(4000, this); //Calls noticeTick every 4 seconds
         
         public GodTimer(HabitatMod mod, HabitatMod modAnimation, User victim, char text) {
                this.mod = mod;
@@ -823,49 +835,97 @@ public abstract class Magical extends HabitatMod {
                this.victim = victim;
                this.text = text;
                clockTimer.start();
+            //   mod.current_region().context().registerContextShutdownWatcher(this);
+            //   mod.current_region().context().registerUserWatcher(this);
+               mod.avatar(victim).current_region().context().registerContextShutdownWatcher(this);
+               mod.avatar(victim).current_region().context().registerUserWatcher(this);
+               
         }
         
         @Override
         public void noticeTimeout() {
-            send_broadcast_msg(THE_REGION, "PLAY_$", "sfx_number", 44, "from_noid", noid);
-            Avatar avatar = avatar(victim);
-            checkpoint_object(avatar);
-            if(text == 'G') {
-            //  avatar.DISCORPORATE(from); Broken?
+            try {
+                Avatar avatar = avatar(victim);
+                checkpoint_object(avatar);
+                if(text == 'G') {
+                    //TODO: Add ghost feature at later date
+                }
+                else
+                    kill_avatar(avatar);
+                trace_msg("Timer has ended.");
+                checkpoint_object(mod);
+                trace_msg("Deleting Hand of God object %s ", mod.object().ref());         
+                send_goaway_msg(mod.noid);
+                destroy_object(mod);
+                didDelete = true;
+                modify_variable(victim, modAnimation, C64_GR_STATE_OFFSET, 1);
+                Head skull = new Head(18, modAnimation.x+2, modAnimation.y+10, 0, 0, false);
+                Item item = create_object("Mistakes were made.", skull, null, false);
+                announce_object(item, avatar.current_region());
+                Region.tellEveryone("The sky is clear again.");
             }
-            else
-                kill_avatar(avatar);
-            trace_msg("Timer has ended.");
-            checkpoint_object(mod);
-            trace_msg("Deleting Hand of God object %s ", mod.object().ref());         
-            send_goaway_msg(mod.noid);
-            destroy_object(mod);
-            modify_variable(victim, modAnimation, C64_GR_STATE_OFFSET, 1);
-            Head skull = new Head(18, modAnimation.x+2, modAnimation.y+10, 0, 0, false);
-            Item item = create_object("Mistakes were made.", skull, null, false);
-            announce_object(item, current_region());
-            Region.tellEveryone("The sky is clear again.");
+            catch (Exception e) {
+                trace_msg("Notice timeout method interupted.");
+            }
         }
 
         @Override
         public void noticeTick(int ticks) {
-            Avatar avatar = avatar(victim);
-            trace_msg("Ticks: " + ticks);
-            if(avatar.x != mod.x) {
-               modify_variable(victim, mod, C64_XPOS_OFFSET, avatar.x+24);
-            }
-            switch(ticks){
-            case 1:
-                object_broadcast(mod.noid, "Thou shalt pay, " + victim.name() + "!");    
-                break;
-            case 6:
+            try {  
+                Avatar avatar = avatar(victim);
+                trace_msg("Ticks: " + ticks);
+                if(avatar.x != mod.x) { // Only update the HoG if the avatar has moved
+                    modify_variable(victim, mod, C64_XPOS_OFFSET, avatar.x+24);
+                }   
+                switch(ticks) {
+                case 1:
+                    object_broadcast(mod.noid, "Thou shalt pay, " + victim.name() + "!");    
+                    break;
+                case 2:
+                    send_broadcast_msg(THE_REGION, "PLAY_$", "sfx_number", 44, "from_noid", noid);
+                    break;
+                case 15:
+                    clockTimer.stop();
+                    send_broadcast_msg(avatar.noid, "POSTURE$", "new_posture", GET_SHOT_POSTURE);
+                    Item newitem = create_object("Hand of God Animation", modAnimation, null, true);
+                    announce_object(newitem, avatar.current_region());
+                    Timer.theTimer().after(5000*2, this);
+                    break;
+                }
+          }
+          catch (Exception e) {
+                trace_msg("Notice tick interrupted.");
                 clockTimer.stop();
-                send_broadcast_msg(avatar.noid, "POSTURE$", "new_posture", GET_SHOT_POSTURE);
-                Item newitem = create_object("Hand of God Animation", modAnimation, null, true);
-                announce_object(newitem, avatar.current_region());
-                Timer.theTimer().after(5000*2, this);
-                break;
             }
-        } 
+       }
+
+        @Override
+        public void noteContextShutdown() {
+            clockTimer.stop();
+            trace_msg("Context shutdown" + current_region().obj_id() + " with Hand of God.");         
+            if (didDelete == false) {
+                trace_msg("Cleaning up Hand of God object %s ", mod.object().ref());         
+                //send_goaway_msg(mod.noid); Causing issues?
+                destroy_object(mod);
+                didDelete = true;           
+            }
+        }
+
+        @Override
+        public void noteUserArrival(User who) {
+            trace_msg(who.name() + " has entered while a Hand of God was activated.");
+        }
+
+        @Override
+        public void noteUserDeparture(User who) {
+            trace_msg(who.name() + " has left while a Hand of God was activated.");  
+            clockTimer.stop();
+            if (didDelete == false) {
+                trace_msg("Deleting Hand of God object %s ", mod.object().ref());         
+              //send_goaway_msg(mod.noid);
+                destroy_object(mod);
+                didDelete = true;
+            }           
+        }
     }
 }

--- a/src/main/java/org/made/neohabitat/Magical.java
+++ b/src/main/java/org/made/neohabitat/Magical.java
@@ -835,8 +835,6 @@ public abstract class Magical extends HabitatMod {
                this.victim = victim;
                this.text = text;
                clockTimer.start();
-            //   mod.current_region().context().registerContextShutdownWatcher(this);
-            //   mod.current_region().context().registerUserWatcher(this);
                mod.avatar(victim).current_region().context().registerContextShutdownWatcher(this);
                mod.avatar(victim).current_region().context().registerUserWatcher(this);
                
@@ -884,7 +882,7 @@ public abstract class Magical extends HabitatMod {
                 case 2:
                     send_broadcast_msg(THE_REGION, "PLAY_$", "sfx_number", 44, "from_noid", noid);
                     break;
-                case 15:
+                case 3:
                     clockTimer.stop();
                     send_broadcast_msg(avatar.noid, "POSTURE$", "new_posture", GET_SHOT_POSTURE);
                     Item newitem = create_object("Hand of God Animation", modAnimation, null, true);
@@ -892,20 +890,21 @@ public abstract class Magical extends HabitatMod {
                     Timer.theTimer().after(5000*2, this);
                     break;
                 }
-          }
-          catch (Exception e) {
+            } 
+            catch (Exception e) {
                 trace_msg("Notice tick interrupted.");
                 clockTimer.stop();
             }
        }
 
+        
         @Override
         public void noteContextShutdown() {
             clockTimer.stop();
-            trace_msg("Context shutdown" + current_region().obj_id() + " with Hand of God.");         
+            trace_msg("Context shutdown with Hand of God.");         
             if (didDelete == false) {
                 trace_msg("Cleaning up Hand of God object %s ", mod.object().ref());         
-                //send_goaway_msg(mod.noid); Causing issues?
+                mod.send_goaway_msg(mod.noid);
                 destroy_object(mod);
                 didDelete = true;           
             }
@@ -913,16 +912,16 @@ public abstract class Magical extends HabitatMod {
 
         @Override
         public void noteUserArrival(User who) {
-            trace_msg(who.name() + " has entered while a Hand of God was activated.");
+            
         }
 
+        //If the victim leaves the region, stop the timer and delete the HoG
         @Override
-        public void noteUserDeparture(User who) {
-            trace_msg(who.name() + " has left while a Hand of God was activated.");  
+        public void noteUserDeparture(User who) { 
             clockTimer.stop();
             if (didDelete == false) {
                 trace_msg("Deleting Hand of God object %s ", mod.object().ref());         
-              //send_goaway_msg(mod.noid);
+                mod.send_goaway_msg(mod.noid);
                 destroy_object(mod);
                 didDelete = true;
             }           

--- a/src/main/java/org/made/neohabitat/Magical.java
+++ b/src/main/java/org/made/neohabitat/Magical.java
@@ -666,7 +666,7 @@ public abstract class Magical extends HabitatMod {
 				trace_msg(from.name() + " used the Hand of God on " + victimUser.name());
 				object_broadcast(noid, "Thou shalt pay, " + victimUser.name() + "!");
 				GodTimer gt = new GodTimer(god, godAnimation, victimUser, command);
-                send_broadcast_msg(THE_REGION, "PLAY_$", "sfx_number", 44, "from_noid", noid);
+				send_broadcast_msg(THE_REGION, "PLAY_$", "sfx_number", 44, "from_noid", noid);
 				break;
 			case '?':
 			case 'h':
@@ -795,7 +795,6 @@ public abstract class Magical extends HabitatMod {
 	 * @return Magical help string
 	 */
 	public String magic_vendo_info() {
-		
 		if (magic_type < 1)
 			return ("Dead magic item.");
 		else if (magic_type > NUMBER_OF_MAGICS)
@@ -821,7 +820,7 @@ public abstract class Magical extends HabitatMod {
         
         @Override
         public void noticeTimeout() {
-            send_broadcast_msg(THE_REGION, "PLAY_$", "sfx_number", 113, "from_noid", noid);
+            send_broadcast_msg(THE_REGION, "PLAY_$", "sfx_number", 44, "from_noid", noid);
             Avatar avatar = avatar(from);
             checkpoint_object(avatar);
             if(text == 'G') {

--- a/src/main/java/org/made/neohabitat/Magical.java
+++ b/src/main/java/org/made/neohabitat/Magical.java
@@ -653,7 +653,7 @@ public abstract class Magical extends HabitatMod {
 				}
 				break;
 			case 'g':
-			//	context().closeGate("Hand of God has been activated. No users may come in");
+			case 'G': //MOD does not kill the victim
 				String text = request_string.substring(1);
 				User   victimUser = Region.getUserByName(text);
 				Avatar victim = avatar(victimUser);
@@ -664,41 +664,7 @@ public abstract class Magical extends HabitatMod {
 				announce_object(item, victim.current_region());
 				checkpoint_object(god);
 		        object_broadcast(noid, "Thou shalt pay, " + victimUser.name() + "!");
-				GodTimer gt = new GodTimer(god, godAnimation, victimUser);
-			
-		
-		        
-		            
-
-		//		 trace_msg("Deleting grenade object %s ", god.object().ref());
-	//   				destroy_object(god);
-
-			//	destroy_object(god);
-			  //  object().contextor().remove(item.baseRef());
-			   
-			//	item.ref().
-	
-			//	item.checkpoint();
-			//	checkpoint_object(god);
-			//	object_say(from, "Deleting");
-			//	item.delete();
-
-				//destroy_object(god);
-				//context().checkpoint();
-			//	new Thread(Genie_Gets_Impatient).start();
-	         //   GodTimer gt = new GodTimer(god);
-	            
-	    	//	send_private_msg(from, THE_REGION, from, "PLAY_$", "sfx_number", 1, "from_noid", noid);
-				
-	          //  context().scheduleContextEvent(GRENADE_FUSE_DELAY * 1000, gt);
-			//	god.HELP(from);
-			//	if (user != null && user != from) {
-			//		kill_avatar(victim);
-			//	}
-			//	if(target.HabitatClass() == CLASS_AVATAR)
-				//{
-					//kill_avatar((Avatar)target);
-			//	}
+				GodTimer gt = new GodTimer(god, godAnimation, victimUser, command);
 				break;
 			case '?':
 			case 'h':
@@ -841,11 +807,13 @@ public abstract class Magical extends HabitatMod {
         private HabitatMod mod;
         private HabitatMod modAnimation;
         private User from;
+        private char command;
         private Clock clockTimer = Timer.theTimer().every(5000, this);
-        public GodTimer(HabitatMod mod, HabitatMod modAnimation, User from) {
+        public GodTimer(HabitatMod mod, HabitatMod modAnimation, User from, char command) {
                this.mod = mod;
                this.modAnimation = modAnimation;
                this.from = from;
+               this.command = command;
                clockTimer.start();
                
         }
@@ -853,25 +821,35 @@ public abstract class Magical extends HabitatMod {
 		@Override
 		public void noticeTimeout() {
 	    	Avatar avatar = avatar(from);
+	    	if(command == 'G')
+			{
+				avatar.DISCORPORATE(from);
+			}
+			else
+				kill_avatar(avatar);
 			trace_msg("Timer has ended.");
 			checkpoint_object(mod);
             trace_msg("Deleting Hand of God object %s ", mod.object().ref());	                
             send_goaway_msg(mod.noid);
             destroy_object(mod);
-        	modify_variable(from, modAnimation, C64_GR_STATE_OFFSET, 2);
+			
+        	modify_variable(from, modAnimation, C64_GR_STATE_OFFSET, 3);
 			Head skull = new Head(18, modAnimation.x, modAnimation.y+6, 0, 0, false);
 			Item item = create_object("Mistakes were made.", skull, null, false);
-			announce_object(item, avatar.current_region());
+			announce_object(item, current_region());
+
+	
 		}
 
 		@Override
 		public void noticeTick(int ticks) {
 	        Avatar avatar = avatar(from);
 	    	trace_msg("Ticks: " + ticks);
-	        if(avatar.x != mod.x){
+	        if(avatar.x != mod.x && avatar.y != mod.y){
 			   modify_variable(from, mod, C64_XPOS_OFFSET, avatar.x+20);
 			   modify_variable(from, mod, C64_YPOS_OFFSET, avatar.y+30);
 	        }
+	        
 		
 			if(ticks >= 5)
 			{
@@ -880,11 +858,8 @@ public abstract class Magical extends HabitatMod {
 				Item newitem = create_object("Hand of God Animation", modAnimation, null, true);
 				announce_object(newitem, avatar.current_region());
 				Timer.theTimer().after(5000*2, this);
-				
-				
-			
+
 			}
-			
 		} 
     }
 }

--- a/src/main/java/org/made/neohabitat/Magical.java
+++ b/src/main/java/org/made/neohabitat/Magical.java
@@ -652,8 +652,8 @@ public abstract class Magical extends HabitatMod {
 					avatar.change_regions(context, AUTO_TELEPORT_DIR, TELEPORT_ENTRY);
 				}
 				break;
-			case 'g':
-			case 'G': //G turns the victim into a ghost
+			case 'g': // Summons the Hand of God
+			case 'G': // G turns the victim into a ghost
 				String text = request_string.substring(1);
 				User   victimUser = Region.getUserByName(text);
 				Avatar victim = avatar(victimUser);
@@ -803,8 +803,6 @@ public abstract class Magical extends HabitatMod {
 		else
 			return (magic_help[magic_type - 1]);
 	}
-    
-    
         
     private class GodTimer implements TimeoutNoticer, TickNoticer {
         private HabitatMod mod;
@@ -852,11 +850,11 @@ public abstract class Magical extends HabitatMod {
                modify_variable(from, mod, C64_YPOS_OFFSET, avatar.y+30);
             }
             if(ticks >= 4) {
-                clockTimer.stop();
-                send_broadcast_msg(avatar.noid, "POSTURE$", "new_posture", GET_SHOT_POSTURE);
-                Item newitem = create_object("Hand of God Animation", modAnimation, null, true);
-                announce_object(newitem, avatar.current_region());
-                Timer.theTimer().after(5000*2, this);
+               clockTimer.stop();
+               send_broadcast_msg(avatar.noid, "POSTURE$", "new_posture", GET_SHOT_POSTURE);
+               Item newitem = create_object("Hand of God Animation", modAnimation, null, true);
+               announce_object(newitem, avatar.current_region());
+               Timer.theTimer().after(5000*2, this);
             }
         } 
     }

--- a/src/main/java/org/made/neohabitat/mods/Hand_of_god.java
+++ b/src/main/java/org/made/neohabitat/mods/Hand_of_god.java
@@ -23,7 +23,6 @@ import org.made.neohabitat.HabitatMod;
  * gr_state: 3 Animation
  * gr_state: 4 Small dot/cinder
  *
- *
  * @author TheCarlSaganExpress
  *
  */

--- a/src/main/java/org/made/neohabitat/mods/Hand_of_god.java
+++ b/src/main/java/org/made/neohabitat/mods/Hand_of_god.java
@@ -1,0 +1,88 @@
+package org.made.neohabitat.mods;
+
+import org.elkoserver.foundation.json.JSONMethod;
+import org.elkoserver.foundation.json.OptBoolean;
+import org.elkoserver.foundation.json.OptInteger;
+import org.elkoserver.foundation.json.OptString;
+import org.elkoserver.json.EncodeControl;
+import org.elkoserver.json.JSONLiteral;
+import org.elkoserver.server.context.Item;
+import org.elkoserver.server.context.User;
+import org.made.neohabitat.Copyable;
+import org.made.neohabitat.HabitatMod;
+
+/**
+ * Habitat Hand of God Mod
+ * 
+ * 
+ *
+ * @author TheCarlSaganExpress
+ *
+ */
+public class Hand_of_god extends HabitatMod implements Copyable {
+        
+    public int HabitatClass() {
+        return CLASS_HAND_OF_GOD;
+    }
+    
+    public String HabitatModName() {
+        return "Hand_of_god";
+    }
+    
+    public int capacity() {
+        return 0;
+    }
+    
+    public int pc_state_bytes() {
+        return 1;
+    }
+    
+    public boolean known() {
+        return true;
+    }
+    
+    public boolean opaque_container() {
+        return false;
+    }
+    
+    public boolean changeable() { 
+        return false;
+    }
+
+    public boolean filler() {
+        return false;
+    }
+    
+    public int state = 0;
+    
+    @JSONMethod({ "style", "x", "y", "orientation", "gr_state", "restricted", "state"})
+    public Hand_of_god(OptInteger style, OptInteger x, OptInteger y, OptInteger orientation, OptInteger gr_state, OptBoolean restricted,
+            OptInteger state) {
+        super(style, x, y, orientation, gr_state, restricted);
+        this.state = state.value(0);
+    }
+
+    public Hand_of_god(int style, int x, int y, int orientation, int gr_state, boolean restricted, int state) {
+        super(style, x, y, orientation, gr_state, restricted);
+        this.state = state;
+    }
+
+    @Override
+    public HabitatMod copyThisMod() {
+        return new Hand_of_god(style, x, y, orientation, gr_state, restricted, state);
+    }
+
+    @Override
+    public JSONLiteral encode(EncodeControl control) {
+        JSONLiteral result = super.encodeCommon(new JSONLiteral(HabitatModName(), control));
+        result.addParameter("state", state);
+        result.finish();
+        return result;
+    }
+    
+    @JSONMethod
+    public void HELP(User from) {
+        generic_HELP(from);
+    }
+    
+}

--- a/src/main/java/org/made/neohabitat/mods/Hand_of_god.java
+++ b/src/main/java/org/made/neohabitat/mods/Hand_of_god.java
@@ -14,7 +14,15 @@ import org.made.neohabitat.HabitatMod;
 /**
  * Habitat Hand of God Mod
  * 
- * 
+ * The hand of god is a giant animated hand that comes down off the top of the
+ * screen and destroys the designated victim. This class was orgiginally unfinished 
+ * and utilizes an unusual implementation that can be found in Magical.java
+ *
+ * gr_state: 1 Pile of cinder
+ * gr_state: 2 "Static" Lightning bolt
+ * gr_state: 3 Animation
+ * gr_state: 4 Small dot/cinder
+ *
  *
  * @author TheCarlSaganExpress
  *
@@ -84,5 +92,4 @@ public class Hand_of_god extends HabitatMod implements Copyable {
     public void HELP(User from) {
         generic_HELP(from);
     }
-    
 }


### PR DESCRIPTION
The Hand of God was never really finished and it was only given a simple HELP command. Although, the original documentation states that the Hand of God would have been used for turning avatars into a pile of smoking cinder. After consulting with Randy it was then decided that the Hand of God would be given the implementation that it deserves! The only feature that is currently missing from the Hand of God is the ability to turn an avatar into a ghost, rather than outright killing them. 

**Using the Hand of God**

- You must possess a god tool in order to use the Hand of God

- To summon the Hand of God, type in the letter 'g' followed by the victim's name.

- E.x. you would type "gjason" in the god tool prompt to smite the user named Jason.

![hand of god pic](https://user-images.githubusercontent.com/7967050/29690895-dfd30660-88f6-11e7-9f5f-d58a3b4ec4bf.JPG)