### PR TITLE
Fix docent compass rose

### DIFF
--- a/pushserver/public/javascripts/eventStream.js
+++ b/pushserver/public/javascripts/eventStream.js
@@ -8,13 +8,13 @@ var CurrentAvatars = {};
 function orientationToRotation(orientation) {
   switch (orientation) {
     case 'North':
-      return 270;
+      return 0;
     case 'West':
       return 90;
     case 'South':
       return 180;
     case 'East':
-      return 0;
+      return 270;
     default:
       return 0;
   }


### PR DESCRIPTION
From examining the image and MDN, it looks like 0 should be North and 270 should be East.

Those were the original values before a commit, I don't know why those were changed

Not actually tested yet.