### PR TITLE
feat: add ?/@ reply handlers and inline JS to Telko scripts

### DIFF
--- a/test/MOTD.elko
+++ b/test/MOTD.elko
@@ -1,3 +1,6 @@
 {"to":"session", "op":"entercontext", "user":"user-randy", "context":"context-Randy_Rd_13_interior", "Telko": { "delay": 2, "logtime": true } }
+
+?make *
+(> last.you)
 {"to":"context","op":"SET_MOTD","MOTD":"Welcome to NeoHabitat! The recreation of the first graphical metaverse!"}
 {"to":"session", "op":"disconnect"}

--- a/test/TELKO-HANDLERS.md
+++ b/test/TELKO-HANDLERS.md
@@ -1,0 +1,232 @@
+# Telko Handler Extensions
+
+## Overview
+
+Telko scripts (`.elko` files) are sequential streams of outgoing JSON messages.
+This extension adds two handler syntaxes for reacting to incoming messages:
+
+- `?OP` — **reply handler**: "wait for" — pauses script until a matching message satisfying the condition arrives
+- `@OP` — **async handler**: persistent, fires whenever a matching message arrives
+
+---
+
+## Syntax
+
+### Outgoing message (existing)
+```
+{"op":"WALK","to":"$ME","x":100,"y":130}
+```
+
+### Inline code
+```
+> javascript expression or function definition
+```
+
+Scheduled to execute after all preceding sends have fired (at `timeLastSent`).
+Definitions accumulate in a shared scope visible to all subsequent `?` and `@`
+handler blocks. Use `>` to read state that is guaranteed to be populated by
+the time the preceding sends have completed.
+
+### Reply handler
+```
+?OP [$TARGET]
+(> javascript code)
+```
+
+Registered after all preceding sends have fired. Means: **wait for an incoming
+OP that satisfies this condition**, then run the code and advance the script.
+
+The code block is evaluated as an expression. If it returns falsy, the handler
+stays pending — waiting for the *next* matching message. If it returns truthy,
+or is a statement with no return value, the script advances.
+
+```
+?make *
+(> last.you)
+```
+
+"Wait for a `make` where `last.you` is true." All other makes are ignored.
+
+```
+?WALK$
+(> if (last.err !== 0) abort('walk failed: err=' + last.err))
+```
+
+"Wait for `WALK$`, then abort if it failed." Statement form — always advances.
+
+### Async handler
+```
+@OP [$TARGET]
+(> javascript code)
+```
+
+Registered after all preceding sends have fired. Does NOT pause the script.
+Fires whenever a matching incoming message arrives. A later `@OP $TARGET` for
+the same op+noid key replaces the earlier one.
+
+---
+
+## Sequencing
+
+`>` lines and `@` handler registrations are **scheduled at `timeLastSent`** —
+the moment the last preceding send fires — not at script parse time. This
+means:
+
+- Sends from preceding lines execute first
+- `>` code sees state (History, Names) populated by those sends and any server
+  responses that arrived during the send delays
+- `@` handlers start listening from that point forward
+
+`?` handler registration is synchronous (it must pause the script immediately),
+but the `?` is resolved using `Names` at registration time, which is after all
+preceding sends have fired.
+
+---
+
+## Target resolution
+
+`$TARGET` is optional. If omitted it defaults to the noid of the `to` field
+of the most recently sent message.
+
+`$TARGET` is resolved through `Names` at the moment the handler is registered —
+after preceding sends have fired and `Names` is populated.
+
+Special targets:
+- `$ME`     — noid of the current user's avatar
+- `$REGION` — noid of the current region (useful for broadcasts)
+- `$TARGET` — noid of the most recent send's `to` field (default)
+- `$chip`   — any Names entry, resolved at registration time
+- `*`       — wildcard: matches any noid for this op
+
+The handler map key is `op + ':' + resolvedNoid`. Last write wins per key.
+
+---
+
+## Code block context
+
+`>` lines, `?` handler blocks, and `@` handler blocks all share a single scope.
+Functions and variables defined with `>` are available to all subsequent handlers.
+
+| Name              | Description                                      |
+|-------------------|--------------------------------------------------|
+| `last`            | Parsed incoming message that triggered this handler |
+| `Names`           | Short-name → full ref lookup table               |
+| `History`         | Full object state (keyed by ref)                 |
+| `Telko`           | Config object (delay, logtime, etc.)             |
+| `send(obj)`       | Queue an outgoing message                        |
+| `abort('reason')` | Stop script execution, log reason and exit       |
+| `ignore()`        | Deregister this `@` handler (no-op inside `?`)   |
+
+---
+
+## Script pause semantics
+
+When a `?` handler is registered:
+- The script **stops advancing** to the next line
+- `@` handlers remain **fully active** and may fire and call `send()` freely
+- Each matching incoming message is tested against the condition code
+- When the condition is satisfied (truthy return, or statement with no return),
+  the script resumes from the next line
+- Non-matching messages (condition returns falsy) are silently skipped — the
+  `?` keeps waiting
+
+If `abort()` is called inside a `?` or `@` block, the script halts immediately
+with an optional exit message. Pending `?` and all `@` handlers are cleared.
+
+---
+
+## Examples
+
+### Wait for avatar before proceeding (standard login guard)
+```
+{"to":"session","op":"entercontext","user":"user-randy","Telko":{"delay":2}}
+
+?make *
+(> last.you)
+
+{"to":"ME","op":"POSTURE","pose":141}
+{"to":"ME","op":"SPEAK","esp":0,"text":"$ME.name$: Greetings Programs!"}
+```
+
+The `?make *` stays pending through all region/item makes until the avatar make
+(`you: true`) arrives, guaranteeing `$ME` and `History[Names['ME']]` are set
+before any subsequent sends or `>` lines run.
+
+### Dump avatar state after login
+```
+{"to":"session","op":"entercontext","user":"user-randy","Telko":{"delay":2}}
+
+?make *
+(> last.you)
+
+> console.log(JSON.stringify(History[Names['ME']], null, 2))
+```
+
+With the guard in place, the `>` line fires at `timeLastSent` (after the sends),
+and `Names['ME']` is guaranteed to be populated.
+
+### Walk and confirm
+```
+{"op":"WALK","to":"$ME","x":100,"y":130}
+?WALK$
+(> if (last.err !== 0) abort('walk failed: err=' + last.err))
+{"op":"SPEAK","to":"$ME","text":"Made it!"}
+```
+
+### Define helpers, react to speech
+```
+> function greet(name) { send({"op":"SPEAK","to":"$ME","text":"Howdy, " + name + "!"}) }
+> function isBot(name) { return name.toLowerCase().includes('bot') }
+
+@APPEARING_$ $REGION
+(> if (!isBot(last.obj.name)) greet(last.obj.name))
+
+@SPEAK$ $REGION
+(> if (last.text.includes('help')) greet(last.text.split(' ')[0]))
+```
+
+### Replace a handler mid-script
+```
+@SPEAK$ $chip
+(> log('chip said: ' + last.text))
+
+{"op":"WALK","to":"$ME","x":50}
+?WALK$
+(> )
+
+@SPEAK$ $chip
+(> if (last.text.includes('bye')) { send({"op":"SPEAK","to":"$ME","text":"See ya!"}); ignore() })
+```
+
+### One-shot async: greet first avatar then stop
+```
+> function greet(name) { send({"op":"SPEAK","to":"$ME","text":"Welcome, " + name + "!"}) }
+
+@APPEARING_$ $REGION
+(> greet(last.obj.name); ignore())
+```
+
+### Wait for a door to open (broadcast to region, not to sender)
+```
+{"op":"OPEN","to":"$door"}
+?OPENED_$ $REGION
+(> log('door is open'))
+{"op":"WALK","to":"$ME","x":100}
+```
+
+---
+
+## Implementation notes
+
+- Shared scope: a plain object accumulates all `>` definitions; spread as named
+  parameters into every handler function via `new Function`
+- `>` lines and `@` registrations are deferred via `setTimeout` to `timeLastSent`
+- `?` registration is synchronous (must pause the script before the next line runs)
+- `?` code is evaluated as `return (code)` first; if that is a syntax error
+  (statement rather than expression), it falls back to running as a statement
+  and always advances
+- `@` map: plain object, key = `"OP:noid"`, value = compiled function
+- `?` slot: single pending handler (op, noid, code); only one active at a time
+- `send()` inside handlers uses the same queue as the script — no special path
+- Incoming messages first check `?` slot, then `@` map (exact key, then `op:*`
+  wildcard), then discard

--- a/test/Telko.js
+++ b/test/Telko.js
@@ -103,6 +103,125 @@ var Names = {};
 /** An instance of all the objects seen during this session. Used for embedded variable substitution */
 var History = {};
 
+// ── Handler support ──────────────────────────────────────────────────────────
+//
+// Shared scope for > lines and handler blocks. Functions/variables defined
+// with > are available to all subsequent ? and @ handlers.
+var HandlerScope = {
+	Names:   Names,
+	History: History,
+	Telko:   Telko,
+	send:    function(obj) { sendWithSubstituions(obj); },
+	abort:   function(reason) {
+		if (reason) Trace.info('abort: ' + reason);
+		process.exit(0);
+	},
+	log:     function(msg) { console.log(msg); }
+};
+
+// Pending one-shot reply handler: { op, noid, fn }
+// Set when a ?OP line is parsed; cleared when it fires.
+var pendingReply = null;
+
+// Persistent async handlers: key = "OP:noid", value = fn
+var asyncHandlers = {};
+
+// Whether the script is paused waiting for a ? reply.
+var scriptPaused = false;
+
+// Lines buffered while the script is paused.
+var pausedLines = [];
+
+// The noid of the most recently sent message's `to` target.
+var lastSentNoid = null;
+
+function resolveNoid(target) {
+	if (!target || target === '$TARGET') return lastSentNoid;
+	if (target === '*') return '*';
+	var ref = Names[target.replace(/^\$/, '')] || target.replace(/^\$/, '');
+	var obj = History[ref];
+	if (obj && obj.obj && obj.obj.mods && obj.obj.mods[0]) return obj.obj.mods[0].noid;
+	return ref;
+}
+
+function runHandlerCode(code, last) {
+	var scope = Object.assign({}, HandlerScope, { last: last });
+	try {
+		var fn = new Function(Object.keys(scope).join(','), code);
+		return fn.apply(null, Object.values(scope));
+	} catch(e) {
+		Trace.error('Handler error: ' + e.message);
+	}
+}
+
+// For ? handlers: tries code as a return expression (condition mode).
+// Falls back to statement mode and returns true (always advance) if not an expression.
+function runReplyCode(code, last) {
+	var scope = Object.assign({}, HandlerScope, { last: last });
+	try {
+		var fn = new Function(Object.keys(scope).join(','), 'return (' + code + ')');
+		return fn.apply(null, Object.values(scope));
+	} catch(e) {
+		try {
+			var fn = new Function(Object.keys(scope).join(','), code);
+			fn.apply(null, Object.values(scope));
+			return true;
+		} catch(e2) {
+			Trace.error('? handler error: ' + e2.message);
+			return true;
+		}
+	}
+}
+
+function runHandlerCodeWithIgnore(code, last, ignoreKey) {
+	var scope = Object.assign({}, HandlerScope, {
+		last:   last,
+		ignore: function() { delete asyncHandlers[ignoreKey]; }
+	});
+	try {
+		var fn = new Function(Object.keys(scope).join(','), code);
+		fn.apply(null, Object.values(scope));
+	} catch(e) {
+		Trace.error('Handler error: ' + e.message);
+	}
+}
+
+function dispatchIncoming(msg) {
+	var op   = msg.op || msg.type;
+	var noid = msg.noid != null ? msg.noid : null;
+
+	// Check pending reply handler first.
+	if (pendingReply) {
+		var pr = pendingReply;
+		if (pr.op === op && (pr.noid == null || pr.noid === '*' || pr.noid == noid)) {
+			var result = pr.code ? runReplyCode(pr.code, msg) : true;
+			if (!result) {
+				// Condition not met — keep waiting for next matching message.
+				return;
+			}
+			pendingReply = null;
+			scriptPaused = false;
+			// Resume buffered lines.
+			var buffered = pausedLines.slice();
+			pausedLines = [];
+			buffered.forEach(function(line) { handleInputLine(line); });
+			return;
+		}
+	}
+
+	// Check async handlers: exact match, then wildcard (*).
+	var key = op + ':' + noid;
+	if (asyncHandlers[key]) {
+		asyncHandlers[key](msg, key);
+		return;
+	}
+	var wildKey = op + ':*';
+	if (asyncHandlers[wildKey]) {
+		asyncHandlers[wildKey](msg, wildKey);
+	}
+}
+// ────────────────────────────────────────────────────────────────────────────
+
 function pad0(n,z) {
 	z = z || 1;
 	return ("000" + n).slice(-(z + 1));
@@ -269,6 +388,8 @@ const Server = Net.connect(Telko.port, Telko.host, function() {
 function processElkoPacket(s) {
 	console.log(timestamp("<-") + s.trim());
 	scanForRefs(s);
+	var msg = parseElko(s);
+	if (msg && msg.op) dispatchIncoming(msg);
 }
 
 /**
@@ -336,6 +457,16 @@ function sendWithSubstituions(obj) {
 	if (undefined !== obj.op && "entercontext" === obj.op && undefined === obj.context) {
 		obj.context = Telko.context;
 	}
+	// Track the noid of the target for ? default resolution.
+	if (obj.to) {
+		var toRef = obj.to;
+		var toObj = History[toRef];
+		if (toObj && toObj.obj && toObj.obj.mods && toObj.obj.mods[0]) {
+			lastSentNoid = toObj.obj.mods[0].noid;
+		} else {
+			lastSentNoid = null;
+		}
+	}
 	var msg = JSON.stringify(obj);
 	console.log(timestamp("->") + msg.trim());
 	Server.write(msg + "\n\n");
@@ -345,7 +476,16 @@ function startReadingSTDIN() {
 	Readline.createInterface({input: process.stdin}).on('line', (input) => { handleInputLine(input); });
 }
 
+// Pending handler op/target parsed from a ?OP or @OP line, waiting for its (> code) block.
+var pendingHandlerSpec = null;
+
 function handleInputLine(input) {
+	// Buffer lines while paused waiting for a ? reply.
+	if (scriptPaused) {
+		pausedLines.push(input);
+		return;
+	}
+
 	if (input.indexOf("{") === 0) {
 		var obj = parseElko(input.toString());
 		// Send the message, potentially in the future...
@@ -362,7 +502,7 @@ function handleInputLine(input) {
 			}
 			delete obj.Telko;
 		}
-		
+
 		if (when <= now) {
 			sendWithSubstituions(obj);
 			timeLastSent = now;
@@ -374,11 +514,75 @@ function handleInputLine(input) {
 	} else if (input.indexOf("<") === 0) {
 		var file = input.trim().slice(1);
 		if ("STDIN" === file) {
-			// Read from STDIN (usually triggered in a script, so that the timing works out...)
 			startReadingSTDIN();
 		} else {
-			// Run a telko script file!
 			executeScript(file);
+		}
+
+	} else if (input.indexOf(">") === 0) {
+		// Inline code: scheduled at timeLastSent so it runs after preceding sends.
+		// Function declarations are rewritten as HandlerScope assignments so
+		// they are visible to subsequent ? and @ handler blocks.
+		var code = input.slice(1).trim();
+		code = code.replace(/^function\s+(\w+)\s*\(/, 'HandlerScope["$1"] = function(');
+		;(function(c) {
+			var delay = Math.max(0, timeLastSent - new Date().getTime());
+			setTimeout(function() {
+				try {
+					var scope = Object.assign({ HandlerScope: HandlerScope }, HandlerScope);
+					var fn = new Function(Object.keys(scope).join(','), c);
+					fn.apply(null, Object.values(scope));
+				} catch(e) {
+					Trace.error('> eval error: ' + e.message);
+				}
+			}, delay);
+		})(code);
+
+	} else if (input.indexOf("?") === 0) {
+		// Reply handler spec: ?OP [$target]
+		// Resolved immediately — ? pauses the script synchronously so Names
+		// is already populated by the time this line is reached.
+		var parts = input.slice(1).trim().split(/\s+/);
+		var op     = parts[0];
+		var target = parts[1] || '$TARGET';
+		var noid   = resolveNoid(target);
+		pendingHandlerSpec = { kind: '?', op: op, noid: noid };
+
+	} else if (input.indexOf("@") === 0) {
+		// Async handler spec: @OP [$target]
+		// Store raw target — resolveNoid is deferred to registration time
+		// so Names is populated by preceding sends when it runs.
+		var parts = input.slice(1).trim().split(/\s+/);
+		var op     = parts[0];
+		var target = parts[1] || '$TARGET';
+		pendingHandlerSpec = { kind: '@', op: op, target: target };
+
+	} else if (input.indexOf("(>") === 0) {
+		// Code block for the preceding ? or @ spec.
+		var code = input.replace(/^\(>\s*/, '').replace(/\)\s*$/, '').trim();
+		if (!pendingHandlerSpec) {
+			Trace.warn('(> code) with no preceding ? or @ spec, ignoring');
+			return;
+		}
+		var spec = pendingHandlerSpec;
+		pendingHandlerSpec = null;
+
+		if (spec.kind === '?') {
+			pendingReply  = { op: spec.op, noid: spec.noid, code: code };
+			scriptPaused  = true;
+		} else {
+			// Schedule @ registration at timeLastSent so it fires after
+			// preceding sends and Names is populated for resolveNoid.
+			;(function(s, c) {
+				var delay = Math.max(0, timeLastSent - new Date().getTime());
+				setTimeout(function() {
+					var noid = resolveNoid(s.target);
+					var k    = s.op + ':' + noid;
+					asyncHandlers[k] = function(msg, handlerKey) {
+						runHandlerCodeWithIgnore(c, msg, handlerKey);
+					};
+				}, delay);
+			})(spec, code);
 		}
 	}
 }

--- a/test/alex.elko
+++ b/test/alex.elko
@@ -1,5 +1,8 @@
 {"to":"session", "op":"entercontext", "user":"user-vonguard", "Telko": { "delay": 2, "logtime": true } }
 
+?make *
+(> last.you)
+
 {"to":"ME","op":"POSTURE","pose":141, "Telko": { "delay": 1 } }
 
 {"to":"ME","op":"SPEAK","esp":0,"text":"I... AM... $ME.name$!", "Telko": { "delay": 2 } }

--- a/test/aric.elko
+++ b/test/aric.elko
@@ -1,5 +1,8 @@
 {"to":"session", "op":"entercontext", "user":"user-aric", "Telko": { "delay": 2, "logtime": true } }
 
+?make *
+(> last.you)
+
 {"to":"ME","op":"POSTURE","pose":141, "Telko": { "delay": 1 } }
 
 {"to":"ME","op":"SPEAK","esp":0,"text":"$ME.name$ here: Greetings!", "Telko": { "delay": 2 } }

--- a/test/chip.elko
+++ b/test/chip.elko
@@ -1,5 +1,8 @@
 {"to":"session", "op":"entercontext", "user":"user-chip", "Telko": { "delay": 2, "logtime": true } }
 
+?make *
+(> last.you)
+
 {"to":"ME","op":"POSTURE","pose":141, "Telko": { "delay": 1 } }
 
 {"to":"ME","op":"SPEAK","esp":0,"text":"$ME.name$: Hi! Theodophilus sent me.", "Telko": { "delay": 2 }}

--- a/test/dumpme.elko
+++ b/test/dumpme.elko
@@ -1,0 +1,1 @@
+> console.log(JSON.stringify(History[Names['ME']], null, 2))

--- a/test/empty.elko
+++ b/test/empty.elko
@@ -1,5 +1,8 @@
 {"to":"session", "op":"entercontext", "user":"user-empty", "Telko": { "delay": 2, "logtime": true } }
 
+?make *
+(> last.you)
+
 {"to":"ME","op":"POSTURE","pose":141, "Telko": { "delay": 1 } }
 
 {"to":"ME","op":"SPEAK","esp":0,"text":"My name is $ME.name$, and that is what I am.", "Telko": { "delay": 2 } }

--- a/test/janet.elko
+++ b/test/janet.elko
@@ -1,5 +1,8 @@
 {"to":"session", "op":"entercontext", "user":"user-janet", "Telko": { "delay": 2, "logtime": true } }
 
+?make *
+(> last.you)
+
 {"to":"ME","op":"POSTURE","pose":141, "Telko": { "delay": 1 } }
 
 {"to":"ME","op":"SPEAK","esp":0,"text":"Commander $ME.name$ requests permission to come aboard.", "Telko": { "delay": 2 } }

--- a/test/library.elko
+++ b/test/library.elko
@@ -2,3 +2,6 @@
 
 {"to":"session","op":"entercontext","context":"context-library","user":"$USER"}
 
+?make *
+(> last.you)
+

--- a/test/matt.elko
+++ b/test/matt.elko
@@ -1,5 +1,8 @@
 {"to":"session", "op":"entercontext", "user":"user-rassilon", "Telko": { "delay": 2, "logtime": true } }
 
+?make *
+(> last.you)
+
 {"to":"ME","op":"POSTURE","pose":141, "Telko": { "delay": 1 } }
 
 {"to":"ME","op":"SPEAK","esp":0,"text":"$ME.name$: Ello gov'nor! Top of the mornin' to ya!", "Telko": { "delay": 2 }}

--- a/test/randy.elko
+++ b/test/randy.elko
@@ -1,5 +1,8 @@
 {"to":"session", "op":"entercontext", "user":"user-randy", "Telko": { "delay": 2, "logtime": true } }
 
+?make *
+(> last.you)
+
 {"to":"ME","op":"POSTURE","pose":141, "Telko": { "delay": 1 } }
 
 {"to":"ME","op":"SPEAK","esp":0,"text":"$ME.name$: Greetings Programs!", "Telko": { "delay": 2 }}

--- a/test/region.elko
+++ b/test/region.elko
@@ -2,3 +2,6 @@
 
 {"to":"session","op":"entercontext","context":"context-test","user":"$USER"}
 
+?make *
+(> last.you)
+

--- a/test/steve.elko
+++ b/test/steve.elko
@@ -1,5 +1,8 @@
 {"to":"session", "op":"entercontext", "user":"user-steve", "Telko": { "delay": 2, "logtime": true } }
 
+?make *
+(> last.you)
+
 {"to":"ME","op":"POSTURE","pose":141, "Telko": { "delay": 1 } }
 
 {"to":"ME","op":"SPEAK","esp":0,"text":"$ME.name$: Hi! Phil Collins sent me.", "Telko": { "delay": 2 }}

--- a/test/stu.elko
+++ b/test/stu.elko
@@ -1,5 +1,8 @@
 {"to":"session", "op":"entercontext", "user":"user-stu", "Telko": { "delay": 2, "logtime": true } }
 
+?make *
+(> last.you)
+
 {"to":"ME","op":"POSTURE","pose":141, "Telko": { "delay": 1 } }
 
 {"to":"ME","op":"SPEAK","esp":0,"text":"$ME.name$: Howdily doodily neighborino!", "Telko": { "delay": 2 }}

--- a/test/table.elko
+++ b/test/table.elko
@@ -2,3 +2,6 @@
 
 {"to":"session","op":"entercontext","context":"context-table","user":"$USER"}
 
+?make *
+(> last.you)
+

--- a/test/test.elko
+++ b/test/test.elko
@@ -2,3 +2,6 @@
 
 {"to":"session","op":"entercontext","context":"context-test","user":"$USER"}
 
+?make *
+(> last.you)
+

--- a/test/turf.elko
+++ b/test/turf.elko
@@ -1,3 +1,6 @@
 {"to":"ME","op":"NEWREGION","direction":2, "Telko": {"delay": 2}}
 
 {"to":"session","op":"entercontext","context":"context-turf","user":"$USER"}
+
+?make *
+(> last.you)

--- a/test/unknown.elko
+++ b/test/unknown.elko
@@ -1,3 +1,6 @@
 {"to":"session", "op":"entercontext", "user":"user-unknown", "Telko": { "delay": 2, "logtime": true } }
 
+?make *
+(> last.you)
+
 {"to":"ME","op":"SPEAK","esp":0,"text":"$ME.name$: I'm a stranger!", "Telko": { "delay": 2 }}


### PR DESCRIPTION
## Summary

- Adds `?OP` (wait-for), `@OP` (async), and `>` (inline code) syntax to `.elko` test scripts, enabling reactive scripts that wait for specific server messages before proceeding
- All `entercontext` scripts now include a `?make *` / `(> last.you)` guard ensuring `$ME` is resolved before subsequent sends or `>` lines execute
- Adds `test/TELKO-HANDLERS.md` — full design and usage documentation
- Adds `test/dumpme.elko` — example script that dumps the current avatar state

## Test plan

- [ ] `node Telko.js -p 2026 --files=randy,dumpme` — enters context, waits for avatar make, dumps avatar JSON, speaks "Greetings Programs!" with correct name, exits cleanly
- [ ] Verify `?make *` / `(> last.you)` guard skips region/item makes and unpauses only on avatar make
- [ ] Verify `>` inline code reads `History[Names['ME']]` correctly after guard

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)