### PR TITLE
Adds EventStream persistence improvements and Vagrant build scripting for PushServer

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,10 +11,13 @@ Vagrant.configure("2") do |config|
   config.vm.box_check_update = false
 
   config.vm.network "forwarded_port", guest: 1337, host: 1337, host_ip: "0.0.0.0"
+  config.vm.network "forwarded_port", guest: 1701, host: 1701, host_ip: "0.0.0.0"
   config.vm.network "forwarded_port", guest: 1986, host: 1986, host_ip: "0.0.0.0"
+  config.vm.network "forwarded_port", guest: 2018, host: 2018, host_ip: "0.0.0.0"
   config.vm.network "forwarded_port", guest: 3307, host: 3307, host_ip: "0.0.0.0"
   config.vm.network "forwarded_port", guest: 5190, host: 5190, host_ip: "0.0.0.0"
   config.vm.network "forwarded_port", guest: 9000, host: 9000, host_ip: "0.0.0.0"
+  config.vm.network "forwarded_port", guest: 9229, host: 9229, host_ip: "127.0.0.1"
   config.vm.network "forwarded_port", guest: 27017, host: 27017, host_ip: "0.0.0.0"
 
   config.vm.provider :virtualbox do |vb|

--- a/pushserver/public/javascripts/eventStream.js
+++ b/pushserver/public/javascripts/eventStream.js
@@ -1,19 +1,38 @@
-var source = new EventSource('/events/' + avatarName + '/eventStream');
-
+var CONNECTED = 'CONNECTED';
 var REGION_CHANGE = 'REGION_CHANGE';
 
+var HabiventsES = null
+
 function processEvent(event) {
-  console.log(event);
   switch (event.type) {
+    case CONNECTED:
+      return;
     case REGION_CHANGE:
       $('#avatarRegion').text(event.msg.description);
       $('#docsFrame').attr('src', event.msg.docsURL);
+      return;
     default:
       console.log('Unknown event type: ', event.type)
+      return;
   }
 }
 
-source.addEventListener('message', function(e) {
-  var event = JSON.parse(e.data);
-  processEvent(event);
-}, false);
+function startEventSource() {
+  if (HabiventsES == null || HabiventsES.readyState == 2) {
+    HabiventsES = new EventSource('/events/' + avatarName + '/eventStream');
+    HabiventsES.onerror = function(e) {
+      if (HabiventsES.readyState == 2) {
+        console.log('Habivents EventSource disconnected, retrying in 3 secs:', e);
+        setTimeout(startEventSource, 3000);
+      }
+    }
+    HabiventsES.addEventListener('message', function(e) {
+      var event = JSON.parse(e.data);
+      processEvent(event);
+    }, false);
+  }
+}
+
+$(document).ready(function() {
+  startEventSource();
+})


### PR DESCRIPTION
The Spine proxying layer that sits in front of the Neohabitat application is configured to close idle HTTP sessions after 50 seconds unless upgraded to an EventSource or WebSocket connection. As these upgrade headers are sent by the PushServer upon the first event message to the client, a 50 second window can elapse before they're sent.

The solution is to add an event which is fired upon the first connection, CONNECTED, which will correctly set the needed upgrade headers. Furthermore, I've added retry code to the frontend to support reconnection during byzantine connection failure scenarios (WiFi changes, etc.)

Finally, I've added support for the PushServer to the Vagrant build code to support Windows developers.