### PR TITLE
Corrects Windows/Docker startup behavior

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "3306:3306"
   neohabitatmongo:
-    image: mongo:3.0
+    image: mongo:4.0
     command: "--smallfiles"
     volumes:
       - ./data/mongodb:/data/db
@@ -32,7 +32,7 @@ services:
       - NEOHABITAT_SHOULD_RUN_BRIDGE=true
       - NEOHABITAT_SHOULD_RUN_NEOHABITAT=true
       - NEOHABITAT_SHOULD_RUN_PUSHSERVER=true
-      - NEOHABITAT_SHOULD_UPDATE_SCHEMA=false
+      - NEOHABITAT_SHOULD_UPDATE_SCHEMA=true
       - NODE_ENV=development
       - PUSH_SERVER_CONFIG=./config.dev.yml
       - PUSH_SERVER_MONGO_URL=mongodb://neohabitatmongo

--- a/run
+++ b/run
@@ -92,6 +92,7 @@ function start_pushserver() {
 }
 
 function start_elko_server() {
+  mvn package
   java "${JVM_ARGS[@]}" \
     -jar ${GIT_BASE_DIR}/target/neohabitat-${VERSION}.jar \
     "${BASE_ARGS[@]}" \


### PR DESCRIPTION
Due to upstream updates to the Docker Mongo 3.0 image, Mongo now fails to startup under WSL/Docker. Furthermore, `docker-compose up` should compile the Elko backend if it has not yet been compiled. These two changes update Mongo to version 4.0, which has been tested to work under WSL/Docker and amends the `run` script to execute a `mvn package` before standing up the server.

With these changes in place, neohabitat starts successfully from a fresh Git checkout under WSL with `docker-compose up`.