### PR TITLE
Fixes teleport-related issues in Habiproxy

### DIFF
--- a/pushserver/public/javascripts/eventStream.js
+++ b/pushserver/public/javascripts/eventStream.js
@@ -163,7 +163,7 @@ function refreshAvatarStatus() {
   $.get('/api/v1/avatar/'+AvatarName, function(data) {
     $('#healthHeader').text(data.health);
     $('#stunCountHeader').text(data.avatar.mods[0].stun_count);
-    $('#bankBalanceHeader').text(data.avatar.mods[0].bankBalance);
+    $('#bankBalanceHeader').text(data.avatar.mods[0].bankBalance+'T');
   }, 'json');
 }
 


### PR DESCRIPTION
Teleports via booths require the client to disconnect from Elko upon receiving a changeContext message with immediate=true. The proxy did not recognize this, leading to two open connections and general mayhem.

While I was at it, I added some try/catches and extra logging to help debug proxy issues further.