### PR TITLE
Adds an empty region for people to use as a template for region creation

### DIFF
--- a/db/Empty/empty.json
+++ b/db/Empty/empty.json
@@ -1,0 +1,53 @@
+[
+  {
+    "ref": "context-empty", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "Empty Region", 
+    "mods": [
+      {
+        "town_dir": "", 
+        "port_dir": "", 
+        "type": "Region",
+        "orientation": 0,		
+        "neighbors": [
+          "",
+          "", 
+          "",
+          ""
+        ], 
+        "nitty_bits": 3
+      }
+    ]
+  }, 
+  {
+    "ref": "item-ground.d8j1.empty", 
+    "mods": [
+      {
+        "y": 4, 
+        "x": 0, 
+        "style": 1, 
+        "type": "Ground", 
+        "orientation": 196
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-empty"
+  },
+  {
+    "ref": "item-wall.a9t4.empty", 
+    "mods": [
+      {
+        "y": 0, 
+        "x": 0, 
+        "style": 4, 
+        "type": "Wall", 
+        "orientation": 252
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-empty"
+  }
+]


### PR DESCRIPTION
This PR adds an empty region for people to use as a template for region creation.

![emptyregion](https://user-images.githubusercontent.com/25211663/35771100-3521f57e-091f-11e8-9894-ddc734c3ed79.png)

It's intended to be an accompaniment to the new [Region Creation](https://github.com/frandallfarmer/neohabitat/wiki/Region-Creation,-Testing-and-Porting) guide on the wiki.