### PR TITLE
Adapts Backbone to new Spine service discovery system

### DIFF
--- a/Backbone
+++ b/Backbone
@@ -26,7 +26,7 @@ clusters:
       image: philcollins/neohabitat
       environment:
         - NEOHABITAT_DEFAULT_CONTEXT=context-Downtown_5f
-        - NEOHABITAT_MONGO_HOST=127.0.0.1:27017
+        - NEOHABITAT_MONGO_HOST=neohabitatmongo:27017
         - NEOHABITAT_SCHEMA_DIR=db
         - NEOHABITAT_SHOULD_ENABLE_CRON=true
         - NEOHABITAT_SHOULD_ENABLE_DEBUGGER=false
@@ -49,11 +49,11 @@ clusters:
   - neohabitatqlink:
       image: philcollins/qlink
       environment:
-        - QLINK_DB_HOST=127.0.0.1
-        - QLINK_DB_JDBC_URI=jdbc:mysql://127.0.0.1:3306/qlink
+        - QLINK_DB_HOST=neohabitatmariadb
+        - QLINK_DB_JDBC_URI=jdbc:mysql://neohabitatmariadb:3306/qlink
         - QLINK_DB_USERNAME=spine
         - QLINK_DB_PASSWORD=spine
-        - QLINK_HABITAT_HOST=127.0.0.1
+        - QLINK_HABITAT_HOST=neohabitat
         - QLINK_SHOULD_CREATE_DB=true
         - QLINK_SHOULD_PING=true
       synapses:


### PR DESCRIPTION
Spine's Synapse service discovery system has been modified to standardize on the form used by docker-compose; namely, services provided by Synapses can now be reached at the hostname of the Spine resource specified. For instance, to reach the Neohabitat Mongo instance, clients will contact the 'neohabitatmongo' host instead of '127.0.0.1'.

This change has been deployed in production and is currently active:

![screen shot 2017-10-29 at 8 14 02 pm](https://user-images.githubusercontent.com/15283/32153282-bf7ff85e-bce6-11e7-91af-c85434462d46.png)

Let me know what you think and thanks for the consideration!