### PR TITLE
Using supervisor to ensure Pushserver remains running

### DIFF
--- a/pushserver/package.json
+++ b/pushserver/package.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "homepage": "https://frandallfarmer.github.io/neohabitat/",
   "scripts": {
-    "start": "node ./bin/pushserver",
-    "debug": "./node_modules/supervisor/lib/cli-wrapper.js --inspect -i public,views -w . -- bin/pushserver"
+    "start": "./node_modules/supervisor/lib/cli-wrapper.js -i public,views -w bin,habiproxy,routes -- ./bin/pushserver",
+    "debug": "./node_modules/supervisor/lib/cli-wrapper.js --inspect -i public,views -w bin,habiproxy,routes -- bin/pushserver"
   },
   "dependencies": {
     "body-parser": "~1.18.2",

--- a/run
+++ b/run
@@ -85,7 +85,7 @@ function start_bridge() {
 
 function start_pushserver() {
   if [[ "${NODE_ENV}" == "production" ]]; then
-    (cd "${GIT_BASE_DIR}/pushserver" && node bin/pushserver | tee ../pushserver.log)
+    (cd "${GIT_BASE_DIR}/pushserver" && npm run start 2>&1 | tee ../pushserver.log)
   else
     (cd "${GIT_BASE_DIR}/pushserver" && npm run debug 2>&1 | tee ../pushserver.log)
   fi


### PR DESCRIPTION
Instead of calling to Node directly when launching the Pushserver, we should run it with Supervisor to ensure it remains running during any potential crash scenario. This PR adds the necessary support for this functionality.