### PR TITLE
Allow importing valid non-templated JSON with UP/DOWN/etc in strings

### DIFF
--- a/db/dumpTeleportEntries.js
+++ b/db/dumpTeleportEntries.js
@@ -58,14 +58,20 @@ function templateConstantJoins(data) {
 }
 
 function templateHabitatObject(data) {
-  var templated = templateConstantJoins(data);
-  for (var replacementId in replacements) {
-    var replacement = replacements[replacementId];
-    var regex = replacement[0];
-    var replacementText = replacement[1];
-    templated = templated.replace(regex, replacementText);
+  try {
+    // try parsing the string - if it's already valid JSON, there's no need to run the preprocessing logic
+    JSON.parse(data)
+    return data
+  } catch (e) {
+    var templated = templateConstantJoins(data);
+    for (var replacementId in replacements) {
+      var replacement = replacements[replacementId];
+      var regex = replacement[0];
+      var replacementText = replacement[1];
+      templated = templated.replace(regex, replacementText);
+    }
+    return templateStringJoins(templated);
   }
-  return templateStringJoins(templated);
 }
 
 /** dump teleport entries found in a json object from STDIN */

--- a/db/populateModels.js
+++ b/db/populateModels.js
@@ -146,14 +146,20 @@ function templateConstantJoins(data) {
 }
 
 function templateHabitatObject(data) {
-  let templated = templateConstantJoins(data);
-  for (let replacementId in replacements) {
-    let replacement = replacements[replacementId];
-    let regex = replacement[0];
-    let replacementText = replacement[1];
-    templated = templated.replace(regex, replacementText);
+  try {
+    // try parsing the string - if it's already valid JSON, there's no need to run the preprocessing logic
+    JSON.parse(data)
+    return data
+  } catch (e) {
+    let templated = templateConstantJoins(data);
+    for (let replacementId in replacements) {
+      let replacement = replacements[replacementId];
+      let regex = replacement[0];
+      let replacementText = replacement[1];
+      templated = templated.replace(regex, replacementText);
+    }
+    return templateStringJoins(templated);
   }
-  return templateStringJoins(templated);
 }
 
 const runAllUpdates = async (promisesArray) => {


### PR DESCRIPTION
When importing objects into mongodb, there is a JSON preprocessing pass that lets you write stuff like `"town_dir": UP` and have it be turned into `"town_dir": "|"`. It also handles the string concatenation for hand-written text objects, like "XXX" + "XXX". This is done with some regexes, and makes hand-editing JSON files more pleasant.

@StuBlad has been recreating some Habitat newsletters from screenshots using the [Habitat Inspector](https://frandallfarmer.github.io/neohabitat-doc/inspector/text.html), which outputs standard JSON. Recently he hit a snag where one of the pages contained the word "DOWNTOWN", in all caps. As a series of regexes, the JSON preprocessing logic doesn't understand JSON structure, so when it sees the text `DOWNTOWN` in the middle of a string literal, it turns it into `"}"TOWN`, which no longer parses as valid JSON. Currently, the way the preprocessor is implemented means that only way to import a text object with the word "DOWNTOWN" in it is to use the "list of ASCII character codes" format, rather than JSON strings.

[text-10081987-rant-vol1-no4.json](https://github.com/user-attachments/files/16637928/text-10081987-rant-vol1-no4.json)

Since the preprocessor is designed to work on syntax which is not valid JSON, a reasonable workaround is to simply try to parse the string as JSON first, and if it succeeds, do nothing. I've made this change in the Habitat Inspector already; this patch simply updates the object import logic to match.