### PR TITLE
Fixing node dependencies so Docker works correctly

### DIFF
--- a/pushserver/app.js
+++ b/pushserver/app.js
@@ -5,7 +5,7 @@ var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var cookieSession = require('cookie-session');
 var bodyParser = require('body-parser');
-var websockify = require('node-websockify');
+var websockify = require('@maximegris/node-websockify');
 
 var YAML = require('yamljs');
 var config = YAML.load(process.env.PUSH_SERVER_CONFIG || './config.dev.yml');

--- a/pushserver/package-lock.json
+++ b/pushserver/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@maximegris/node-websockify": "^1.0.7",
         "body-parser": "~1.18.2",
         "cookie-parser": "~1.4.3",
         "cookie-session": "^2.0.0-beta.3",
@@ -18,13 +19,61 @@
         "mongo": "^0.1.0",
         "mongodb": "^6.8",
         "morgan": "~1.9.1",
-        "node-websockify": "^1.0.2",
         "serve-favicon": "^2.5.0",
         "server-send-events": "0.0.6",
         "showdown": "^1.9.1",
         "supervisor": "^0.12.0",
         "winston": "^2.4.0",
         "yamljs": "^0.3.0"
+      }
+    },
+    "node_modules/@maximegris/node-websockify": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@maximegris/node-websockify/-/node-websockify-1.0.7.tgz",
+      "integrity": "sha512-UIrO+wxxiBxWwIr63eCt8w0aXBGL2BM1pbibW/8m5Zh3Q9VxXPUjnu2c/1sgFyWRfvZfGIbkAa4JxUQXzf2Evw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime": "2.4.4",
+        "ws": "7.2.1"
+      },
+      "bin": {
+        "websockify": "websockify.js"
+      },
+      "engines": {
+        "node": ">=0.8.9"
+      }
+    },
+    "node_modules/@maximegris/node-websockify/node_modules/mime": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@maximegris/node-websockify/node_modules/ws": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -1088,20 +1137,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-websockify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/node-websockify/-/node-websockify-1.0.2.tgz",
-      "integrity": "sha512-wwEPWqYzW+/wRlewvN92qvMjT4rMRcZzEJiPDJuL8AytOP+D5cNeyF1o5jF5gAQpaShdg4m1bNkU18UmHOl4Bw==",
-      "dependencies": {
-        "ws": ">=0.4.27"
-      },
-      "bin": {
-        "websockify": "websockify.js"
-      },
-      "engines": {
-        "node": ">=0.8.9"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -1619,26 +1654,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "node_modules/ws": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.1.tgz",
-      "integrity": "sha512-XkgWpJU3sHU7gX8f13NqTn6KQ85bd1WU7noBHTT8fSohx7OS1TPY8k+cyRPCzFkia7C4mM229yeHr1qK9sM4JQ==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/y18n": {
       "version": "4.0.1",

--- a/pushserver/package.json
+++ b/pushserver/package.json
@@ -17,7 +17,7 @@
     "mongo": "^0.1.0",
     "mongodb": "^6.8",
     "morgan": "~1.9.1",
-    "node-websockify": "^1.0.2",
+    "@maximegris/node-websockify": "^1.0.7",
     "serve-favicon": "^2.5.0",
     "server-send-events": "0.0.6",
     "showdown": "^1.9.1",


### PR DESCRIPTION
I matched Steve's changes from the Bridge 2.0 branch switching out node-websockify which is now deprecated, for a maintained fork of it. This small change gets the Docker build working once more with zero friction. I've personally tested this from start to finish and was able to successfully stand up a NeoHabitat instance.