### PR TITLE
Adds web interface improvements

### DIFF
--- a/pushserver/public/javascripts/avatarSelector.js
+++ b/pushserver/public/javascripts/avatarSelector.js
@@ -1,4 +1,9 @@
 var RefreshInterval = null;
+var EmulatorHelpPage = '/docs/region/EMULATOR_HELP';
+
+function supportsGamepads() {
+  return false;
+}
 
 function selectAvatar(avatarName) {
   AvatarName = avatarName;
@@ -15,7 +20,7 @@ function activateDocent() {
 }
 
 function viewHelp() {
-  $('#docsFrame').attr('src', '/docs/region/EMULATOR_HELP');
+  $('#docsFrame').attr('src', EmulatorHelpPage);
 }
 
 function refreshAvatarDropdown() {
@@ -40,6 +45,10 @@ function refreshAvatarDropdown() {
 }
 
 $(document).ready(function() {
+  if (supportsGamepads()) {
+    EmulatorHelpPage = '/docs/region/EMULATOR_HELP_JOYSTICK';
+    viewHelp();
+  }
   refreshAvatarDropdown();
   // Checks for new Avatars every 5 seconds.
   RefreshInterval = setInterval(refreshAvatarDropdown, 5000);

--- a/pushserver/public/javascripts/emularity.js
+++ b/pushserver/public/javascripts/emularity.js
@@ -1439,7 +1439,7 @@ var Module = null;
 
             // Emscripten doesn't use the proper prefixed functions for fullscreen requests,
             // so let's map the prefixed versions to the correct function.
-            canvas.requestPointerLock = getpointerlockenabler();
+            canvas.requestPointerLock = function(){};
 
             moveConfigToRoot(game_data.fs);
 
@@ -2016,7 +2016,6 @@ var Module = null;
   }
 
   function _SDL_CreateRGBSurfaceFrom(pixels, width, height, depth, pitch, rmask, gmask, bmask, amask) {
-    console.log("CALLIN ME", width, height);
     // TODO: Actually fill pixel data to created surface.
     // TODO: Take into account depth and pitch parameters.
     // console.log('TODO: Partially unimplemented SDL_CreateRGBSurfaceFrom called!');

--- a/pushserver/public/javascripts/emulator.js
+++ b/pushserver/public/javascripts/emulator.js
@@ -1,8 +1,13 @@
+// Vice's Joystick Device 4 == Joystick, whereas Joystick Device 2 == Keyset 1
+var JoyDevice1 = supportsGamepads() ? 4 : 2;
+
+var emulatorCanvas = document.getElementById("emulatorCanvas");
 var emulator = new Emulator(
-  document.querySelector("#emulatorCanvas"),
+  emulatorCanvas,
   null,
-  new VICELoader(VICELoader.emulatorJS(EmulatorUrl),
-    VICELoader.nativeResolution(0, 0),
+  new VICELoader(
+    VICELoader.emulatorJS(EmulatorUrl),
+    VICELoader.nativeResolution(160, 200),
     VICELoader.extraArgs([
       "-ntsc",
       "-soundfragsize", "4",
@@ -20,7 +25,7 @@ var emulator = new Emulator(
         "/disks/Habitat-B.d64")),
     VICELoader.mountFile("vice.ini",
       VICELoader.fetchFile("Configuration",
-        "/emulator/vice.ini")),
+        "/emulator/vice.ini?jd1=" + JoyDevice1)),
     VICELoader.mountFile("hotkeys.txt",
       VICELoader.fetchFile("Hotkeys",
         "/vice/hotkeys.txt")),
@@ -30,7 +35,9 @@ var emulator = new Emulator(
     VICELoader.fliplist([
       ["Habitat-B.d64"]
     ]),
-    VICELoader.autoLoad("Habitat-Boot.d64")));
+    VICELoader.autoLoad("Habitat-Boot.d64")
+  )
+);
 
 emulator.start({
   waitAfterDownloading: false

--- a/pushserver/public/stylesheets/style.css
+++ b/pushserver/public/stylesheets/style.css
@@ -6,20 +6,21 @@ pre {
   word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
 
-.d-none {
-  display: none;
+body {
+  margin-bottom: 130px;
 }
 
-.emulator-canvas {
-  position: absolute;
-  top: 0px;
-  left: 0px;
-  margin: 0px;
-  border: 0;
+.container.control-panel {
+  margin: 0 auto;
   width: 100%;
-  height: 100%;
-  overflow: hidden;
-  display: block;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.d-none {
+  display: none;
 }
 
 .docs-div {
@@ -27,35 +28,27 @@ pre {
 }
 
 .docent-div {
+  padding-left: 0px;
   padding-right: 0px;
 }
 
-.docent-panel {
-  height: 480px;
+.emulator-canvas {
+  width: 100%;
 }
 
-@media (min-width: 576px) {
-  .docent-panel {
-    height: 480px;
-  }
+.emulator-div {
+  width: 100%;
 }
 
-@media (min-width: 768px) {
-  .docent-panel {
-    height: 480px;
-  }
+.footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 130px;
 }
 
-@media (min-width: 992px) {
-  .docent-panel {
-    height: 480px;
-  }
-}
-
-@media (min-width: 1200px) {
-  .docent-panel {
-    height: 480px;
-  }
+.main-panel {
+  margin-bottom: 130px;
 }
 
 .nav-div {
@@ -69,27 +62,16 @@ pre {
 
 .login-panel {
   background-color: #DFE2DB;
-  height: 80px;
-  margin-bottom: 15px;
+  height: 130px;
 }
 
 .status-panel {
   background-color: #DFE2DB;
-  margin-bottom: 15px;
   height: 130px;
 }
 
 .docent-region {
   padding-top: 10px;
-}
-
-.container.control-panel {
-  margin: 0 auto;
-  width: 100%;
-  padding-top: 20px;
-  padding-bottom: 20px;
-  padding-left: 0;
-  padding-right: 0;
 }
 
 .vcenter {

--- a/pushserver/routes/docs.js
+++ b/pushserver/routes/docs.js
@@ -12,7 +12,6 @@ const RegionNotFoundLocation = RegionDocsDir + 'NOT_FOUND.md';
 const HelpDocsDir = './public/docs/help/';
 const HelpNotFoundLocation = HelpDocsDir + 'help.does.not.exist.md';
 
-
 class DocsRoutes {
   constructor(habiproxy, config, mongoDb) {
     var self = this;
@@ -21,6 +20,7 @@ class DocsRoutes {
     self.config = config;
     self.mongoDb = mongoDb;
     self.mdConverter = new showdown.Converter();
+    self.mdConverter.setOption('simpleLineBreaks', false);
     self.router = express.Router();
 
     fs.readFile(RegionNotFoundLocation, 'utf8', function(err, contents) {

--- a/pushserver/routes/emulator.js
+++ b/pushserver/routes/emulator.js
@@ -15,10 +15,14 @@ class EmulatorRoutes {
 
   setRoutes() {
     var self = this;
-
     self.router.get('/vice.ini', function(req, res, next) {
+      var jd1 = parseInt(req.query.jd1);
+      if (jd1 == NaN) {
+        jd1 = 2;
+      }
       res.render('vice_ini', {
         config: self.config,
+        joyDevice1: jd1,
       });
     });
   }

--- a/pushserver/views/emulator.ejs
+++ b/pushserver/views/emulator.ejs
@@ -3,95 +3,77 @@
   <% include ./header.ejs %>
 
   <body>
-    <div class="container h-100 control-panel">
-      <div class="row status-panel d-none rounded text-center align-items-center w-100">
-        <div class="col-2">
-          <img id="compass" src="/images/compass.png"></img>
-        </div>
-        <div class="col-2">
-          North <span id="northArrow"></span>
-          <h5 id="northHeader" class="text-center"></h5>
-        </div>
-        <div class="col-2">
-          South <span id="southArrow"></span>
-          <h5 id="southHeader" class="text-center"></h5>
-        </div>
-        <div class="col-2">
-          East <span id="eastArrow"></span>
-          <h5 id="eastHeader" class="text-center"></h5>
-        </div>
-        <div class="col-2">
-          West <span id="westArrow"></span>
-          <h5 id="westHeader" class="text-center"></h5>
-        </div>
-        <div class="col-2">
-          <div class="btn-group-vertical">
-            <button type="submit" id="fullScreenBtn" class="btn btn-primary" href="#" onclick="emulator.requestFullScreen(); return false;">Full Screen</button>
-            <button type="submit" id="fullScreenBtn" class="btn btn-success" href="#" onclick="viewHelp(); return false;">Help</button>
-          </div>
-        </div>
-      </div>
-
-      <div class="row login-panel rounded text-center align-items-center w-100">
-        <div class="mx-auto">
-          <form class="form-inline">
-            <div class="form-group">
-              <div class="dropdown">
-                <button class="btn btn-secondary dropdown-toggle" disabled="disabled" type="button" id="avatarMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  Select Avatar Name
-                </button>
-                <div id="avatarMenu" class="dropdown-menu" aria-labelledby="avatarMenuButton"></div>
-              </div>
-            </div>
-            &nbsp;&nbsp;
-            <button type="submit" id="avatarSubmit" disabled="disabled" class="btn btn-primary" href="#" onclick="activateDocent(); return false;">Activate Docent</button>
-          </form>
-        </div>
-      </div>
-
-      <div class="row docent-panel w-100">
+    <main role="main" class="container-fluid h-100 main-panel">
+      <div class="row h-100 docent-panel main-panel">
         <!-- Emulator pane: -->
-        <div id="emulatorContainer" class="col-8 emulator-div">
-          <canvas id="emulatorCanvas" class="emulator-canvas" />
+        <div class="col-7 main-panel">
+          <div class="emulator-div">
+            <canvas id="emulatorCanvas" class="emulator-canvas" />
+          </div>
         </div>
 
         <!-- Docent docs pane: -->
-        <div class="col-4 mx-auto rounded docent-div h-100">
-          <div class="embed-responsive embed-responsive-4by3 rounded docs-div h-100">
-            <iframe name="docsFrame" id="docsFrame" class="embed-responsive-item rounded" src="/docs/region/EMULATOR_HELP"></iframe>
+        <div class="col-5 mx-auto docent-div h-100">
+          <div class="embed-responsive docs-div h-100">
+            <iframe name="docsFrame" id="docsFrame" class="embed-responsive-item" src="/docs/region/EMULATOR_HELP"></iframe>
           </div>
         </div>
       </div>
+    </main>
 
-      <div class="row users-panel rounded text-center d-flex align-items-center w-100">
-        <div class="col-2">
-          <img src="https://frandallfarmer.github.io/neohabitat-doc/docs/images/Habitat-Menu-Options.svg" width="150px"/>
+    <footer class="footer">
+      <!-- Directioneering pane: -->
+      <div class="container-fluid">
+        <div class="row status-panel d-none text-center align-items-center">
+          <div class="col-2">
+            <img id="compass" src="/images/compass.png"></img>
+          </div>
+          <div class="col-2">
+            North <span id="northArrow"></span>
+            <h5 id="northHeader" class="text-center"></h5>
+          </div>
+          <div class="col-2">
+            South <span id="southArrow"></span>
+            <h5 id="southHeader" class="text-center"></h5>
+          </div>
+          <div class="col-2">
+            East <span id="eastArrow"></span>
+            <h5 id="eastHeader" class="text-center"></h5>
+          </div>
+          <div class="col-2">
+            West <span id="westArrow"></span>
+            <h5 id="westHeader" class="text-center"></h5>
+          </div>
+          <div class="col-2">
+            <div class="btn-group-vertical">
+              <button type="submit" id="fullScreenBtn" class="btn btn-primary" href="#" onclick="emulator.requestFullScreen(); return false;">Full Screen</button>
+              <button type="submit" id="fullScreenBtn" class="btn btn-success" href="#" onclick="viewHelp(); return false;">Help</button>
+            </div>
+          </div>
         </div>
-        <div class="col-2">
-          <a href="https://github.com/frandallfarmer/neohabitat/blob/master/README.md" target="_blank">
-            <h4>Getting Started</h4>
-          </a>
-        </div>
-        <div class="col-2">
-          <a href="https://frandallfarmer.github.io/neohabitat-doc/docs/Avatar%20Handbook.html" target="_blank">
-            <h4>Official Handbook</h4>
-          </a>
-        </div>
-        <div class="col-2">
-          <a href="https://github.com/frandallfarmer/neohabitat/blob/master/README-RealC64.md" target="_blank">
-            <h4>Using a C64</h4>
-          </a>
-        </div>
-        <div class="col-2">
-          <a href="http://slack.neohabitat.org" target="_blank">
-            <h4>Neohabitat Slack</h4>
-          </a>
-        </div>
-        <div class="col-2">
-          <img src="https://frandallfarmer.github.io/neohabitat-doc/docs/images/f7.svg" />
+
+        <!-- Login pane: -->
+        <div class="row login-panel text-center align-items-center">
+          <div class="mx-auto">
+            <form class="form-inline">
+              <div class="form-group">
+                <div class="dropdown">
+                  <button class="btn btn-secondary dropdown-toggle" disabled="disabled" type="button" id="avatarMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Select Avatar Name
+                  </button>
+                  <div id="avatarMenu" class="dropdown-menu" aria-labelledby="avatarMenuButton"></div>
+                </div>
+              </div>
+              &nbsp;
+              <div class="btn-group-horizontal">
+                <button type="submit" id="avatarSubmit" disabled="disabled" class="btn btn-primary" href="#" onclick="activateDocent(); return false;">Activate Docent</button>
+                <button type="submit" id="fullScreenBtn" class="btn btn-primary" href="#" onclick="emulator.requestFullScreen(); return false;">Full Screen</button>
+              </div>
+            </form>
+          </div>
         </div>
       </div>
-    </div>
+    </footer>
 
     <% include ./footer.ejs %>
     <script type="text/javascript">

--- a/pushserver/views/vice_ini.ejs
+++ b/pushserver/views/vice_ini.ejs
@@ -22,16 +22,14 @@ VICIIFilter=0
 VICIIBorderMode=0
 VICIICheckSsColl=1
 VICIICheckSbColl=1
-VICIINewLuminances=1
 SidResidSampling=0
 SidResidFilterBias=0
 SidEngine=1
 SidModel=0
-TrueAspectRatio=1
 RsDevice1="<%= config.websocketProxy.clientAddr %>"
 RsUserEnable=1
 RsUserBaud=1200
-JoyDevice1=2
+JoyDevice1=<%= joyDevice1 %>
 JoyMapFile="/emulator/joymap.txt"
 HotkeyFile="/emulator/hotkeys.txt"
 AutostartPrgDiskImage=".\Habitat-Boot.d64"


### PR DESCRIPTION
This PR adds several requested improvements to the Habitat web interface:

- Rearranges interface to better fit a display/eliminate negative space
- Disables mouse takeover
- Corrects Markdown rendering to eliminate bogon newlines
- Lays groundwork for rendering gamepad interface (currently not fully implemented as gamepads must be moved to be detected due to browser security settings; we may want to build in a selector for this)
- Attempts to correct aspect ratio weirdness

Please note that several elements still require work:

- Gamepad/Keyboard Selector Switch
- Aspect ratio needs work as Vice sets a fixed canvas size on startup that must be resized