### PR TITLE
fix: mask coordinate arithmetic to uint8 to prevent negative y values

### DIFF
--- a/src/main/java/org/made/neohabitat/mods/Avatar.java
+++ b/src/main/java/org/made/neohabitat/mods/Avatar.java
@@ -494,7 +494,7 @@ public class Avatar extends Container implements UserMod {
                         }
                         if (obj.HabitatClass() == CLASS_ELEVATOR) {
                             x = obj.x + 12;
-                            y = obj.y -  5;
+                            y = (obj.y - 5) & 0xFF;
                         }
                     }
                 }
@@ -508,12 +508,12 @@ public class Avatar extends Container implements UserMod {
 
 
     private int x_invert(int x) {
-        return (XMAX - x);         
+        return (XMAX - x) & 0xFF;
     }
 
 
     private int y_invert(int y) {
-        return(current_region().depth - y);
+        return (current_region().depth - y) & 0xFF;
     }
 
     private int x_scale(int x) {


### PR DESCRIPTION
## Summary

- `y_invert()`, `x_invert()`, and elevator arrival y calculation in `Avatar.java` now apply `& 0xFF` to restore the original unsigned byte semantics from PL/1
- Java signed integer arithmetic was producing negative coordinates (e.g. `y=-2`) during region transitions, which crash bridge_v2 on decode and permanently lock out affected avatars
- 6 prod avatars (Naibor, Test, Menta, OneMore, Droid, RM) were affected and have been patched directly in the database

## Test plan
- [x] Walked back and forth between Broadway Cross (Downtown_7f) and Arcade (Downtown_7g) locally — no negative y produced
- [x] Confirmed `y=160` after transitions that previously would have stored `y=-2`
- [x] Prod database patched for all 6 affected avatars

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)