### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,7 @@ RUN yum -y install \
   which \
   maven \
   mongodb-org \
-#  nodejs \
-  npm  && \
+  nsolid  && \
   yum clean all
 
 # Installs Node dependencies.

--- a/habibots/Dockerfile
+++ b/habibots/Dockerfile
@@ -1,10 +1,10 @@
 # In-world bots for Neohabitat
 #
 # VERSION              0.1.0
-FROM node:18.16
+FROM node:18.19
 COPY . /habibots
 WORKDIR /habibots
 RUN npm install -g supervisor
 RUN npm ci
-RUN apt-get update && apt-get install -y netcat
+RUN apt-get update && apt-get install -y netcat-openbsd
 ENTRYPOINT /habibots/run


### PR DESCRIPTION
Addresses #437.

NodeSource has reinstated the deprecated installer scripts, but the NodeSource repo doesn't contain a packge for npm, and the CentOS package for npm conflicts with the NodeSource nodejs. Updated to use the nsolid package directly.

Also updated the habibots Dockerfile to use the latest node 18 image. Debian Bookworm transitioned the netcat package from one that installed netcat-openbsd to a "virtual package" which doesn't specify a preferred version. Changed it to specify netcat-openbsd explicitly.