### PR TITLE
World Changes

### DIFF
--- a/db/Back4t/back4t_31.json
+++ b/db/Back4t/back4t_31.json
@@ -11,7 +11,7 @@
           "context-back4t_41", 
           "context-back4t_32", 
           "context-back4t_21", 
-          "context-Woods_6j"
+          ""
         ],
         "realm": "Back4t",         
         "orientation": 0, 

--- a/db/Back4t/back4t_75.json
+++ b/db/Back4t/back4t_75.json
@@ -6,17 +6,17 @@
     "name": "The Back 40",  
     "mods": [
       {
-        "town_dir": "", 
+        "town_dir": DOWN, 
         "neighbors": [
           "", 
-          "context-back4t_65", 
+          "context-Woods_1164", 
           "context-back4t_65", 
           "context-back4t_74"
         ],
         "realm": "Back4t",         
         "orientation": 0, 
         "nitty_bits": 2, 
-        "port_dir": "", 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]
@@ -173,6 +173,31 @@
     ], 
     "type": "item", 
     "name": "Tree", 
+    "in": "context-back4t_75"
+  },
+  {
+    "ref": "item-Short_sign.d8k1.back4t_75", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 16, 
+        "ascii": [
+          72, 
+          73, 
+          87, 
+          65, 
+          89, 
+          133, 
+          125
+        ], 
+        "gr_state": 7, 
+        "y": 129, 
+        "x": 20, 
+        "type": "Short_sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Short_sign", 
     "in": "context-back4t_75"
   }
 ]

--- a/db/Beach/beach_0a.json
+++ b/db/Beach/beach_0a.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_0b", 
           "context-beach_1a", 
@@ -16,7 +16,7 @@
         "realm": "Beach",            
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_0b.json
+++ b/db/Beach/beach_0b.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_0c", 
           "context-beach_1b", 
@@ -16,7 +16,7 @@
         "realm": "Beach",            
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_0c.json
+++ b/db/Beach/beach_0c.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_0d", 
           "context-beach_1c", 
@@ -16,7 +16,7 @@
         "realm": "Beach",     
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_0d.json
+++ b/db/Beach/beach_0d.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_0e", 
           "context-beach_1d", 
@@ -16,7 +16,7 @@
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_0e.json
+++ b/db/Beach/beach_0e.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_0f", 
           "context-beach_1e", 
@@ -16,7 +16,7 @@
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_1a.json
+++ b/db/Beach/beach_1a.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_1b", 
           "context-beach_2a", 
@@ -16,7 +16,7 @@
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_1b.json
+++ b/db/Beach/beach_1b.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_1c", 
           "context-beach_2b", 
@@ -16,7 +16,7 @@
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_1c.json
+++ b/db/Beach/beach_1c.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_1d", 
           "context-beach_2c", 
@@ -16,7 +16,7 @@
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_1d.json
+++ b/db/Beach/beach_1d.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_1e", 
           "context-beach_2d", 
@@ -16,7 +16,7 @@
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_1e.json
+++ b/db/Beach/beach_1e.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_1f", 
           "context-beach_2e", 
@@ -16,7 +16,7 @@
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_1f.json
+++ b/db/Beach/beach_1f.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_1g", 
           "context-beach_2f", 
@@ -16,7 +16,7 @@
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_2a.json
+++ b/db/Beach/beach_2a.json
@@ -6,17 +6,17 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": DOWN, 
         "neighbors": [
           "context-beach_2b", 
-          "context-beach_2b", 
+          "context-I5_7204", 
           "context-beach_2f", 
           "context-beach_1a"
         ],
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": DOWN, 
         "type": "Region"
       }
     ]
@@ -155,5 +155,31 @@
     "type": "item", 
     "name": "Pond", 
     "in": "context-beach_2a"
-  }
+  }, 
+  {
+    "ref": "item-Short_sign.b8m2.beach_2a", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 16, 
+        "ascii": [
+          72, 
+          73, 
+          87, 
+          65, 
+          89, 
+          32, 
+          133, 
+          125
+        ], 
+        "gr_state": 7, 
+        "y": 35, 
+        "x": 20, 
+        "type": "Short_sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Short_sign", 
+    "in": "context-beach_2a"
+  } 
 ]

--- a/db/Beach/beach_2b.json
+++ b/db/Beach/beach_2b.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": RIGHT, 
+        "town_dir": LEFT, 
         "neighbors": [
           "context-beach_2c", 
           "context-beach_2a", 
@@ -16,7 +16,7 @@
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": RIGHT, 
+        "port_dir": LEFT, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_2c.json
+++ b/db/Beach/beach_2c.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": LEFT, 
         "neighbors": [
           "context-beach_2d", 
           "context-beach_2d", 
@@ -16,7 +16,7 @@
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": LEFT, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_2e.json
+++ b/db/Beach/beach_2e.json
@@ -6,7 +6,7 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": RIGHT, 
         "neighbors": [
           "context-beach_2f", 
           "context-beach_2f", 
@@ -16,7 +16,7 @@
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": RIGHT, 
         "type": "Region"
       }
     ]

--- a/db/Beach/beach_2f.json
+++ b/db/Beach/beach_2f.json
@@ -6,17 +6,17 @@
     "name": "The Beach", 
     "mods": [
       {
-        "town_dir": DOWN + SPACE + RIGHT, 
+        "town_dir": RIGHT, 
         "neighbors": [
-          "context-Woods_5x", 
-          "context-Woods_5x", 
+          "context-beach_2a", 
+          "context-beach_2e", 
           "context-beach_2e", 
           "context-beach_1f"
         ],
         "realm": "Beach",          
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN + SPACE + RIGHT, 
+        "port_dir": RIGHT, 
         "type": "Region"
       }
     ]

--- a/db/Desert/Desert_1a.json
+++ b/db/Desert/Desert_1a.json
@@ -11,7 +11,7 @@
           "context-Desert_1b", 
           "context-Desert_2a", 
           "", 
-          "context-Desert_1b"
+          "context-I5_7209"
         ],
         "realm": "Desert",    
         "orientation": 0, 

--- a/db/I5/I5_1310.json
+++ b/db/I5/I5_1310.json
@@ -1,0 +1,195 @@
+[
+  {
+    "ref": "context-I5_1310", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "Construction Zone", 
+    "mods": [
+      {
+        "town_dir": DOWN, 
+        "neighbors": [
+          "context-I5_7209", 
+          "", 
+          "", 
+          ""
+        ],
+        "realm": "I5",		
+        "orientation": 3, 
+        "nitty_bits": 3, 
+        "port_dir": DOWN, 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Bush.d9k2.I5_1310", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 17, 
+        "gr_state": 0, 
+        "y": 149, 
+        "x": 32, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-I5_1310"
+  }, 
+  {
+    "ref": "item-Garbage_can.a9l1.I5_1310", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 172, 
+        "key_hi": 0, 
+        "key_lo": 0, 
+        "gr_state": 1, 
+        "y": 136, 
+        "x": 112, 
+        "type": "Garbage_can", 
+        "open_flags": 3
+      }
+    ], 
+    "type": "item", 
+    "name": "Garbage_can", 
+    "in": "context-I5_1310"
+  }, 
+  {
+    "ref": "item-Sign1.f8j1.I5_1310", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 188, 
+        "ascii": [
+          139, 
+          128, 
+          72, 
+          65, 
+          82, 
+          68, 
+          134, 
+          32, 
+          72, 
+          65, 
+          84, 
+          134, 
+          128, 
+          65, 
+          82, 
+          69, 
+          65
+        ], 
+        "gr_state": 0, 
+        "y": 130, 
+        "x": 32, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-I5_1310"
+  }, 
+  {
+    "ref": "item-Sign2.d9k1.I5_1310", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 220, 
+        "ascii": [
+          32, 
+          32, 
+          32, 
+          85, 
+          78, 
+          68, 
+          69, 
+          82, 
+          134, 
+          67, 
+          79, 
+          78, 
+          83, 
+          84, 
+          82, 
+          85, 
+          67, 
+          84, 
+          73, 
+          79, 
+          78, 
+          134, 
+          134, 
+          68, 
+          79, 
+          32, 
+          78, 
+          79, 
+          84, 
+          32, 
+          69, 
+          78, 
+          84, 
+          69, 
+          82
+        ], 
+        "gr_state": 0, 
+        "y": 26, 
+        "x": 56, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-I5_1310"
+  }, 
+  {
+    "ref": "item-Street.k1l2.I5_1310", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 8, 
+        "gr_state": 1, 
+        "y": 10, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-I5_1310"
+  }, 
+  {
+    "ref": "item-Wall.x9j2.I5_1310", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Wall"
+      }
+    ], 
+    "type": "item", 
+    "name": "Wall", 
+    "in": "context-I5_1310"
+  }, 
+  {
+    "ref": "item-Ground.l1m2.I5_1310", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 228, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-I5_1310"
+  }
+]

--- a/db/I5/I5_7200.json
+++ b/db/I5/I5_7200.json
@@ -1,0 +1,128 @@
+[
+  {
+    "ref": "context-I5_7200", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "I-5", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-Woods_1164", 
+          "", 
+          "context-I5_7201", 
+          ""
+        ],
+        "realm": "I5", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "\u007f", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sign.d8k3.I5_7200", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 172, 
+        "ascii": [
+          133, 
+          136, 
+          128, 
+          87, 
+          69, 
+          76, 
+          67, 
+          79, 
+          77, 
+          69, 
+          134, 
+          32, 
+          32, 
+          84, 
+          79, 
+          134, 
+          32, 
+          128, 
+          73, 
+          45, 
+          53, 
+          134, 
+          133, 
+          136, 
+          128, 
+          68, 
+          101, 
+          112, 
+          116, 
+          32, 
+          111, 
+          102, 
+          128, 
+          84, 
+          114, 
+          97, 
+          110, 
+          115
+        ], 
+        "gr_state": 0, 
+        "y": 34, 
+        "x": 8, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-I5_7200"
+  }, 
+  {
+    "ref": "item-Ground1.s9l1.I5_7200", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 40, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-I5_7200"
+  }, 
+  {
+    "ref": "item-Street1.l2k1.I5_7200", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 6, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-I5_7200"
+  }, 
+  {
+    "ref": "item-Sky1.x9k2.I5_7200", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7200"
+  }
+]

--- a/db/I5/I5_7201.json
+++ b/db/I5/I5_7201.json
@@ -1,0 +1,200 @@
+[
+  {
+    "ref": "context-I5_7201", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "I-5", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-I5_7200", 
+          "", 
+          "context-I5_7202", 
+          ""
+        ],
+        "realm": "I5", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "\u007f", 
+        "type": "Region"
+      }
+    ]
+  },
+  {
+    "ref": "item-Ground.d9k2.I5_7201", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 40, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-I5_7201"
+  }, 
+  {
+    "ref": "item-Sky.x8k1.I5_7201", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7201"
+  }, 
+  {
+    "ref": "item-Street.l9j1.I5_7201", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 6, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-I5_7201"
+  },
+  {
+    "ref": "item-Tree1.d8k1.I5_7201", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 40, 
+        "gr_state": 0, 
+        "y": 130, 
+        "x": 140, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7201"
+  },
+  {
+    "ref": "item-Tree2.f9k2.I5_7201", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 236, 
+        "gr_state": 0, 
+        "y": 133, 
+        "x": 120, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7201"
+  }, 
+  {
+    "ref": "item-Tree3.f9k1.I5_7201", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 172, 
+        "gr_state": 0, 
+        "y": 40, 
+        "x": 52, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7201"
+  }, 
+  {
+    "ref": "item-Tree4.a9l1.I5_7201", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 64, 
+        "gr_state": 0, 
+        "y": 42, 
+        "x": 24, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7201"
+  }, 
+  {
+    "ref": "item-Tree5.d9j1.I5_7201", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 48, 
+        "gr_state": 0, 
+        "y": 42, 
+        "x": 128, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7201"
+  }, 
+  {
+    "ref": "item-Tree6.u6u1.I5_7201", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 204, 
+        "gr_state": 0, 
+        "y": 40, 
+        "x": 0, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7201"
+  }, 
+  {
+    "ref": "item-Tree7.o9j1.I5_7201", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "gr_state": 0, 
+        "y": 133, 
+        "x": 16, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7201"
+  }, 
+  {
+    "ref": "item-Bush.g9k2.I5_7201", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 32, 
+        "gr_state": 0, 
+        "y": 32, 
+        "x": 104, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-I5_7201"
+  }
+]

--- a/db/I5/I5_7202.json
+++ b/db/I5/I5_7202.json
@@ -1,0 +1,152 @@
+[
+  {
+    "ref": "context-I5_7202", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "I-5", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-I5_7201", 
+          "", 
+          "context-I5_7203", 
+          ""
+        ],
+        "realm": "I5", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "\u007f", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.d8k3.I5_7202", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 40, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-I5_7202"
+  }, 
+  {
+    "ref": "item-Sky.m2d9.I5_7202", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7202"
+  }, 
+  {
+    "ref": "item-Street.l2m4.I5_7202", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 6, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-I5_7202"
+  }, 
+  {
+    "ref": "item-Tree1.x9m3.I5_7202", 
+    "mods": [
+      {
+        "style": 10, 
+        "orientation": 32, 
+        "gr_state": 0, 
+        "y": 132, 
+        "x": 128, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7202"
+  }, 
+  {
+    "ref": "item-Tree2.d8j2.I5_7202", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 156, 
+        "gr_state": 2, 
+        "y": 59, 
+        "x": 100, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7202"
+  }, 
+  {
+    "ref": "item-Tree3.a0l1.I5_7202", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 172, 
+        "gr_state": 0, 
+        "y": 40, 
+        "x": 32, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7202"
+  }, 
+  {
+    "ref": "item-Tree4.x7m2.I5_7202", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 40, 
+        "x": 100, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7202"
+  }, 
+  {
+    "ref": "item-Tree5.k9j1.I5_7202", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 16, 
+        "gr_state": 0, 
+        "y": 133, 
+        "x": 44, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7202"
+  }
+]

--- a/db/I5/I5_7203.json
+++ b/db/I5/I5_7203.json
@@ -1,0 +1,120 @@
+[
+  {
+    "ref": "context-I5_7203", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "I-5", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-I5_7202", 
+          "", 
+          "context-I5_7204", 
+          ""
+        ],
+        "realm": "I5", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "\u007f", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Bush.d8k1.I5_7203", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 148, 
+        "gr_state": 0, 
+        "y": 133, 
+        "x": 112, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-I5_7203"
+  }, 
+  {
+    "ref": "item-Tree1.j3m4.I5_7203", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 189, 
+        "gr_state": 0, 
+        "y": 33, 
+        "x": 60, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7203"
+  }, 
+  {
+    "ref": "item-Tree2.y8j9.I5_7203", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 204, 
+        "gr_state": 0, 
+        "y": 132, 
+        "x": 24, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7203"
+  }, 
+  {
+    "ref": "item-Street.q9k1.I5_7203", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 6, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-I5_7203"
+  }, 
+  {
+    "ref": "item-Sky.p4d1.I5_7203", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7203"
+  }, 
+  {
+    "ref": "item-Ground.w9e8.I5_7203", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 40, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-I5_7203"
+  }
+]

--- a/db/I5/I5_7204.json
+++ b/db/I5/I5_7204.json
@@ -1,0 +1,248 @@
+[
+  {
+    "ref": "context-I5_7204", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "I-5", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-I5_7203", 
+          "", 
+          "context-I5_7205", 
+          "context-beach_2a"
+        ],
+        "realm": "I5", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "\u007f", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Plant1.d9l2.I5_7204", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 204, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 40, 
+        "x": 16, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Plant2.k9h7.I5_7204", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 204, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 44, 
+        "x": 24, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Short_sign.f9k2.I5_7204", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 248, 
+        "ascii": [
+          66, 
+          69, 
+          65, 
+          67, 
+          72, 
+          32, 
+          133, 
+          124
+        ], 
+        "gr_state": 7, 
+        "y": 35, 
+        "x": 104, 
+        "type": "Short_sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Short_sign", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Tree1.m3d9.I5_7204", 
+    "mods": [
+      {
+        "style": 6, 
+        "orientation": 173, 
+        "gr_state": 0, 
+        "y": 132, 
+        "x": 140, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Street.k8j6.I5_7204", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 14, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Sky.a9l1.I5_7204", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Ground.j8h6.I5_7204", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 40, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Bush1.d8j3.I5_7204", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 149, 
+        "gr_state": 0, 
+        "y": 133, 
+        "x": 44, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Bush2.a9k4.I5_7204", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 149, 
+        "gr_state": 1, 
+        "y": 133, 
+        "x": 68, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Plant3.x9k1.I5_7204", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 204, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 44, 
+        "x": 32, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Plant4.a9k3.I5_7204", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 204, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 37, 
+        "x": 4, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Plant5.d9k1.I5_7204", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 204, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 44, 
+        "x": 44, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-I5_7204"
+  }, 
+  {
+    "ref": "item-Plant6.h8k3.I5_7204", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 204, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 42, 
+        "x": 52, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-I5_7204"
+  }
+]

--- a/db/I5/I5_7205.json
+++ b/db/I5/I5_7205.json
@@ -1,0 +1,188 @@
+[
+  {
+    "ref": "context-I5_7205", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "I-5", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-I5_7204", 
+          "", 
+          "context-I5_7206", 
+          ""
+        ],
+        "realm": "I5", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "\u007f", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Ground.f9l2.I5_7205", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 40, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-I5_7205"
+  }, 
+  {
+    "ref": "item-Sky1.l9d0.I5_7205", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7205"
+  }, 
+  {
+    "ref": "item-Short_sign.f8k2.I5_7205", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 252, 
+        "ascii": [
+          128, 
+          72, 
+          105, 
+          119, 
+          97, 
+          121, 
+          32, 
+          53
+        ], 
+        "gr_state": 4, 
+        "y": 131, 
+        "x": 120, 
+        "type": "Short_sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Short_sign", 
+    "in": "context-I5_7205"
+  }, 
+  {
+    "ref": "item-Street.k1d9.I5_7205", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 6, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-I5_7205"
+  }, 
+  {
+    "ref": "item-Sky2.s9k2.I5_7205", 
+    "mods": [
+      {
+        "style": 11, 
+        "orientation": 221, 
+        "gr_state": 0, 
+        "y": 81, 
+        "x": 40, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7205"
+  }, 
+  {
+    "ref": "item-Sky3.s9k1.I5_7205", 
+    "mods": [
+      {
+        "style": 11, 
+        "orientation": 8, 
+        "gr_state": 0, 
+        "y": 91, 
+        "x": 24, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7205"
+  }, 
+  {
+    "ref": "item-Super_trapezoid.a8j4.I5_7205", 
+    "mods": [
+      {
+        "style": 0, 
+        "pattern_x_size": 1, 
+        "lower_right_x": 29, 
+        "orientation": 252, 
+        "pattern": [
+          0, 
+          64, 
+          16, 
+          0, 
+          16, 
+          16, 
+          16, 
+          16, 
+          17, 
+          16, 
+          1, 
+          0, 
+          1, 
+          0, 
+          1, 
+          0, 
+          0, 
+          4, 
+          0, 
+          4, 
+          16, 
+          0, 
+          16, 
+          0, 
+          16, 
+          0, 
+          0, 
+          1, 
+          0, 
+          65, 
+          0, 
+          64
+        ], 
+        "upper_right_x": 29, 
+        "lower_left_x": 0, 
+        "trapezoid_type": 0, 
+        "gr_state": 0, 
+        "y": 41, 
+        "x": 24, 
+        "height": 49, 
+        "type": "Super_trapezoid", 
+        "pattern_y_size": 15, 
+        "upper_left_x": 0
+      }
+    ], 
+    "type": "item", 
+    "name": "Super_trapezoid", 
+    "in": "context-I5_7205"
+  }
+]

--- a/db/I5/I5_7206.json
+++ b/db/I5/I5_7206.json
@@ -1,0 +1,195 @@
+[
+  {
+    "ref": "context-I5_7206", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "I-5", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-I5_7205", 
+          "", 
+          "context-I5_7207", 
+          ""
+        ],
+        "realm": "I5", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "\u007f", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Tree1.d8k3.I5_7206", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 236, 
+        "gr_state": 0, 
+        "y": 133, 
+        "x": 4, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7206"
+  }, 
+  {
+    "ref": "item-Tree2.g9k2.I5_7206", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 196, 
+        "gr_state": 0, 
+        "y": 40, 
+        "x": 36, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7206"
+  }, 
+  {
+    "ref": "item-Rock.f8k2.I5_7206", 
+    "mods": [
+      {
+        "style": 2, 
+        "orientation": 220, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 131, 
+        "x": 108, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-I5_7206"
+  }, 
+  {
+    "ref": "item-Sign.s9l2.I5_7206", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 16, 
+        "ascii": [
+          134, 
+          72, 
+          65, 
+          66, 
+          73, 
+          84, 
+          65, 
+          84
+        ], 
+        "gr_state": 0, 
+        "y": 32, 
+        "x": 148, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-I5_7206"
+  }, 
+  {
+    "ref": "item-Tree3.a9l3.I5_7206", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 40, 
+        "x": 92, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7206"
+  }, 
+  {
+    "ref": "item-Tree4.g9l3.I5_7206", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 188, 
+        "gr_state": 2, 
+        "y": 59, 
+        "x": 92, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7206"
+  }, 
+  {
+    "ref": "item-Tree5.g9l2.I5_7206", 
+    "mods": [
+      {
+        "style": 10, 
+        "orientation": 228, 
+        "gr_state": 0, 
+        "y": 132, 
+        "x": 128, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7206"
+  }, 
+  {
+    "ref": "item-Ground.g7j2.I5_7206", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 40, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-I5_7206"
+  }, 
+  {
+    "ref": "item-Street.g8k2.I5_7206", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 6, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-I5_7206"
+  }, 
+  {
+    "ref": "item-Sky.f9l1.I5_7206", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7206"
+  }
+]

--- a/db/I5/I5_7207.json
+++ b/db/I5/I5_7207.json
@@ -1,0 +1,214 @@
+[
+  {
+    "ref": "context-I5_7207", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "I-5", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-I5_7206", 
+          "", 
+          "context-I5_7208", 
+          ""
+        ],
+        "realm": "I5", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "\u007f", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Plant1.f9k1.I5_7207", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 173, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 32, 
+        "x": 128, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-I5_7207"
+  }, 
+  {
+    "ref": "item-Plant2.d7x9.I5_7207", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 172, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 130, 
+        "x": 72, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-I5_7207"
+  }, 
+  {
+    "ref": "item-Plant3.v8k2.I5_7207", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 173, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 130, 
+        "x": 108, 
+        "type": "Plant"
+      }
+    ], 
+    "type": "item", 
+    "name": "Plant", 
+    "in": "context-I5_7207"
+  }, 
+  {
+    "ref": "item-Sign1.v8m3.I5_7207", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 16, 
+        "ascii": [
+          32, 
+          32, 
+          128, 
+          73, 
+          83, 
+          134, 
+          32, 
+          32, 
+          70, 
+          79, 
+          82, 
+          134, 
+          128, 
+          80, 
+          69, 
+          79, 
+          80, 
+          76, 
+          69
+        ], 
+        "gr_state": 0, 
+        "y": 32, 
+        "x": 44, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-I5_7207"
+  }, 
+  {
+    "ref": "item-Ground.h9k2.I5_7207", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 40, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-I5_7207"
+  }, 
+  {
+    "ref": "item-Sky.v6n2.I5_7207", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7207"
+  }, 
+  {
+    "ref": "item-Street.d8k1.I5_7207", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 6, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-I5_7207"
+  }, 
+  {
+    "ref": "item-Bush.j4k1.I5_7207", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 188, 
+        "gr_state": 0, 
+        "y": 129, 
+        "x": 8, 
+        "type": "Bush"
+      }
+    ], 
+    "type": "item", 
+    "name": "Bush", 
+    "in": "context-I5_7207"
+  }, 
+  {
+    "ref": "item-Sign2.b7n2.I5_7207", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 16, 
+        "ascii": [
+          32, 
+          32, 
+          87, 
+          72, 
+          79, 
+          134, 
+          32, 
+          67, 
+          65, 
+          78, 
+          39, 
+          84, 
+          134, 
+          128, 
+          72, 
+          65, 
+          78, 
+          68, 
+          76, 
+          69
+        ], 
+        "gr_state": 0, 
+        "y": 32, 
+        "x": 148, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-I5_7207"
+  }
+]

--- a/db/I5/I5_7208.json
+++ b/db/I5/I5_7208.json
@@ -1,0 +1,178 @@
+[
+  {
+    "ref": "context-I5_7208", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "I-5", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-I5_7207", 
+          "", 
+          "context-I5_7209", 
+          ""
+        ],
+        "realm": "I5", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "\u007f", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Tree1.s8k2.I5_7208", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 236, 
+        "gr_state": 0, 
+        "y": 157, 
+        "x": 28, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7208"
+  }, 
+  {
+    "ref": "item-Tree2.f9k2.I5_7208", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 252, 
+        "gr_state": 0, 
+        "y": 32, 
+        "x": 0, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7208"
+  }, 
+  {
+    "ref": "item-Sky.v8m2.I5_7208", 
+    "mods": [
+      {
+        "style": 10, 
+        "orientation": 188, 
+        "gr_state": 0, 
+        "y": 110, 
+        "x": 8, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7208"
+  }, 
+  {
+    "ref": "item-Street.m3n8.I5_7208", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 6, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-I5_7208"
+  }, 
+  {
+    "ref": "item-Sky.x8n3.I5_7208", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7208"
+  }, 
+  {
+    "ref": "item-Ground.b7m2.I5_7208", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 40, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-I5_7208"
+  }, 
+  {
+    "ref": "item-Tree3.f7j1.I5_7208", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 188, 
+        "gr_state": 2, 
+        "y": 44, 
+        "x": 112, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7208"
+  }, 
+  {
+    "ref": "item-Tree4.g2j4.I5_7208", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 188, 
+        "gr_state": 3, 
+        "y": 32, 
+        "x": 108, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7208"
+  }, 
+  {
+    "ref": "item-Sign.x6n2.I5_7208", 
+    "mods": [
+      {
+        "style": 3, 
+        "orientation": 16, 
+        "ascii": [
+          134, 
+          82, 
+          69, 
+          65, 
+          76, 
+          73, 
+          84, 
+          89
+        ], 
+        "gr_state": 0, 
+        "y": 32, 
+        "x": 148, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-I5_7208"
+  }
+]

--- a/db/I5/I5_7209.json
+++ b/db/I5/I5_7209.json
@@ -1,0 +1,228 @@
+[
+  {
+    "ref": "context-I5_7209", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "I-5", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-I5_7208", 
+          "context-Desert_1a", 
+          "context-I5_1310", 
+          ""
+        ],
+        "realm": "I5", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "\u007f", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Sky.m3n8.I5_7209", 
+    "mods": [
+      {
+        "style": 10, 
+        "orientation": 188, 
+        "gr_state": 0, 
+        "y": 80, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7209"
+  }, 
+  {
+    "ref": "item-Tree1.v7n2.I5_7209", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 172, 
+        "gr_state": 0, 
+        "y": 43, 
+        "x": 120, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7209"
+  }, 
+  {
+    "ref": "item-Sky.b7h1.I5_7209", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-I5_7209"
+  }, 
+  {
+    "ref": "item-Street.t8j2.I5_7209", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 16, 
+        "gr_state": 13, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-I5_7209"
+  }, 
+  {
+    "ref": "item-Tree2.x8n1.I5_7209", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 173, 
+        "gr_state": 2, 
+        "y": 82, 
+        "x": 80, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7209"
+  }, 
+  {
+    "ref": "item-Ground.a9l1.I5_7209", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 40, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-I5_7209"
+  }, 
+  {
+    "ref": "item-Rock1.v8b2.I5_7209", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 220, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 161, 
+        "x": 60, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-I5_7209"
+  }, 
+  {
+    "ref": "item-Rock2.f9l1.I5_7209", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 220, 
+        "mass": 1, 
+        "gr_state": 0, 
+        "y": 38, 
+        "x": 32, 
+        "type": "Rock"
+      }
+    ], 
+    "type": "item", 
+    "name": "Rock", 
+    "in": "context-I5_7209"
+  }, 
+  {
+    "ref": "item-Tree3.d8j2.I5_7209", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 172, 
+        "gr_state": 2, 
+        "y": 78, 
+        "x": 84, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7209"
+  }, 
+  {
+    "ref": "item-Short_sign.h2u3.I5_7209", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 16, 
+        "ascii": [
+          68, 
+          69, 
+          83, 
+          69, 
+          82, 
+          84, 
+          133, 
+          125
+        ], 
+        "gr_state": 7, 
+        "y": 32, 
+        "x": 20, 
+        "type": "Short_sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Short_sign", 
+    "in": "context-I5_7209"
+  }, 
+  {
+    "ref": "item-Tree4.t8j2.I5_7209", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 172, 
+        "gr_state": 1, 
+        "y": 33, 
+        "x": 84, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7209"
+  }, 
+  {
+    "ref": "item-Tree5.u2h3.I5_7209", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 172, 
+        "gr_state": 4, 
+        "y": 59, 
+        "x": 92, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-I5_7209"
+  }
+]

--- a/db/Popustop/Popustop.afront2.line1106.json
+++ b/db/Popustop/Popustop.afront2.line1106.json
@@ -6,12 +6,12 @@
         "town_dir": DOWN, 
         "neighbors": [
           "", 
-          "context-Popustop.lobby.line3", 
+          "context-Popustop.aprominade2.line1107", 
           "", 
-          "context-Popustop.aprominade2.line1107"
+          "context-Popustop.lobby.line3"
         ], 
         "realm": "Popustop", 
-        "orientation": 2, 
+        "orientation": 0, 
         "nitty_bits": 3, 
         "port_dir": DOWN, 
         "type": "Region"

--- a/db/Popustop/Popustop.aprominade2.line1107.json
+++ b/db/Popustop/Popustop.aprominade2.line1107.json
@@ -3,16 +3,16 @@
     "capacity": 64, 
     "mods": [
       {
-        "town_dir": DOWN, 
+        "town_dir": RIGHT, 
         "neighbors": [
+          "context-Woods_1284", 
           "", 
-          "context-Popustop.afront2.line1106", 
-          "", 
-          "context-Woods_5x"
+          "context-Woods_1164", 
+          "context-Popustop.afront2.line1106"
         ], 
         "realm": "Popustop", 
         "aliases" : [ "pop-hotel", "pop-motel", "pop-apartment", "pop-apt" ],
-        "orientation": 2, 
+        "orientation": 0, 
         "nitty_bits": 3, 
         "port_dir": "", 
         "type": "Region"
@@ -41,7 +41,7 @@
     "ref": "item-ground.Popustop.aprominade2.line1107", 
     "mods": [
       {
-        "y": 1, 
+        "y": 4, 
         "x": 0, 
         "style": 1, 
         "type": "Ground", 
@@ -65,6 +65,23 @@
     ], 
     "ref": "item-sky2.Popustop.aprominade2.line1107", 
     "name": "Sky", 
+    "in": "context-Popustop.aprominade2.line1107"
+  },
+  {
+    "ref": "item-street.d9w9.Popustop.aprominade2.line1107", 
+    "mods": [
+      {
+        "orientation": 8, 
+        "height": 0, 
+        "width": 0, 
+        "gr_state": 6, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
     "in": "context-Popustop.aprominade2.line1107"
   },  
   {
@@ -263,14 +280,14 @@
     "ref": "item-trap5.Popustop.aprominade2.line1107", 
     "mods": [
       {
-        "lower_right_x": 40, 
-        "upper_left_x": 16,
-        "upper_right_x": 20,
+        "lower_right_x": 20, 
+        "upper_left_x": 9,
+        "upper_right_x": 11,
         "lower_left_x": 0, 
         "trapezoid_type": 0, 
-        "y": 5, 
-        "x": 56, 
-        "height": 44, 
+        "y": 28, 
+        "x": 66, 
+        "height": 20, 
         "type": "Trapezoid", 
         "orientation": 8
       }

--- a/db/Woods/Woods_1164.json
+++ b/db/Woods/Woods_1164.json
@@ -1,0 +1,115 @@
+[
+  {
+    "ref": "context-Woods_1164", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "Map recommended", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-Popustop.aprominade2.line1107", 
+          "", 
+          "context-I5_7200", 
+          "context-back4t_75"
+        ],
+        "realm": "Woods", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": "\u007f", 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Street.f8k2.Woods_1164", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 8, 
+        "gr_state": 14, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Woods_1164"
+  }, 
+  {
+    "ref": "item-Ground.v8m3.Woods_1164", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 196, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-Woods_1164"
+  }, 
+  {
+    "ref": "item-Sky.b8m1.Woods_1164", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Woods_1164"
+  }, 
+  {
+    "ref": "item-Sign.b7m1.Woods_1164", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 16, 
+        "ascii": [
+          66, 
+          65, 
+          67, 
+          75, 
+          52, 
+          48, 
+          128, 
+          133, 
+          124
+        ], 
+        "gr_state": 5, 
+        "y": 163, 
+        "x": 48, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-Woods_1164"
+  }, 
+  {
+    "ref": "item-Tree.m4n3.Woods_1164", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 172, 
+        "gr_state": 0, 
+        "y": 32, 
+        "x": 148, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Woods_1164"
+  }
+]

--- a/db/Woods/Woods_1284.json
+++ b/db/Woods/Woods_1284.json
@@ -1,0 +1,205 @@
+[
+  {
+    "ref": "context-Woods_1284", 
+    "capacity": 64, 
+    "type": "context", 
+    "name": "Woods Rd/I-5", 
+    "mods": [
+      {
+        "town_dir": "\u007f", 
+        "neighbors": [
+          "context-Woods_5x", 
+          "", 
+          "context-Popustop.aprominade2.line1107", 
+          ""
+        ],
+        "realm": "Woods", 
+        "orientation": 0, 
+        "nitty_bits": 3, 
+        "port_dir": LEFT, 
+        "type": "Region"
+      }
+    ]
+  }, 
+  {
+    "ref": "item-Tree1.x8m2.Woods_1284", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 172, 
+        "gr_state": 0, 
+        "y": 35, 
+        "x": 36, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Woods_1284"
+  }, 
+  {
+    "ref": "item-Short_sign.d9k1.Woods_1284", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 16, 
+        "ascii": [
+          68, 
+          78, 
+          84, 
+          79, 
+          87, 
+          78, 
+          128, 
+          133, 
+          127
+        ], 
+        "gr_state": 7, 
+        "y": 160, 
+        "x": 112, 
+        "type": "Short_sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Short_sign", 
+    "in": "context-Woods_1284"
+  }, 
+  {
+    "ref": "item-Sign.n3m1.Woods_1284", 
+    "mods": [
+      {
+        "style": 5, 
+        "orientation": 16, 
+        "ascii": [
+          87, 
+          111, 
+          111, 
+          100, 
+          115, 
+          32, 
+          82, 
+          100
+        ], 
+        "gr_state": 5, 
+        "y": 31, 
+        "x": 64, 
+        "type": "Sign"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sign", 
+    "in": "context-Woods_1284"
+  }, 
+  {
+    "ref": "item-Tree2.g8j2.Woods_1284", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 172, 
+        "gr_state": 0, 
+        "y": 169, 
+        "x": 108, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Woods_1284"
+  }, 
+  {
+    "ref": "item-Sky.v8m1.Woods_1284", 
+    "mods": [
+      {
+        "style": 4, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 0, 
+        "x": 0, 
+        "type": "Sky"
+      }
+    ], 
+    "type": "item", 
+    "name": "Sky", 
+    "in": "context-Woods_1284"
+  }, 
+  {
+    "ref": "item-Street.b8m1.Woods_1284", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 8, 
+        "gr_state": 6, 
+        "y": 12, 
+        "x": 68, 
+        "type": "Street"
+      }
+    ], 
+    "type": "item", 
+    "name": "Street", 
+    "in": "context-Woods_1284"
+  }, 
+  {
+    "ref": "item-Tree3.a9k1.Woods_1284", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 172, 
+        "gr_state": 0, 
+        "y": 42, 
+        "x": 96, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Woods_1284"
+  }, 
+  {
+    "ref": "item-Ground.b7m2.Woods_1284", 
+    "mods": [
+      {
+        "style": 0, 
+        "orientation": 204, 
+        "gr_state": 0, 
+        "y": 4, 
+        "x": 0, 
+        "type": "Ground"
+      }
+    ], 
+    "type": "item", 
+    "name": "Ground", 
+    "in": "context-Woods_1284"
+  }, 
+  {
+    "ref": "item-Tree4.n2m3.Woods_1284", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 172, 
+        "gr_state": 0, 
+        "y": 41, 
+        "x": 120, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Woods_1284"
+  }, 
+  {
+    "ref": "item-Tree5.n7b2.Woods_1284", 
+    "mods": [
+      {
+        "style": 1, 
+        "orientation": 173, 
+        "gr_state": 0, 
+        "y": 42, 
+        "x": 148, 
+        "type": "Tree"
+      }
+    ], 
+    "type": "item", 
+    "name": "Tree", 
+    "in": "context-Woods_1284"
+  }
+]

--- a/db/Woods/Woods_5x.json
+++ b/db/Woods/Woods_5x.json
@@ -3,16 +3,16 @@
     "ref": "context-Woods_5x", 
     "capacity": 64, 
     "type": "context", 
-    "name": "Woods Rd", 
+    "name": "Woods Rd/I-5", 
     "mods": [
       {
         "town_dir": UP,
         "port_dir": UP,
         "neighbors": [
           "context-Woods_5y", 
-          "context-Popustop.aprominade2.line1107",
-          "context-beach_2f", 
-          "context-welcomecenterext"
+          "",
+          "context-Woods_1284", 
+          "context-Downtown_7f"
         ],
         "realm": "Woods",             
         "orientation": 0, 
@@ -57,7 +57,7 @@
         "orientation": 8, 
         "height": 0, 
         "width": 0, 
-        "gr_state": 0, 
+        "gr_state": 14, 
         "y": 12, 
         "x": 68, 
         "type": "Street"

--- a/db/Woods/Woods_5y.json
+++ b/db/Woods/Woods_5y.json
@@ -3,7 +3,7 @@
     "ref": "context-Woods_5y", 
     "capacity": 64, 
     "type": "context", 
-    "name": "Woods Rd", 
+    "name": "Woods Rd/I-5", 
     "mods": [
       {
         "town_dir": LEFT,

--- a/db/Woods/Woods_6j.json
+++ b/db/Woods/Woods_6j.json
@@ -9,7 +9,7 @@
         "town_dir": "", 
         "neighbors": [
           "context-Woods_6k", 
-          "context-back4t_31", 
+          "", 
           "context-Woods_6i", 
           "context-Woods_5j"
         ],


### PR DESCRIPTION
Adds:
 - I/5
 - context-Woods_1284
 - context-Woods_1164
 
Restores original connections to
 - Popustop
 - Back 40
 - Beach
 - Desert
 - I/5
 
Removed NeoHabitat placeholder connections from the following regions:
 - context-back4t_31
 - context-back4t_75
 - context-beach_2f
 - context-Popustop.aprominade2.line1007
 - Woods_5x
 - Woods_6j
 
Changed street shapes for Woods_5x and Woods_1284 for now until the areas that link to them are restored

Modified Back4t_75 to have a sign that was in the original Habitat db

Modified Beach_2a to have a sign that was in the original Habitat db

Modified Beach Town/Port dirs to match the new connection point