### PR TITLE
bridge_v2: nil-safe changeContext + default to DEBUG logging

### DIFF
--- a/ansible/roles/bridge_host/defaults/main.yml
+++ b/ansible/roles/bridge_host/defaults/main.yml
@@ -29,7 +29,14 @@ bridge_host_mongo_collection: "odb"
 bridge_host_otel_endpoint: "http://127.0.0.1:4318"
 bridge_host_initial_context: "context-hatchery"
 bridge_host_rate: 1200
-bridge_host_log_level: "INFO"
+# Default to DEBUG. Bridge client lockups have been hard to diagnose
+# at INFO because the per-message wire flow isn't logged — when a
+# Habitat NAK or session hang shows up, we can't see what command
+# came in or what reply went out. Volume is manageable for the
+# made's session count; promtail ingests it into Loki via journald.
+# Override per-host in inventory/group_vars if a noisier or quieter
+# level is wanted.
+bridge_host_log_level: "DEBUG"
 
 # Run as root for now: TCP_REPAIR requires CAP_NET_ADMIN, the /proc
 # walk in SnapshotAllWithTCP wants self-process visibility, and the

--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -358,9 +358,18 @@ func (c *ClientSession) handleElkoMessage(msg *ElkoMessage) {
 
 	if msg.Type == "changeContext" {
 		// Save for MESSAGE_DESCRIBE to deal with later.
-		c.nextRegion = *msg.Context
-		// Force enterContext after reconnect? aka Client has prematurely sent MESSAGE_DESCRIBE and we ignored it.
-		go c.reconnectToElko(*msg.Immediate, *msg.Context)
+		// Nil-safe deref: Elko can omit either field when it didn't
+		// set them (the JSON decoder leaves the matching pointer nil).
+		// Previously these were `*msg.Context` / `*msg.Immediate`,
+		// which would panic the entire bridge process — and a panic in
+		// elkoReader takes down EVERY connected client, not just the
+		// one whose message was malformed. str() / boolor return
+		// safe defaults; reconnectToElko handles "" context fine
+		// (waits for the client's followup entercontext) and
+		// immediate=false is the conservative choice (don't auto-enter
+		// when we don't know what we're entering).
+		c.nextRegion = str(msg.Context)
+		go c.reconnectToElko(boolor(msg.Immediate, false), c.nextRegion)
 		return
 	}
 

--- a/bridge_v2/bridge/utils.go
+++ b/bridge_v2/bridge/utils.go
@@ -173,6 +173,15 @@ func i32sor(p *[]int32, def []int32) []int32 {
 	return *p
 }
 
+// boolor returns *p, or def if p is nil. Mirrors u8or for *bool fields
+// like ElkoMessage.Immediate that Elko frequently omits.
+func boolor(p *bool, def bool) bool {
+	if p == nil {
+		return def
+	}
+	return *p
+}
+
 func BoolP(b bool) *bool {
 	return &b
 }


### PR DESCRIPTION
## Why

Came out of digging into Randy's session-9 lockup at 05:00:45.

## What

**1. Nil-safe `changeContext` handler in `bridge_v2/bridge/client_session.go`**

The handler at line 359-364 was dereferencing `*msg.Context` and `*msg.Immediate` directly on every server-initiated changeContext. Either pointer can be nil — Elko omits fields it didn't set; the JSON decoder leaves the matching Go pointer nil. On nil, the deref panics `elkoReader`, which takes down the **entire bridge process**, killing every connected client — not just the one whose message was malformed.

Same class of bug as the broader nil-safe sweep in `040201aa` / `ed633df5`; this site was simply missed. Now uses `str()` and a new `boolor()` helper. Defaults on nil: empty context (reconnectToElko handles "" — waits for the client's followup entercontext) and `immediate=false` (don't auto-enter when we don't know what we're entering).

**2. Default log level → DEBUG in `ansible/roles/bridge_host/defaults/main.yml`**

Randy's lockup was impossible to diagnose at INFO because the per-message wire flow isn't logged — we could see EOFs, "not converted" warnings, and the eventual NAK, but nothing about which client command went unanswered ~70s before the timeout. DEBUG gets us the full per-frame translation. Volume is manageable for the made's session count; promtail ingests via journald → Loki. Overridable per-host in `inventory/group_vars` if a noisier or quieter level is wanted.

## Test plan

- [x] Cross-compile clean for linux/amd64
- [x] Hand-deployed the binary + DEBUG to the made; bridge running with the change for ~10 min, all three listeners healthy, bots reconnected, no panics
- [ ] Maintainer to confirm Loki volume from DEBUG isn't blowing through Grafana Cloud quotas after a day
- [ ] Repro Randy's lockup pattern (rapid region transits) with DEBUG on and capture the actual culprit message