### PR TITLE
Fixes Book of Records generation in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN npm install -g supervisor
 RUN printf '#!/bin/bash\ntail -f /neohabitat/{bridge,elko_server}.log' > /usr/bin/habitail && chmod a+x /usr/bin/habitail
 
 # Adds a cronjob to enable the updating of the Hall of Records.
-RUN printf "*/5 * * * * root /bin/bash -c 'cd /neohabitat/db && make book' >> /var/log/hallofrecords.log\n" > /etc/cron.d/hall-of-records
+RUN printf "*/5 * * * * root /bin/bash -c 'cd /neohabitat/db && NEOHABITAT_MONGO_HOST=neohabitatmongo:27017 make book' >> /var/log/hallofrecords.log\n" > /etc/cron.d/hall-of-records
 
 # Builds the Neohabitat project.
 WORKDIR /neohabitat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
-  mariadb:
+  neohabitatmariadb:
     image: mariadb
     environment:
       - MYSQL_ROOT_PASSWORD=dev
@@ -42,12 +42,12 @@ services:
       - "9000:9000"
       - "9229:9229"
     depends_on:
-      - mongo
+      - neohabitatmongo
   qlink:
     image: philcollins/qlink
     environment:
-      - QLINK_DB_HOST=mariadb
-      - QLINK_DB_JDBC_URI=jdbc:mysql://mariadb:3306/qlink
+      - QLINK_DB_HOST=neohabitatmariadb
+      - QLINK_DB_JDBC_URI=jdbc:mysql://neohabitatmariadb:3306/qlink
       - QLINK_DB_USERNAME=qlink
       - QLINK_DB_PASSWORD=qlink
       - QLINK_HABITAT_HOST=neohabitat
@@ -56,4 +56,4 @@ services:
       - "1986:1986"
     depends_on:
       - neohabitat
-      - mariadb
+      - neohabitatmariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./data/mariadb:/var/lib/mysql
     ports:
       - "3306:3306"
-  mongo:
+  neohabitatmongo:
     image: mongo:3.0
     command: "--smallfiles"
     volumes:
@@ -27,13 +27,13 @@ services:
       - .:/neohabitat
     environment:
       - NEOHABITAT_BRIDGE_ELKO_HOST=127.0.0.1:2018
-      - NEOHABITAT_MONGO_HOST=mongo:27017
+      - NEOHABITAT_MONGO_HOST=neohabitatmongo:27017
       - NEOHABITAT_SHOULD_ENABLE_DEBUGGER=true
       - NEOHABITAT_SHOULD_RUN_BRIDGE=true
       - NEOHABITAT_SHOULD_RUN_NEOHABITAT=true
       - NEOHABITAT_SHOULD_RUN_PUSHSERVER=true
       - NEOHABITAT_SHOULD_UPDATE_SCHEMA=false
-      - PUSH_SERVER_MONGO_URL=mongodb://mongo
+      - PUSH_SERVER_MONGO_URL=mongodb://neohabitatmongo
     ports:
       - "1337:1337"
       - "1701:1701"


### PR DESCRIPTION
Docker environment variables do not propagate to a cron context, leading the Book of Records generation to die silently. This PR patches up this behavior by explicitly specifying the needed environment variable.