### PR TITLE
Corrects Dnalsi teleporter, adds test user

### DIFF
--- a/bridge/Habitat2ElkoBridge.js
+++ b/bridge/Habitat2ElkoBridge.js
@@ -847,7 +847,7 @@ function parseHabitatClientMessage(client, server, data) {
 						context = client.user.mods[0].lastArrivedIn;
 						client.user.mods[0].lastArrivedIn = "";
 					} else {
-						choices = ["context-Downtown_5f"/* ,"context-Downtown_3b","context-Downtown_7g","context-Downtown_7b","context-Downtown_3j" */];
+						choices = ["context-welcomecenterinthatch"/* ,"context-Downtown_3b","context-Downtown_7g","context-Downtown_7b","context-Downtown_3j" */];
 						context = choices[rnd(choices.length)];
 					}
 				} else if (client.state.nextRegion !== "") {

--- a/db/Dnalsi/dnalsi_2a.json
+++ b/db/Dnalsi/dnalsi_2a.json
@@ -106,7 +106,7 @@
         "x": 104, 
         "type": "Teleport", 
         "orientation": 204, 
-        "address": "dnalsi"
+        "address": "pop-dnalsi"
       }
     ], 
     "type": "item", 

--- a/db/Makefile
+++ b/db/Makefile
@@ -93,7 +93,11 @@ back4t:
 hell:
 	@echo "Building Hell Only"
 	@node populateModels.js $(NEOHABITAT_MONGO_HOST) hell >>.errs 2>&1	
-    
+
+dnalsi:
+	@echo "Building Dnalsi Only"
+	@node populateModels.js $(NEOHABITAT_MONGO_HOST) dnalsi >>.errs 2>&1
+
 users:
 	@echo "Building Users Only"
 	@node populateModels.js $(NEOHABITAT_MONGO_HOST) users >>.errs 2>&1

--- a/db/Users/user-phil.json
+++ b/db/Users/user-phil.json
@@ -1,0 +1,42 @@
+[
+  {
+    "type" : "user",
+    "ref" : "user-phil",
+    "name" : "Phil",
+    "mods" : [ {
+      "type" : "Avatar",
+      "x" : 100,
+      "y" : 130,
+      "bodyType" : "male",
+      "bankBalance" : 50000,
+      "custom" : [ 17, 151 ],
+      "nitty_bits" : 8
+    } ]
+  },
+  {
+    "type" : "item",
+    "ref" : "item-phil.head",
+    "name" : "Steve's Head",
+    "in" : "user-phil",
+    "mods" : [ {
+      "type" : "Head",
+      "style" : 28,
+      "orientation" : 16,
+      "y" : 6
+    } ]
+  },
+  {
+    "type" : "item",
+    "ref" : "item-phil.godtool",
+    "name" : "Tool to rule the universe.",
+    "in" : "user-phil",
+    "mods" : [ {
+      "type" : "Knick_knack",
+      "style" : 2,
+      "y" : 2,
+      "orientation" : 8,
+      "magic_type" : 17,
+      "charges" : 255
+    } ]
+  }
+]

--- a/db/populateModels.js
+++ b/db/populateModels.js
@@ -19,6 +19,7 @@ const fileRoots = {
   beach: './Beach',
   hell:  './Hell',
   back4t: './Back4t',
+  dnalsi: './Dnalsi',
   streets: "./Streets",
   text: './Text',
   users: './Users'


### PR DESCRIPTION
While testing some of the new Spine metrics features, I found that the Dnalsi teleporter did not have a ```-pop``` prefix. This PR adds this alongside a new bot user, phil, and support to the DB Makefile to support dnalsi-only building.

Thanks so much!