### PR TITLE
Revert "Fix docent compass rose"

### DIFF
--- a/pushserver/public/javascripts/eventStream.js
+++ b/pushserver/public/javascripts/eventStream.js
@@ -8,13 +8,13 @@ var CurrentAvatars = {};
 function orientationToRotation(orientation) {
   switch (orientation) {
     case 'North':
-      return 0;
+      return 270;
     case 'West':
       return 90;
     case 'South':
       return 180;
     case 'East':
-      return 270;
+      return 0;
     default:
       return 0;
   }


### PR DESCRIPTION
Reverts frandallfarmer/neohabitat#347

This code looks correct, but there are deeper issues going on that should be fixed first.

For reference: Broadway Bank is supposed to be East, but indications in the DB seem to suggest it's North.