### PR TITLE
Enable production mode for Pushserver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - sleep 60
 
   # Executes functional tests:
-  - cd test && node Telko.js -f chip
+  - cd test && node Telko.js -p 2018 -f chip
 
 after_success:
   # Pushes the Docker image then deploys it to Spine.

--- a/pushserver/habiproxy/session.js
+++ b/pushserver/habiproxy/session.js
@@ -247,7 +247,7 @@ class HabitatSession {
 
     // Fires any message-specific callbacks.
     if (message.op in this.callbacks) {
-      log.debug('Running callbacks for %s on: %s', o.op, this.id());
+      log.debug('Running callbacks for %s on: %s', message.op, this.id());
       for (var i in this.callbacks[message.op]) {
         this.callbacks[message.op][i](this, message);
       }

--- a/run
+++ b/run
@@ -84,7 +84,11 @@ function start_bridge() {
 }
 
 function start_pushserver() {
-  (cd "${GIT_BASE_DIR}/pushserver" && npm run debug 2>&1 | tee ../pushserver.log)
+  if [[ "${NODE_ENV}" == "production" ]]; then
+    (cd "${GIT_BASE_DIR}/pushserver" && node bin/pushserver | tee ../pushserver.log)
+  else
+    (cd "${GIT_BASE_DIR}/pushserver" && npm run debug 2>&1 | tee ../pushserver.log)
+  fi
 }
 
 function start_elko_server() {


### PR DESCRIPTION
Currently, the pushserver is launched in debug mode; this change adds support for launching the production mode of the server instead.