### PR TITLE
Corrects JITPack JAR location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.github.FUDCo</groupId>
             <artifactId>Elko</artifactId>
-            <version>master-v2.0.3-g61c78f4-45</version>
+            <version>master-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The format for a JITPack-based JAR has changed; this PR corrects it to ensure successful Neohabitat builds.

Thanks!