### PR TITLE
Region changes!

### DIFF
--- a/db/Dnalsi/dnalsi_02.json
+++ b/db/Dnalsi/dnalsi_02.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_03.json
+++ b/db/Dnalsi/dnalsi_03.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_04.json
+++ b/db/Dnalsi/dnalsi_04.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_05.json
+++ b/db/Dnalsi/dnalsi_05.json
@@ -15,8 +15,9 @@
         ], 
         "realm": "Dnalsi",
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_08.json
+++ b/db/Dnalsi/dnalsi_08.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_09.json
+++ b/db/Dnalsi/dnalsi_09.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_0a.json
+++ b/db/Dnalsi/dnalsi_0a.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",         
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_11.json
+++ b/db/Dnalsi/dnalsi_11.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_12.json
+++ b/db/Dnalsi/dnalsi_12.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_15.json
+++ b/db/Dnalsi/dnalsi_15.json
@@ -15,8 +15,9 @@
         ], 
         "realm": "Dnalsi",
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_18.json
+++ b/db/Dnalsi/dnalsi_18.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_19.json
+++ b/db/Dnalsi/dnalsi_19.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_1a.json
+++ b/db/Dnalsi/dnalsi_1a.json
@@ -15,8 +15,9 @@
         ], 
         "realm": "Dnalsi",
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_1b.json
+++ b/db/Dnalsi/dnalsi_1b.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_1c.json
+++ b/db/Dnalsi/dnalsi_1c.json
@@ -15,8 +15,9 @@
         ], 
         "realm": "Dnalsi",
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_1d.json
+++ b/db/Dnalsi/dnalsi_1d.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_21.json
+++ b/db/Dnalsi/dnalsi_21.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_25.json
+++ b/db/Dnalsi/dnalsi_25.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_26.json
+++ b/db/Dnalsi/dnalsi_26.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_28.json
+++ b/db/Dnalsi/dnalsi_28.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_29.json
+++ b/db/Dnalsi/dnalsi_29.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_2a.json
+++ b/db/Dnalsi/dnalsi_2a.json
@@ -15,8 +15,9 @@
         ], 
         "realm": "Dnalsi",
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_2b.json
+++ b/db/Dnalsi/dnalsi_2b.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_2c.json
+++ b/db/Dnalsi/dnalsi_2c.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_2d.json
+++ b/db/Dnalsi/dnalsi_2d.json
@@ -15,8 +15,9 @@
         ], 
         "realm": "Dnalsi",
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_30.json
+++ b/db/Dnalsi/dnalsi_30.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_31.json
+++ b/db/Dnalsi/dnalsi_31.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_36.json
+++ b/db/Dnalsi/dnalsi_36.json
@@ -15,8 +15,9 @@
         ], 
         "realm": "Dnalsi",
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_37.json
+++ b/db/Dnalsi/dnalsi_37.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 28, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_38.json
+++ b/db/Dnalsi/dnalsi_38.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_39.json
+++ b/db/Dnalsi/dnalsi_39.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_3a.json
+++ b/db/Dnalsi/dnalsi_3a.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_3b.json
+++ b/db/Dnalsi/dnalsi_3b.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_3c.json
+++ b/db/Dnalsi/dnalsi_3c.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_3d.json
+++ b/db/Dnalsi/dnalsi_3d.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_40.json
+++ b/db/Dnalsi/dnalsi_40.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_47.json
+++ b/db/Dnalsi/dnalsi_47.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_48.json
+++ b/db/Dnalsi/dnalsi_48.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_49.json
+++ b/db/Dnalsi/dnalsi_49.json
@@ -15,8 +15,9 @@
         ], 
         "realm": "Dnalsi",
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_4a.json
+++ b/db/Dnalsi/dnalsi_4a.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_4b.json
+++ b/db/Dnalsi/dnalsi_4b.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_4c.json
+++ b/db/Dnalsi/dnalsi_4c.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_50.json
+++ b/db/Dnalsi/dnalsi_50.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_57.json
+++ b/db/Dnalsi/dnalsi_57.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_58.json
+++ b/db/Dnalsi/dnalsi_58.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_59.json
+++ b/db/Dnalsi/dnalsi_59.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_5a.json
+++ b/db/Dnalsi/dnalsi_5a.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_5b.json
+++ b/db/Dnalsi/dnalsi_5b.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_5c.json
+++ b/db/Dnalsi/dnalsi_5c.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_60.json
+++ b/db/Dnalsi/dnalsi_60.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_61.json
+++ b/db/Dnalsi/dnalsi_61.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_62.json
+++ b/db/Dnalsi/dnalsi_62.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_63.json
+++ b/db/Dnalsi/dnalsi_63.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_64.json
+++ b/db/Dnalsi/dnalsi_64.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_65.json
+++ b/db/Dnalsi/dnalsi_65.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_66.json
+++ b/db/Dnalsi/dnalsi_66.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_67.json
+++ b/db/Dnalsi/dnalsi_67.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_68.json
+++ b/db/Dnalsi/dnalsi_68.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_69.json
+++ b/db/Dnalsi/dnalsi_69.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_6a.json
+++ b/db/Dnalsi/dnalsi_6a.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_6b.json
+++ b/db/Dnalsi/dnalsi_6b.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_6c.json
+++ b/db/Dnalsi/dnalsi_6c.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_71.json
+++ b/db/Dnalsi/dnalsi_71.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_72.json
+++ b/db/Dnalsi/dnalsi_72.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_73.json
+++ b/db/Dnalsi/dnalsi_73.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_74.json
+++ b/db/Dnalsi/dnalsi_74.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_75.json
+++ b/db/Dnalsi/dnalsi_75.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_76.json
+++ b/db/Dnalsi/dnalsi_76.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_78.json
+++ b/db/Dnalsi/dnalsi_78.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_79.json
+++ b/db/Dnalsi/dnalsi_79.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_7a.json
+++ b/db/Dnalsi/dnalsi_7a.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_7b.json
+++ b/db/Dnalsi/dnalsi_7b.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_7c.json
+++ b/db/Dnalsi/dnalsi_7c.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_82.json
+++ b/db/Dnalsi/dnalsi_82.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_83.json
+++ b/db/Dnalsi/dnalsi_83.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_84.json
+++ b/db/Dnalsi/dnalsi_84.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_85.json
+++ b/db/Dnalsi/dnalsi_85.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_92.json
+++ b/db/Dnalsi/dnalsi_92.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_93.json
+++ b/db/Dnalsi/dnalsi_93.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_94.json
+++ b/db/Dnalsi/dnalsi_94.json
@@ -15,8 +15,9 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave1_0a.json
+++ b/db/Dnalsi/dnalsi_cave1_0a.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave1_0b.json
+++ b/db/Dnalsi/dnalsi_cave1_0b.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave1_1a.json
+++ b/db/Dnalsi/dnalsi_cave1_1a.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave1_1b.json
+++ b/db/Dnalsi/dnalsi_cave1_1b.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_0c.json
+++ b/db/Dnalsi/dnalsi_cave2_0c.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_0d.json
+++ b/db/Dnalsi/dnalsi_cave2_0d.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_1a.json
+++ b/db/Dnalsi/dnalsi_cave2_1a.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_1b.json
+++ b/db/Dnalsi/dnalsi_cave2_1b.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_1c.json
+++ b/db/Dnalsi/dnalsi_cave2_1c.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_1d.json
+++ b/db/Dnalsi/dnalsi_cave2_1d.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_1e.json
+++ b/db/Dnalsi/dnalsi_cave2_1e.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_2a.json
+++ b/db/Dnalsi/dnalsi_cave2_2a.json
@@ -15,8 +15,10 @@
         ], 
         "realm": "Dnalsi",
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_2b.json
+++ b/db/Dnalsi/dnalsi_cave2_2b.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_2c.json
+++ b/db/Dnalsi/dnalsi_cave2_2c.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_2d.json
+++ b/db/Dnalsi/dnalsi_cave2_2d.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_2e.json
+++ b/db/Dnalsi/dnalsi_cave2_2e.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave2_3a.json
+++ b/db/Dnalsi/dnalsi_cave2_3a.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave3_0c.json
+++ b/db/Dnalsi/dnalsi_cave3_0c.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave3_1a.json
+++ b/db/Dnalsi/dnalsi_cave3_1a.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 2, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave3_1c.json
+++ b/db/Dnalsi/dnalsi_cave3_1c.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave3_2a.json
+++ b/db/Dnalsi/dnalsi_cave3_2a.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 0, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave3_2b.json
+++ b/db/Dnalsi/dnalsi_cave3_2b.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave3_2c.json
+++ b/db/Dnalsi/dnalsi_cave3_2c.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 3, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/Dnalsi/dnalsi_cave3_3c.json
+++ b/db/Dnalsi/dnalsi_cave3_3c.json
@@ -15,8 +15,10 @@
         ],
         "realm": "Dnalsi",        
         "orientation": 1, 
-        "nitty_bits": 3, 
-        "port_dir": "", 
+        "nitty_bits": 0, 
+        "port_dir": "",
+        "depth": 30, 
+        "lighting": -1, 
         "type": "Region"
       }
     ]

--- a/db/I5/I5_1310.json
+++ b/db/I5/I5_1310.json
@@ -16,7 +16,8 @@
         "realm": "I5",		
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": DOWN, 
+        "port_dir": DOWN,
+		"depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Popustop/Popustop.afront2.line1106.json
+++ b/db/Popustop/Popustop.afront2.line1106.json
@@ -13,7 +13,8 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": DOWN, 
+        "port_dir": DOWN,
+        "depth": 25,		
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.aprominade2.line1107.json
+++ b/db/Popustop/Popustop.aprominade2.line1107.json
@@ -14,7 +14,8 @@
         "aliases" : [ "pop-hotel", "pop-motel", "pop-apartment", "pop-apt" ],
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "", 
+        "port_dir": "",
+        "depth": 25,		
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.bboard.line4.json
+++ b/db/Popustop/Popustop.bboard.line4.json
@@ -13,7 +13,8 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "", 
+        "port_dir": "",
+        "depth": 24,		
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.lobby.line3.json
+++ b/db/Popustop/Popustop.lobby.line3.json
@@ -13,7 +13,8 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "}", 
+        "port_dir": "}",
+        "depth": 29, 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/Popustop.stairs.line2.json
+++ b/db/Popustop/Popustop.stairs.line2.json
@@ -13,7 +13,8 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "}", 
+        "port_dir": "}",
+        "depth": 29,		
         "type": "Region"
       }
     ], 

--- a/db/Popustop/basement.line1.json
+++ b/db/Popustop/basement.line1.json
@@ -13,7 +13,8 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "", 
+        "port_dir": "",
+		"depth": 29, 
         "type": "Region"
       }
     ], 

--- a/db/Popustop/roof.line1105.json
+++ b/db/Popustop/roof.line1105.json
@@ -13,7 +13,8 @@
         "realm": "Popustop", 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "~", 
+        "port_dir": "~",
+        "depth": 29,		
         "type": "Region"
       }
     ], 

--- a/db/Streets/Aric_Ave_24_interior.json
+++ b/db/Streets/Aric_Ave_24_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Aric_Ave_34_interior.json
+++ b/db/Streets/Aric_Ave_34_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Aric_Ave_44_interior.json
+++ b/db/Streets/Aric_Ave_44_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Aric_Ave_64_interior.json
+++ b/db/Streets/Aric_Ave_64_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Baker_St_221_interior.json
+++ b/db/Streets/Baker_St_221_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Dice_Ave_11_interior.json
+++ b/db/Streets/Dice_Ave_11_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Dice_Ave_31_interior.json
+++ b/db/Streets/Dice_Ave_31_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Dice_Ave_61_interior.json
+++ b/db/Streets/Dice_Ave_61_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Dice_Ave_71_interior.json
+++ b/db/Streets/Dice_Ave_71_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Dice_Ave_81_interior.json
+++ b/db/Streets/Dice_Ave_81_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Disk_Dr_927_interior.json
+++ b/db/Streets/Disk_Dr_927_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/EZ_St_626_interior.json
+++ b/db/Streets/EZ_St_626_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/HyperDr_830_interior.json
+++ b/db/Streets/HyperDr_830_interior.json
@@ -16,7 +16,8 @@
         "realm": "Streets",        
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": "", 
+        "port_dir": "",
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/IO_517_interior.json
+++ b/db/Streets/IO_517_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Lori_Ln_313_interior.json
+++ b/db/Streets/Lori_Ln_313_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Mince_St_82_interior.json
+++ b/db/Streets/Mince_St_82_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Mince_St_92_interior.json
+++ b/db/Streets/Mince_St_92_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/Streets/OutamyWy_229_interior.json
+++ b/db/Streets/OutamyWy_229_interior.json
@@ -16,7 +16,8 @@
         "realm": "Streets",            
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": "", 
+        "port_dir": "",
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Randy_Rd_103_interior.json
+++ b/db/Streets/Randy_Rd_103_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Randy_Rd_23_interior.json
+++ b/db/Streets/Randy_Rd_23_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 28, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Randy_Rd_93_interior.json
+++ b/db/Streets/Randy_Rd_93_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/RoadSt_332_interior.json
+++ b/db/Streets/RoadSt_332_interior.json
@@ -16,7 +16,8 @@
         "realm": "Streets",    
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": "", 
+        "port_dir": "",
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Sunday_Dr_120_interior.json
+++ b/db/Streets/Sunday_Dr_120_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/This_Way_25_interior.json
+++ b/db/Streets/This_Way_25_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/Streets/This_Way_35_interior.json
+++ b/db/Streets/This_Way_35_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/This_Way_45_interior.json
+++ b/db/Streets/This_Way_45_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/Streets/This_Way_55_interior.json
+++ b/db/Streets/This_Way_55_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/Streets/This_Way_65_interior.json
+++ b/db/Streets/This_Way_65_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/Streets/This_Way_85_interior.json
+++ b/db/Streets/This_Way_85_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Wrong_Wy_16_interior.json
+++ b/db/Streets/Wrong_Wy_16_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/Streets/Wrong_Wy_86_interior.json
+++ b/db/Streets/Wrong_Wy_86_interior.json
@@ -17,7 +17,8 @@
         "is_turf": true, 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": UP, 
+        "port_dir": UP,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/Woods/Woods_4t.json
+++ b/db/Woods/Woods_4t.json
@@ -16,7 +16,8 @@
         "realm": "Woods",             
         "orientation": 0, 
         "nitty_bits": 1, 
-        "port_dir": "", 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Woods/Woods_4u.json
+++ b/db/Woods/Woods_4u.json
@@ -16,7 +16,8 @@
         "realm": "Woods",             
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "", 
+        "port_dir": "",
+        "depth": 30, 
         "type": "Region"
       }
     ]

--- a/db/Woods/Woods_6w.json
+++ b/db/Woods/Woods_6w.json
@@ -34,7 +34,25 @@
     "type": "item", 
     "name": "Ground", 
     "in": "context-Woods_6w"
-  }, 
+  },
+  {
+    "ref": "item-Magic_immobile.f8d7.Woods_6w", 
+    "mods": [
+      {
+        "style": 11, 
+        "orientation": 0, 
+        "gr_state": 0, 
+        "y": 31, 
+        "x": 12,
+        "magic_type": 4,
+        "magic_data": 999860, 
+        "type": "Magic_immobile"
+      }
+    ], 
+    "type": "item", 
+    "name": "Magic_immobile", 
+    "in": "context-Woods_6w"
+  },   
   {
     "ref": "item-sky.da0f.Woods_6w", 
     "mods": [

--- a/db/new_Downtown/Downtown_10350.json
+++ b/db/new_Downtown/Downtown_10350.json
@@ -9,7 +9,8 @@
         "town_dir": "}", 
         "port_dir": "}", 
         "type": "Region",
-        "orientation": 0,		
+        "orientation": 0,
+        "depth": 25,		
         "neighbors": [
           "",
           "context-Downtown_10351",

--- a/db/new_Downtown/Downtown_10351.json
+++ b/db/new_Downtown/Downtown_10351.json
@@ -9,7 +9,8 @@
         "town_dir": "}", 
         "port_dir": "}", 
         "type": "Region",
-        "orientation": 0,		
+        "orientation": 0,
+        "depth": 29,		
         "neighbors": [
           "context-Downtown_10352",
           "context-Downtown_1972",

--- a/db/new_Downtown/Downtown_10352.json
+++ b/db/new_Downtown/Downtown_10352.json
@@ -9,7 +9,8 @@
         "town_dir": "~", 
         "port_dir": "~", 
         "type": "Region",
-        "orientation": 0,		
+        "orientation": 0,
+        "depth": 23,		
         "neighbors": [
           "",
           "",

--- a/db/new_Downtown/Downtown_10385.json
+++ b/db/new_Downtown/Downtown_10385.json
@@ -9,7 +9,8 @@
         "town_dir": "}", 
         "port_dir": "}", 
         "type": "Region",
-        "orientation": 1,		
+        "orientation": 1,
+        "depth": 29,		
         "neighbors": [
           "",
           "",

--- a/db/new_Downtown/Downtown_10386.json
+++ b/db/new_Downtown/Downtown_10386.json
@@ -9,7 +9,8 @@
         "town_dir": "}", 
         "port_dir": "}", 
         "type": "Region",
-        "orientation": 1,		
+        "orientation": 1,
+        "depth": 29,		
         "neighbors": [
           "",
           "",

--- a/db/new_Downtown/Downtown_10456.json
+++ b/db/new_Downtown/Downtown_10456.json
@@ -9,7 +9,8 @@
         "town_dir": "\u007f", 
         "port_dir": "\u007f", 
         "type": "Region",
-        "orientation": 1,		
+        "orientation": 1,
+        "depth": 29,		
         "neighbors": [
           "",
           "context-Downtown_10457",

--- a/db/new_Downtown/Downtown_10457.json
+++ b/db/new_Downtown/Downtown_10457.json
@@ -9,7 +9,8 @@
         "town_dir": "}", 
         "port_dir": "}", 
         "type": "Region",
-        "orientation": 1,		
+        "orientation": 1,
+        "depth": 29,		
         "neighbors": [
           "",
           "context-Downtown_10458",

--- a/db/new_Downtown/Downtown_10458.json
+++ b/db/new_Downtown/Downtown_10458.json
@@ -9,7 +9,8 @@
         "town_dir": "~", 
         "port_dir": "~", 
         "type": "Region",
-        "orientation": 1,		
+        "orientation": 1,
+        "depth": 29,		
         "neighbors": [
           "",
           "",

--- a/db/new_Downtown/Downtown_10459.json
+++ b/db/new_Downtown/Downtown_10459.json
@@ -9,7 +9,8 @@
         "town_dir": "|", 
         "port_dir": "|", 
         "type": "Region",
-        "orientation": 1,		
+        "orientation": 1,
+        "depth": 29,		
         "neighbors": [
           "context-Downtown_10458",
           "",

--- a/db/new_Downtown/Downtown_10473.json
+++ b/db/new_Downtown/Downtown_10473.json
@@ -10,6 +10,7 @@
         "port_dir": "}",
         "type": "Region",
 		"orientation": 3,
+        "depth": 29,
         "neighbors": [
           "context-Downtown_10479",
           "",

--- a/db/new_Downtown/Downtown_10474.json
+++ b/db/new_Downtown/Downtown_10474.json
@@ -10,6 +10,7 @@
         "port_dir": "}",
         "type": "Region",
 		"orientation": 3,
+        "depth": 29,
         "neighbors": [
           "context-Downtown_10479",
           "",

--- a/db/new_Downtown/Downtown_10475.json
+++ b/db/new_Downtown/Downtown_10475.json
@@ -10,6 +10,7 @@
         "port_dir": "}",
         "type": "Region",
 		"orientation": 3,
+        "depth": 29,
         "neighbors": [
           "context-Downtown_10479",
           "",

--- a/db/new_Downtown/Downtown_10476.json
+++ b/db/new_Downtown/Downtown_10476.json
@@ -10,6 +10,7 @@
         "port_dir": "}",
         "type": "Region",
 		"orientation": 3,
+        "depth": 29,
         "neighbors": [
           "context-Downtown_10479",
           "",

--- a/db/new_Downtown/Downtown_10477.json
+++ b/db/new_Downtown/Downtown_10477.json
@@ -10,6 +10,7 @@
         "port_dir": "}",
         "type": "Region",
 		"orientation": 3,
+        "depth": 29,
         "neighbors": [
           "context-Downtown_10479",
           "",

--- a/db/new_Downtown/Downtown_10478.json
+++ b/db/new_Downtown/Downtown_10478.json
@@ -10,6 +10,7 @@
         "port_dir": "}",
         "type": "Region",
 		"orientation": 3,
+        "depth": 29,
         "neighbors": [
           "context-Downtown_10479",
           "",

--- a/db/new_Downtown/Downtown_10479.json
+++ b/db/new_Downtown/Downtown_10479.json
@@ -10,6 +10,7 @@
         "port_dir": "}",
         "type": "Region",
 		"orientation": 3,
+        "depth": 29,
         "neighbors": [
           "context-Downtown_7b",
           "",

--- a/db/new_Downtown/Downtown_1977.json
+++ b/db/new_Downtown/Downtown_1977.json
@@ -15,7 +15,8 @@
         ], 
         "orientation": 1, 
         "nitty_bits": 3, 
-        "port_dir": "}", 
+        "port_dir": "}",
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_2g.json
+++ b/db/new_Downtown/Downtown_2g.json
@@ -16,7 +16,8 @@
         "orientation": 0,
         "realm": "Downtown",         
         "nitty_bits": 3, 
-        "port_dir": DOWN, 
+        "port_dir": DOWN,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_2i.json
+++ b/db/new_Downtown/Downtown_2i.json
@@ -16,7 +16,8 @@
         "orientation": 0,
         "realm": "Downtown",         
         "nitty_bits": 3, 
-        "port_dir": DOWN, 
+        "port_dir": DOWN,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_4a.json
+++ b/db/new_Downtown/Downtown_4a.json
@@ -16,7 +16,8 @@
         "realm": "Downtown",         
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": DOWN, 
+        "port_dir": DOWN,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_4b.json
+++ b/db/new_Downtown/Downtown_4b.json
@@ -16,7 +16,8 @@
         ], 
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": RIGHT, 
+        "port_dir": RIGHT,
+		"depth": 29, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_4c.json
+++ b/db/new_Downtown/Downtown_4c.json
@@ -16,7 +16,8 @@
         "orientation": 3,
         "realm": "Downtown", 
         "nitty_bits": 3, 
-        "port_dir": DOWN, 
+        "port_dir": DOWN,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_4l.json
+++ b/db/new_Downtown/Downtown_4l.json
@@ -16,7 +16,8 @@
         "orientation": 3,
         "realm": "Downtown", 
         "nitty_bits": 3, 
-        "port_dir": LEFT, 
+        "port_dir": LEFT,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_4m.json
+++ b/db/new_Downtown/Downtown_4m.json
@@ -16,7 +16,8 @@
         "orientation": 3,
         "realm": "Downtown", 
         "nitty_bits": 3, 
-        "port_dir": RIGHT, 
+        "port_dir": RIGHT,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_5c.json
+++ b/db/new_Downtown/Downtown_5c.json
@@ -16,7 +16,8 @@
         "realm": "Downtown",         
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": DOWN, 
+        "port_dir": DOWN,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_5f.json
+++ b/db/new_Downtown/Downtown_5f.json
@@ -10,7 +10,8 @@
         "port_dir": UP + SPACE + DOWN + SPACE + LEFT + SPACE + RIGHT, 
         "type": "Region",
         "orientation": 0,
-        "realm": "Downtown",         
+        "realm": "Downtown",
+        "depth": 24,		
         "neighbors": [
           "context-Downtown_5g",
           "context-Downtown_6f",

--- a/db/new_Downtown/Downtown_6a.json
+++ b/db/new_Downtown/Downtown_6a.json
@@ -10,7 +10,7 @@
         "port_dir": DOWN, 
         "type": "Region",
         "orientation": 3,
-        "depth": 48,
+        "depth": 50,
         "realm": "Downtown", 
         "neighbors": [
           "context-Downtown_6b",

--- a/db/new_Downtown/Downtown_6c.json
+++ b/db/new_Downtown/Downtown_6c.json
@@ -16,7 +16,8 @@
         "realm": "Downtown",         
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": DOWN, 
+        "port_dir": DOWN,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_7a.json
+++ b/db/new_Downtown/Downtown_7a.json
@@ -16,7 +16,8 @@
         "realm": "Downtown",         
         "orientation": 3, 
         "nitty_bits": 3, 
-        "port_dir": DOWN, 
+        "port_dir": DOWN,
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_7g.json
+++ b/db/new_Downtown/Downtown_7g.json
@@ -10,7 +10,8 @@
         "port_dir": DOWN,
         "type": "Region",
         "orientation": 2,
-        "realm": "Downtown", 
+        "realm": "Downtown",
+		"depth": 30, 
         "neighbors": [
           "context-Downtown_7h",
           "context-Downtown_8g",

--- a/db/new_Downtown/Downtown_8g.json
+++ b/db/new_Downtown/Downtown_8g.json
@@ -10,7 +10,8 @@
         "port_dir": DOWN,
         "type": "Region",
         "orientation": 2,
-        "realm": "Downtown", 
+        "realm": "Downtown",
+		"depth": 28, 
         "neighbors": [
           "context-Downtown_1t",
           "context-Downtown_2s",

--- a/db/new_Downtown/Downtown_8i.json
+++ b/db/new_Downtown/Downtown_8i.json
@@ -16,7 +16,8 @@
         "realm": "Downtown", 
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": DOWN, 
+        "port_dir": DOWN,
+		"depth": 28, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_9194.json
+++ b/db/new_Downtown/Downtown_9194.json
@@ -16,7 +16,8 @@
         "orientation": 0,
         "realm": "Downtown", 		
         "nitty_bits": 3, 
-        "port_dir": "", 
+        "port_dir": "",
+		"depth": 24, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_9204.json
+++ b/db/new_Downtown/Downtown_9204.json
@@ -18,6 +18,7 @@
         "nitty_bits": 3, 
         "port_dir": UP, 
         "lighting": -1,
+		"depth": 15,
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_9205.json
+++ b/db/new_Downtown/Downtown_9205.json
@@ -18,6 +18,7 @@
         "nitty_bits": 3, 
         "port_dir": LEFT + SPACE + RIGHT, 
         "lighting": -1,
+		"depth": 15,
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_9206.json
+++ b/db/new_Downtown/Downtown_9206.json
@@ -18,6 +18,7 @@
         "nitty_bits": 3, 
         "port_dir": UP, 
         "lighting": -1,
+		"depth": 15,
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_9241.json
+++ b/db/new_Downtown/Downtown_9241.json
@@ -15,7 +15,8 @@
         ], 
         "orientation": 0, 
         "nitty_bits": 3, 
-        "port_dir": "}", 
+        "port_dir": "}",
+		"depth": 26, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_9g.json
+++ b/db/new_Downtown/Downtown_9g.json
@@ -10,7 +10,8 @@
         "port_dir": LEFT,
         "type": "Region",
         "orientation": 2,
-        "realm": "Downtown", 
+        "realm": "Downtown",
+		"depth": 28, 
         "neighbors": [
           "context-Downtown_9h",
           "",

--- a/db/new_Downtown/Downtown_9h.json
+++ b/db/new_Downtown/Downtown_9h.json
@@ -16,7 +16,8 @@
         "realm": "Downtown",         
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": LEFT, 
+        "port_dir": LEFT,
+		"depth": 28, 
         "type": "Region"
       }
     ]

--- a/db/new_Downtown/Downtown_9j.json
+++ b/db/new_Downtown/Downtown_9j.json
@@ -16,7 +16,8 @@
         "realm": "Downtown", 
         "orientation": 2, 
         "nitty_bits": 3, 
-        "port_dir": RIGHT, 
+        "port_dir": RIGHT,
+		"depth": 28, 
         "type": "Region"
       }
     ]


### PR DESCRIPTION
Depth fixes for the following areas:
 - D'nalsi Island
 - I/5
 - Downtown
 - Popustop
 - Streets
 - Woods

Popustop will require a lot of work and so only the ground floor has been corrected to begin with. D'nalsi Island will also need further work as a couple of regions seem to have graphical issues, however they work fine in the db dump. Fixes for these will come in a later PR.

Lighting has been turned off in the D'nalsi Island caves. People now need a flashlight to explore just like in the original!

A choke machine was added to the Woods based on findings from the db dump in Woods_6w. This one also teleports you back to your turf, just like the one at the start of the Woods area.