### PR TITLE
Fixed supervisor startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN yum -y install \
   yum clean all
 
 # Installs Node dependencies.
-RUN npm install -g supervisor
+RUN npm install -g supervisor serve-favicon
 
 # Adds a container log tailing utility.
 RUN printf '#!/bin/bash\ntail -f /neohabitat/{bridge,elko_server}.log' > /usr/bin/habitail && chmod a+x /usr/bin/habitail

--- a/pushserver/package.json
+++ b/pushserver/package.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "homepage": "https://frandallfarmer.github.io/neohabitat/",
   "scripts": {
-    "start": "./node_modules/supervisor/lib/cli-wrapper.js -i public,views -w bin,constants,habiproxy,routes -- ./bin/pushserver",
-    "debug": "./node_modules/supervisor/lib/cli-wrapper.js --inspect -i public,views -w bin,constants,habiproxy,routes -- bin/pushserver"
+    "start": "supervisor -i public,views -w bin,constants,habiproxy,routes -- ./bin/pushserver",
+    "debug": "supervisor --inspect -i public,views -w bin,constants,habiproxy,routes -- bin/pushserver"
   },
   "dependencies": {
     "body-parser": "~1.18.2",


### PR DESCRIPTION
A simple change to get the supervisor working again.

Note that I don't know what the supervisor does or what it is supervising. So I haven't really tested anything, it just doesn't fail to start anymore:

```
neohabitat-neohabitat-1         | > pushserver@0.1.0 debug /neohabitat/pushserver
neohabitat-neohabitat-1         | > supervisor --inspect -i public,views -w bin,constants,habiproxy,routes -- bin/pushserver
neohabitat-neohabitat-1         |
neohabitat-neohabitat-1         | Missing/invalid defaults.elko configuration file. Proceeding with factory defaults.
neohabitat-neohabitat-1         | info: Habitat to Elko Bridge listening on 0.0.0.0:1337
neohabitat-neohabitat-1         |
neohabitat-neohabitat-1         | Running node-supervisor with
neohabitat-neohabitat-1         |   program '--inspect bin/pushserver'
neohabitat-neohabitat-1         |   --watch 'bin,constants,habiproxy,routes'
neohabitat-neohabitat-1         |   --ignore 'public,views'
neohabitat-neohabitat-1         |   --extensions 'node,js'
neohabitat-neohabitat-1         |   --exec 'node'
neohabitat-neohabitat-1         |
neohabitat-neohabitat-1         | Starting child process with 'node --inspect bin/pushserver'
neohabitat-neohabitat-1         | Ignoring directory '/neohabitat/pushserver/public'.
neohabitat-neohabitat-1         | Ignoring directory '/neohabitat/pushserver/views'.
neohabitat-neohabitat-1         | Watching directory '/neohabitat/pushserver/bin' for changes.
neohabitat-neohabitat-1         | Press rs for restarting the process.
neohabitat-neohabitat-1         | Watching directory '/neohabitat/pushserver/constants' for changes.
neohabitat-neohabitat-1         | Press rs for restarting the process.
neohabitat-neohabitat-1         | Watching directory '/neohabitat/pushserver/habiproxy' for changes.
neohabitat-neohabitat-1         | Press rs for restarting the process.
neohabitat-neohabitat-1         | Watching directory '/neohabitat/pushserver/routes' for changes.
neohabitat-neohabitat-1         | Press rs for restarting the process.
neohabitat-neohabitat-1         | Debugger listening on ws://127.0.0.1:9229/bc9c9b54-134b-4f9c-b859-49973341d393
neohabitat-neohabitat-1         | For help, see: https://nodejs.org/en/docs/inspector
neohabitat-neohabitat-1         | WebSocket settings:
neohabitat-neohabitat-1         |     - proxying from 0.0.0.0:1987 to qlink:1986
neohabitat-neohabitat-1         |     - Running in unencrypted HTTP (ws://) mode
```