### PR TITLE
feat: add /status error log page to pushserver

### DIFF
--- a/ansible/roles/bridge_host/defaults/main.yml
+++ b/ansible/roles/bridge_host/defaults/main.yml
@@ -38,6 +38,7 @@ bridge_host_rate: 1200
 # Override per-host in inventory/group_vars if a noisier or quieter
 # level is wanted.
 bridge_host_log_level: "DEBUG"
+bridge_host_admin_listen: "127.0.0.1:2027"
 
 # Run as root for now: TCP_REPAIR requires CAP_NET_ADMIN, the /proc
 # walk in SnapshotAllWithTCP wants self-process visibility, and the

--- a/ansible/roles/bridge_host/templates/bridge_v2.service.j2
+++ b/ansible/roles/bridge_host/templates/bridge_v2.service.j2
@@ -33,7 +33,8 @@ ExecStart={{ bridge_host_binary_path }} \
   --mongo.collection={{ bridge_host_mongo_collection }} \
   --context={{ bridge_host_initial_context }} \
   --rate={{ bridge_host_rate }} \
-  --log.level={{ bridge_host_log_level }}
+  --log.level={{ bridge_host_log_level }} \
+  --admin.listen={{ bridge_host_admin_listen }}
 # `systemctl reload bridge_v2` → SIGHUP → tableflip graceful upgrade.
 # The new binary on disk (placed by the deploy job at
 # {{ bridge_host_binary_path }}) takes over via fork+exec; sessions

--- a/bridge_v2/.air.toml
+++ b/bridge_v2/.air.toml
@@ -7,6 +7,7 @@ bin = "./tmp/bridge_v2"
 args_bin = [
   "--qlink",
   "--listen", "0.0.0.0:2026",
+  "--admin.listen", "0.0.0.0:2027",
   "--elko.host", "neohabitat:2018",
   "--mongo.host", "mongodb://neohabitatmongo:27017",
   "--mongo.db", "elko",

--- a/bridge_v2/bridge/ringlog.go
+++ b/bridge_v2/bridge/ringlog.go
@@ -1,0 +1,102 @@
+package bridge
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	"github.com/rs/zerolog"
+)
+
+const ringlogCap = 20
+
+// LogEntry is one captured log line exposed by the admin /logs endpoint.
+type LogEntry struct {
+	Level   string          `json:"level"`
+	Time    string          `json:"time,omitempty"`
+	Message string          `json:"message"`
+	Fields  json.RawMessage `json:"fields,omitempty"`
+}
+
+// RingLog is a zerolog LevelWriter that retains the last ringlogCap
+// error- and warn-level entries in memory. Thread-safe.
+type RingLog struct {
+	mu      sync.Mutex
+	entries []LogEntry
+}
+
+// NewRingLog returns an initialised RingLog.
+func NewRingLog() *RingLog { return &RingLog{} }
+
+// WriteLevel satisfies zerolog.LevelWriter. Only error and warn entries
+// are retained; all other levels are silently discarded.
+func (r *RingLog) WriteLevel(level zerolog.Level, p []byte) (int, error) {
+	if level != zerolog.ErrorLevel && level != zerolog.WarnLevel {
+		return len(p), nil
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(p, &raw); err != nil {
+		return len(p), nil
+	}
+
+	entry := LogEntry{Level: level.String()}
+	if m, ok := raw["message"]; ok {
+		_ = json.Unmarshal(m, &entry.Message)
+	}
+	if t, ok := raw["time"]; ok {
+		_ = json.Unmarshal(t, &entry.Time)
+	}
+
+	// Collect all fields that are not the standard zerolog envelope keys.
+	fields := make(map[string]json.RawMessage)
+	for k, v := range raw {
+		switch k {
+		case "level", "message", "time":
+			// skip
+		default:
+			fields[k] = v
+		}
+	}
+	if len(fields) > 0 {
+		entry.Fields, _ = json.Marshal(fields)
+	}
+
+	r.mu.Lock()
+	r.entries = append(r.entries, entry)
+	if len(r.entries) > ringlogCap {
+		r.entries = r.entries[len(r.entries)-ringlogCap:]
+	}
+	r.mu.Unlock()
+	return len(p), nil
+}
+
+// Write satisfies io.Writer (required by zerolog.MultiLevelWriter). Since
+// we only care about levelled writes, this is a no-op.
+func (r *RingLog) Write(p []byte) (int, error) { return len(p), nil }
+
+// Entries returns a copy of the retained entries, newest last.
+func (r *RingLog) Entries() []LogEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]LogEntry, len(r.entries))
+	copy(out, r.entries)
+	return out
+}
+
+// ServeHTTP handles GET /logs — returns JSON array of retained entries.
+// Supports ?level=error or ?level=warn to filter.
+func (r *RingLog) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	levelFilter := req.URL.Query().Get("level")
+
+	entries := r.Entries()
+	out := entries[:0:0]
+	for _, e := range entries {
+		if levelFilter == "" || e.Level == levelFilter {
+			out = append(out, e)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}

--- a/bridge_v2/main.go
+++ b/bridge_v2/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -45,6 +46,7 @@ var logLevel = flag.String("log.level", "INFO", "Log level for logger")
 var qlinkMode = flag.Bool("qlink", false, "Listen for Habilink/QLink clients")
 var otelEnabled = flag.Bool("otel.enabled", false, "Enable OpenTelemetry export")
 var graceful = flag.Bool("graceful", false, "Enable graceful restart via SIGHUP (tableflip). Production only.")
+var adminListen = flag.String("admin.listen", "", "Host:Port for the admin HTTP server (e.g. 127.0.0.1:2027). Disabled if empty.")
 
 const snapshotEnvVar = "BRIDGE_SNAPSHOT_PATH"
 
@@ -72,14 +74,29 @@ func main() {
 		listenAddrs = stringSliceFlag{"127.0.0.1:1337"}
 	}
 	setLogLevel(*logLevel)
+	ringLog := bridge.NewRingLog()
 	if !*otelEnabled {
-		log.Logger = log.Output(zerolog.ConsoleWriter{
+		console := zerolog.ConsoleWriter{
 			Out:        os.Stderr,
 			TimeFormat: "3:04:05PM",
 			FormatTimestamp: func(i interface{}) string {
 				return "\033[35m" + fmt.Sprintf("%s", i) + "\033[0m"
 			},
-		})
+		}
+		log.Logger = log.Output(zerolog.MultiLevelWriter(console, ringLog))
+	} else {
+		log.Logger = log.Output(zerolog.MultiLevelWriter(os.Stderr, ringLog))
+	}
+
+	if *adminListen != "" {
+		mux := http.NewServeMux()
+		mux.Handle("/logs", ringLog)
+		go func() {
+			if err := http.ListenAndServe(*adminListen, mux); err != nil {
+				log.Error().Err(err).Str("addr", *adminListen).Msg("Admin HTTP server failed")
+			}
+		}()
+		log.Info().Str("addr", *adminListen).Msg("Admin HTTP server listening")
 	}
 
 	var otelShutdown func(context.Context) error

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,7 @@ services:
       - ./bridge_v2:/app
     ports:
       - "2026:2026"
+      - "2027:2027"
     cap_add:
       - NET_ADMIN
     security_opt:

--- a/pushserver/bin/pushserver
+++ b/pushserver/bin/pushserver
@@ -97,12 +97,14 @@ const startPushserver = async () => {
   var EmulatorRoutes = require('../routes/emulator');
   var EventsRoutes = require('../routes/events');
   var IndexRoutes = require('../routes/index');
+  var StatusRoutes = require('../routes/status');
 
   const apiRoutes = new APIRoutes(habiproxy, config, mongoDb);
   const docsRoutes = new DocsRoutes(habiproxy, config, mongoDb);
   const emulatorRoutes = new EmulatorRoutes(habiproxy, config, mongoDb);
   const eventsRoutes = new EventsRoutes(habiproxy, config, mongoDb);
   const indexRoutes = new IndexRoutes(habiproxy, config, mongoDb);
+  const statusRoutes = new StatusRoutes(config);
 
   // Register application routes.
   app.use('/', indexRoutes.router);
@@ -110,6 +112,7 @@ const startPushserver = async () => {
   app.use('/docs', docsRoutes.router);
   app.use('/emulator', emulatorRoutes.router);
   app.use('/events', eventsRoutes.router);
+  app.use('/status', statusRoutes.router);
 
   // catch 404 and forward to error handler
   app.use(function(req, res, next) {

--- a/pushserver/config.dev.yml
+++ b/pushserver/config.dev.yml
@@ -6,6 +6,8 @@ websocketProxy:
   listenAddr: 0.0.0.0:1987
   remoteAddr: bridge_v2:2026
 
+bridgeAdminAddr: bridge_v2:2027
+
 backgroundImages:
   - https://raw.githubusercontent.com/frandallfarmer/neohabitat-doc/master/docs/images/neohabitat_splash.png
   - https://raw.githubusercontent.com/frandallfarmer/neohabitat-doc/master/docs/images/launcher_login.png

--- a/pushserver/config.prod.yml
+++ b/pushserver/config.prod.yml
@@ -6,6 +6,8 @@ websocketProxy:
   listenAddr: 0.0.0.0:1987
   remoteAddr: habitat.themade.org:1986
 
+bridgeAdminAddr: 127.0.0.1:2027
+
 backgroundImages:
   - https://raw.githubusercontent.com/frandallfarmer/neohabitat-doc/master/docs/images/neohabitat_splash.png
   - https://raw.githubusercontent.com/frandallfarmer/neohabitat-doc/master/docs/images/launcher_login.png

--- a/pushserver/config.vagrant.yml
+++ b/pushserver/config.vagrant.yml
@@ -6,6 +6,8 @@ websocketProxy:
   listenAddr: 0.0.0.0:1987
   remoteAddr: neohabitatqlink:1986
 
+bridgeAdminAddr: neohabitatqlink:2027
+
 backgroundImages:
   - https://raw.githubusercontent.com/frandallfarmer/neohabitat-doc/master/docs/images/neohabitat_splash.png
   - https://raw.githubusercontent.com/frandallfarmer/neohabitat-doc/master/docs/images/launcher_login.png

--- a/pushserver/routes/status.js
+++ b/pushserver/routes/status.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const http = require('http');
+
+class StatusRoutes {
+  constructor(config) {
+    this.config = config;
+    this.router = express.Router();
+    this.setRoutes();
+  }
+
+  fetchBridgeLogs(level, callback) {
+    const adminAddr = this.config.bridgeAdminAddr;
+    if (!adminAddr) {
+      return callback(null, []);
+    }
+    const [host, port] = adminAddr.split(':');
+    const options = {
+      hostname: host,
+      port: parseInt(port, 10),
+      path: '/logs' + (level ? '?level=' + encodeURIComponent(level) : ''),
+      method: 'GET',
+      timeout: 3000,
+    };
+    const req = http.request(options, (res) => {
+      let body = '';
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', () => {
+        try {
+          callback(null, JSON.parse(body));
+        } catch (e) {
+          callback(e, []);
+        }
+      });
+    });
+    req.on('error', (e) => callback(e, []));
+    req.on('timeout', () => { req.destroy(); callback(new Error('timeout'), []); });
+    req.end();
+  }
+
+  setRoutes() {
+    const self = this;
+    this.router.get('/', function(req, res) {
+      const level = 'level' in req.query ? req.query.level : 'error';
+      self.fetchBridgeLogs(level, function(err, entries) {
+        res.render('status', {
+          title: 'Server Status',
+          level: level,
+          entries: entries,
+          bridgeUnavailable: !!err,
+        });
+      });
+    });
+  }
+}
+
+module.exports = StatusRoutes;

--- a/pushserver/views/status.ejs
+++ b/pushserver/views/status.ejs
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title><%= title %></title>
+  <style>
+    body { font-family: monospace; background: #111; color: #ccc; margin: 2em; }
+    h1 { color: #eee; font-size: 1.2em; margin-bottom: 0.5em; }
+    .controls { margin-bottom: 1em; }
+    select, button { background: #222; color: #ccc; border: 1px solid #444; padding: 2px 6px; font-family: monospace; cursor: pointer; }
+    .unavailable { color: #f66; }
+    .empty { color: #666; font-style: italic; }
+    table { border-collapse: collapse; width: 100%; }
+    th { text-align: left; color: #888; font-size: 0.85em; padding: 4px 8px; border-bottom: 1px solid #333; }
+    td { padding: 4px 8px; vertical-align: top; border-bottom: 1px solid #222; font-size: 0.9em; }
+    .level-error { color: #ff3333; }
+    .level-warn  { color: #fa8; }
+    .fields { color: #888; font-size: 0.85em; }
+  </style>
+</head>
+<body>
+  <h1>NeoHabitat Server Status</h1>
+
+  <div class="controls">
+    <form method="get" action="/status">
+      <select name="level" onchange="this.form.submit()">
+        <option value="error"<% if (level === 'error') { %> selected<% } %>>errors</option>
+        <option value="warn"<% if (level === 'warn') { %> selected<% } %>>warnings</option>
+        <option value=""<% if (level === '') { %> selected<% } %>>all</option>
+      </select>
+      &nbsp;(last 20)
+      &nbsp;<button type="submit">reload</button>
+    </form>
+  </div>
+
+  <% if (bridgeUnavailable) { %>
+    <p class="unavailable">Bridge unavailable.</p>
+  <% } else if (entries.length === 0) { %>
+    <p class="empty">No <%= level || 'log' %> entries.</p>
+  <% } else { %>
+    <table>
+      <tr><th>time</th><th>level</th><th>message</th><th>fields</th></tr>
+      <% entries.forEach(function(e) { %>
+      <tr>
+        <td class="fields"><%= e.time ? e.time.replace('T',' ').replace('Z','') : '' %></td>
+        <td class="level-<%= e.level %>"><%= e.level %></td>
+        <td><%= e.message %></td>
+        <td class="fields"><%= e.fields ? JSON.stringify(e.fields) : '' %></td>
+      </tr>
+      <% }); %>
+    </table>
+  <% } %>
+</body>
+</html>


### PR DESCRIPTION
Closes #485

## Summary

- **bridge_v2**: in-memory ring buffer (`RingLog`) captures last 20 error/warn log entries; new `--admin.listen` flag exposes them via `GET /logs` on a local HTTP admin server (default port 2027)
- **pushserver**: new `/status` route fetches from bridge's admin endpoint and renders a minimal dark monospace page with timestamp, level (color-coded), message, and fields columns; level dropdown filters error/warn/all; reload button

## Screenshot

![NeoHabitat Server Status page](https://github.com/frandallfarmer/neohabitat/assets/placeholder/status.png)

## Notes

- Page is intentionally link-free ("you need to know to know")
- Ring buffer is in-memory; clears on bridge_v2 restart (acceptable — prod restarts are rare via graceful SIGHUP upgrade)
- `bridgeAdminAddr` added to all three config files (dev/prod/vagrant)
- Ansible `bridge_host` role and `.air.toml` updated to pass `--admin.listen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)