### PR TITLE
Fixes AudioContext and emulator slowness issues under Chrome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN yum -y install \
 RUN wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo
 
 # Installs the Nodesource Yum repository.
-RUN curl -sL https://rpm.nodesource.com/setup_6.x | bash -
+RUN curl -sL https://rpm.nodesource.com/setup_9.x | bash -
 
 # Installs MongoDB Yum repository.
 RUN curl -sL https://goo.gl/CxNbGr > /etc/yum.repos.d/mongodb-org.3.4.repo

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,10 +50,6 @@
         "type-is": "1.6.16"
       }
     },
-    "bson": {
-      "version": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
-      "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
-    },
     "buffer-shims": {
       "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
@@ -96,7 +92,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
     },
     "cookie": {
       "version": "0.3.1",
@@ -119,7 +115,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -388,20 +384,43 @@
       }
     },
     "mongodb": {
-      "version": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.27.tgz",
-      "integrity": "sha1-NBIgNNtm2YO89qta2yaiSnD+9uY=",
+      "version": "2.2.36",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.36.tgz",
+      "integrity": "sha512-P2SBLQ8Z0PVx71ngoXwo12+FiSfbNfGOClAao03/bant5DgLNkOPAck5IaJcEk4gKlQhDEURzfR3xuBG1/B+IA==",
       "requires": {
         "es6-promise": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-        "mongodb-core": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.11.tgz",
+        "mongodb-core": "2.1.20",
         "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz"
-      }
-    },
-    "mongodb-core": {
-      "version": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.11.tgz",
-      "integrity": "sha1-HDh3bOsXSZepnCiGDu2QKNqbPho=",
-      "requires": {
-        "bson": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
-        "require_optional": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+          "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
+        },
+        "mongodb-core": {
+          "version": "2.1.20",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.20.tgz",
+          "integrity": "sha512-IN57CX5/Q1bhDq6ShAR6gIv4koFsZP7L8WOK1S0lR0pVDQaScffSMV5jxubLsmZ7J+UdqmykKw4r9hG3XQEGgQ==",
+          "requires": {
+            "bson": "1.0.9",
+            "require_optional": "1.0.1"
+          }
+        },
+        "require_optional": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+          "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+          "requires": {
+            "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+            "semver": "5.7.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "ms": {
@@ -559,14 +578,6 @@
         "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
       }
     },
-    "require_optional": {
-      "version": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
-      "integrity": "sha1-UqhhN6hJco62ClVTNhf4+RT1mr8=",
-      "requires": {
-        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-      }
-    },
     "require-directory": {
       "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
@@ -646,21 +657,10 @@
       "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
-    "stack-trace": {
-      "version": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
-    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-    },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-      "requires": {
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-      }
     },
     "string-width": {
       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -669,6 +669,13 @@
         "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
         "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
         "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+      "requires": {
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
       }
     },
     "strip-ansi": {
@@ -722,8 +729,9 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "walk": {
-      "version": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
-      "integrity": "sha1-MbTbZnjyrgHDnqn7hyWpAx5Vins=",
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
+      "integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
       "requires": {
         "foreachasync": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz"
       }
@@ -733,15 +741,23 @@
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
     "winston": {
-      "version": "https://registry.npmjs.org/winston/-/winston-2.3.0.tgz",
-      "integrity": "sha1-IH+qq2/M8/5JN0PdKwPbr8fOt4w=",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
       "requires": {
         "async": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
         "colors": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
         "cycle": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
         "eyes": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
         "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-        "stack-trace": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "stack-trace": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+          "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+        }
       }
     },
     "wrap-ansi": {

--- a/pushserver/public/docs/region/EMULATOR_HELP.md
+++ b/pushserver/public/docs/region/EMULATOR_HELP.md
@@ -8,7 +8,8 @@ visit every day.
 Logging In
 ----------
 
-To get started, **hit any key** to get past the splash screen. Next, enter a name for your
+To get started, **click on the emulator panel** to start the emulator. Once Neohabitat
+loads, **hit any key** to get past the splash screen. Next, enter a name for your
 new **Avatar**, such as **Threepwood**, **dril** or **Phil Collins**.
 
 Flipping Disks

--- a/pushserver/public/javascripts/emulator.js
+++ b/pushserver/public/javascripts/emulator.js
@@ -2,6 +2,7 @@
 var JoyDevice1 = supportsGamepads() ? 4 : 2;
 
 var emulatorCanvas = document.getElementById("emulatorCanvas");
+
 var emulator = new Emulator(
   emulatorCanvas,
   null,
@@ -39,6 +40,28 @@ var emulator = new Emulator(
   )
 );
 
-emulator.start({
-  waitAfterDownloading: false
-});
+function resumeAudio(e) {
+  if (typeof SDL == 'undefined'
+    || typeof SDL.audioContext == 'undefined')
+    return;
+  if (SDL.audioContext.state == 'suspended') {
+    SDL.audioContext.resume();
+  }
+  if (SDL.audioContext.state == 'running') {
+    document.getElementById('emulatorCanvas').removeEventListener('click', resumeAudio);
+    document.removeEventListener('keydown', resumeAudio);
+  }
+}
+emulatorCanvas.addEventListener('click', resumeAudio);
+document.addEventListener('keydown', resumeAudio);
+
+function startEmulator() {
+  $('#emulatorPanel').removeClass('d-none');
+  $('#emulatorStartPanel').addClass('d-none');
+  emulator.start({
+    waitAfterDownloading: false
+  });
+  resumeAudio();
+}
+
+document.getElementById("emulatorStartPanel").addEventListener('click', startEmulator);

--- a/pushserver/public/stylesheets/style.css
+++ b/pushserver/public/stylesheets/style.css
@@ -47,6 +47,13 @@ body {
   height: 130px;
 }
 
+.emulator-panel {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+}
+
 .main-panel {
   margin-bottom: 130px;
 }

--- a/pushserver/views/emulator.ejs
+++ b/pushserver/views/emulator.ejs
@@ -6,8 +6,11 @@
     <main role="main" class="container-fluid h-100 main-panel">
       <div class="row h-100 docent-panel main-panel">
         <!-- Emulator pane: -->
-        <div class="col-7 main-panel">
-          <div class="emulator-div">
+        <div class="col-7 main-panel h-100 emulator-panel">
+          <div id="emulatorStartPanel" class="jumbotron">
+            <h1 class="display-4 text-center">Click here to start!</h1>
+          </div>
+          <div id="emulatorPanel" class="emulator-div d-none">
             <canvas id="emulatorCanvas" class="emulator-canvas" />
           </div>
         </div>


### PR DESCRIPTION
The emulator embedded within the docent system no longer functions due to recent AudioContext autoplay policy changes made by Google:

https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio

This audio blockage also has the side effect of rendering the emulator's performance artificially slow, as SDL cannot write to its AudioContext and this interrupts Vice's main loop.

This PR corrects the issue by requiring user interaction before starting the AudioContext embedded within SDL. In my testing, doing so corrects the issue on Chrome and Safari.

Let me know what you think and thanks for the consideration!