### PR TITLE
Fix certificate issues in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,38 +2,23 @@
 #
 # VERSION              0.1.0
 
-FROM philcollins/aurora-centos7
+FROM quay.io/centos/centos:stream8
+
+# Installs MongoDB Yum repository.
+ADD https://goo.gl/CxNbGr /etc/yum.repos.d/mongodb-org.3.4.repo
 
 # Installs base build dependencies.
 RUN yum -y install \
   cronie \
-  curl \
   git \
-  htop \
+  # htop \
   java-1.8.0-openjdk \
   make \
   mariadb \
-  tar \
   vim \
   wget \
-  which && \
-  yum clean all
-
-# Add Let's Encrypt root certificate
-RUN wget --no-check-certificate --directory-prefix=/etc/pki/ca-trust/source/anchors/ https://letsencrypt.org/certs/lets-encrypt-r3.pem && update-ca-trust
-
-# Installs the Apache Maven Yum repository.
-RUN wget --no-check-certificate http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo
-
-# Installs the Nodesource Yum repository.
-RUN curl -L https://rpm.nodesource.com/setup_9.x | bash -
-
-# Installs MongoDB Yum repository.
-RUN curl -L https://goo.gl/CxNbGr > /etc/yum.repos.d/mongodb-org.3.4.repo
-
-# Installs Node and MongoDB.
-RUN yum -y install \
-  apache-maven \
+  which \
+  maven \
   mongodb-org \
   nodejs && \
   yum clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@
 
 FROM philcollins/aurora-centos7
 
-# Ensures that the codebase is homed at /neohabitat.
-ADD . /neohabitat
-
 # Installs base build dependencies.
 RUN yum -y install \
   cronie \
@@ -22,14 +19,17 @@ RUN yum -y install \
   which && \
   yum clean all
 
+# Add Let's Encrypt root certificate
+RUN wget --no-check-certificate --directory-prefix=/etc/pki/ca-trust/source/anchors/ https://letsencrypt.org/certs/lets-encrypt-r3.pem && update-ca-trust
+
 # Installs the Apache Maven Yum repository.
-RUN wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo
+RUN wget --no-check-certificate http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo
 
 # Installs the Nodesource Yum repository.
-RUN curl -sL https://rpm.nodesource.com/setup_9.x | bash -
+RUN curl -L https://rpm.nodesource.com/setup_9.x | bash -
 
 # Installs MongoDB Yum repository.
-RUN curl -sL https://goo.gl/CxNbGr > /etc/yum.repos.d/mongodb-org.3.4.repo
+RUN curl -L https://goo.gl/CxNbGr > /etc/yum.repos.d/mongodb-org.3.4.repo
 
 # Installs Node and MongoDB.
 RUN yum -y install \
@@ -40,6 +40,9 @@ RUN yum -y install \
 
 # Installs Node dependencies.
 RUN npm install -g supervisor
+
+# Ensures that the codebase is homed at /neohabitat.
+ADD . /neohabitat
 
 # Adds a container log tailing utility.
 RUN printf '#!/bin/bash\ntail -f /neohabitat/{bridge,elko_server}.log' > /usr/bin/habitail && chmod a+x /usr/bin/habitail


### PR DESCRIPTION
In collaboration with: @cspaeth

Issues resolved:
    
* Outdated CentOS 7 distro (`philcollins/aurora-centos7` hasn't been rebuilt for seven years) is apparently missing some newer root certificates. In particular, certificates signed by Let's Encrypt were rejected (like the one for nodesource.com).

Improvements:

* To properly fix the certificate issues, a new base image was needed. Switched from outdated CentOS 7 base image (`philcollins/aurora-centos7`) to a CentOS Stream 8 base image (`quay.io/centos/centos:stream8`). [CentOS Linux is dead](https://www.centos.org/centos-linux-eol/), so the less stable CentOS Stream was used (see [here](https://pythonspeed.com/articles/centos-8-is-dead/) for why this might be bad choice).
* The reason CentOS Stream 9 _wasn't_ used just yet, is that no MongoDB 3.4 packages were readily available (compare https://repo.mongodb.org/yum/redhat/8/mongodb-org/ with https://repo.mongodb.org/yum/redhat/9/mongodb-org/), although no attempt has been made to simply upgrade MongoDB alongside.
* The `curl` and `wget` calls were removed for simplification. Maven and NodeJS are now fetched straight from the distro's default package repository (the former as `maven` instead of `apache-maven`, both quite possibly in a newer versions). The one external package repository still needed (MongoDB is not available in the official CentOS repositories) is set up through Docker's `ADD` instruction.
* The Dockerfile has been [rearranged for build caching](https://docs.docker.com/build/cache/#how-can-i-use-the-cache-efficiently), specifically the distro repository is only accessed once and as early as possible. The codebase is injected as late as possible, right before first use.

Please note that I'm no Docker expert, and I'm not sure if any of my changes are following the best practices. Also, I haven't managed to get the container fully working yet, so I couldn't test whether these changes (e.g. version upgrade of NodeJS and Maven) might cause new compatibility issues.

Should you decide to merge this PR, I would recommend squashing the commits. I left the earlier one in for reference, because it illustrates the existing certificate issues, but I don't think it's worth preserving beyond this PR.