### PR TITLE
Fixed an incorrect linking issue in the woods.

### DIFF
--- a/db/Woods/Woods_6q.json
+++ b/db/Woods/Woods_6q.json
@@ -9,7 +9,7 @@
         "town_dir": LEFT,
         "port_dir": LEFT,
         "neighbors": [
-          "context-Woods_6q", 
+          "context-Woods_6r", 
           "context-Woods_7q", 
           "context-Woods_6p", 
           "context-Woods_5q"


### PR DESCRIPTION
Fixed an incorrect linking issue in the woods. The end of the "Henry the Avatar" area of the Woods is meant to connect to the Habitat crossroads. Keith's video shows this was the correct link, however the RDL file for the region simply looped back on itself.

![restoredwoodslink](https://user-images.githubusercontent.com/25211663/35883136-30a6f7ae-0b7e-11e8-8603-b93e40c466f7.png)


