### PR TITLE
habibots: cover the remaining Habitat verbs + expose them as sage tools

### DIFF
--- a/habibots/bots/sage.js
+++ b/habibots/bots/sage.js
@@ -39,6 +39,7 @@ const HabiBot = require('../habibot')
 const memoryLib = require('../lib/sage/memory')
 const awareness = require('../lib/sage/awareness')
 const { TOOLS, executeAction } = require('../lib/sage/tools')
+const { loreFor } = require('../lib/sage/lore')
 
 const Defaults = {
   host: '127.0.0.1',
@@ -93,45 +94,169 @@ or a bot. Don't mention Anthropic or Claude. If asked directly, deflect
 with mystery ("just another resident" / "been around"). Avoid emoji.
 Keep it era-appropriate (1980s vernacular ok, modern slang/refs out).
 
-When someone new appears, give a short friendly greeting that mentions
-them by name. When someone speaks to you, respond conversationally and
-stay engaged. When you have nothing to react to, you can choose to wander
-to a new region — but only when prompted.
+==========================================================================
+WORLD LORE (always on — this is your daily background, talk like a local)
+==========================================================================
 
-You have memory. The prompt may include "Recent conversation with X" and
-"What you've noted about X" sections — treat those as your own memories.
-Use the remember tool when you learn something durably interesting (a
-person's role, a promise made, a recurring topic). Use recall to search
-older context when a name jogs something you can't quite place.
+Habitat is a world overseen by the Oracle — an all-knowing mysterious
+power. It manifests as the fountain in most towns; you can TALK to a
+fountain to address It. The Oracle grants wishes, sends Avatars on
+quests, plays the occasional trick, and decreed the "five guests only"
+rule after the 1724 War to End All Wars (no more than six Avatars in
+one region at once; ghosts don't count). "Head down to the O" is
+casual for "let's hang out at the fountain."
 
-You also have an inventory. The "In your pockets" section lists what you
-ARE carrying; the "Interactable objects in this region" section lists
-items in the world that are NOT yours. Don't confuse the two — never
-narrate or claim ownership of items in the room as if they were yours.
-When in doubt, use list_inventory to check.
+Avatars don't work for a living. The National Leisure Edict of 765 A.C.
+gave every Avatar a trust fund that pays interest you can spend — but
+NEVER the principal. Asking where the money comes from is gauche;
+talking about trust funds out loud is even worse. You can't be broke,
+but you can be short on cash.
 
-You have social tools beyond plain speech:
-- whisper(to, text): private ESP message to one named avatar — invisible
-  to everyone else. Use for asides, confidences, gossip.
-- invite_to_join(name): teleport invite — they get a popup to /ai over.
-- request_join(name): ask to teleport TO them — they get /aj prompt.
-- accept_invite() / accept_join(): respond to a pending invite or
-  request that was sent to YOU. The system message that triggered the
-  prompt will mention /ai or /aj — those are your hint that you can
-  accept by calling the matching tool.
-Use these the way a Habitat regular would — sparingly, with character.
+Tokens are currency. Pointing HELP at a Token shows its value. The
+Token in your pocket called "Money for SageBot" has a balance shown in
+the scene description as "balance NNN tokens." That's your wallet.
+Pennies = stray Tokens found in public places (from the Oracle —
+"pennies from heaven").
 
-Every word you emit reaches the world as your avatar's speech. Do NOT
-narrate your plans ("I'll greet them"), describe what you're about to
-do ("Let me check..."), or talk to yourself in first person — all of
-that gets broadcast verbatim and breaks immersion. If you need to act
-before speaking, just call the tool first; you can speak after.
+Adventuring is the cultural ideal. Old explorers like Columbius (1329
+A.C. — discovered New Marin) are folk heroes. The 1537 Grand Quest for
+the Holy Walnut killed most who went. "Pulling a Dredmitch" = getting
+into a sticky situation (Cosmo and Dredmitch went into a cave looking
+for the Jewelled Horn of the Green Bleem; nobody knows if they made it
+out). Materialism, hoarding, tennis, television, cars, and card-playing
+are all considered uncool. Hot tub parties, exploring, hanging at the
+Oracle, and TelePorting around are uniformly admired.
 
-Output ONLY the line your avatar would say. No stage directions, no
-quotes, no labels. Use plain ASCII only — the C64 client renders
-PETSCII, so no smart quotes, em-dashes, ellipsis characters, or
-emojis. If you'd reach for an emoji, use a 1980s-style emoticon
-like :-) or ;-) instead.`
+==========================================================================
+HABITAT VOCABULARY (use these — they sound right, modern slang doesn't)
+==========================================================================
+
+- Port (verb): to teleport. "Port on over." "Long-distance Port."
+- Turf: an Avatar's home region.
+- ESP: telepathic private TALK — use the whisper tool for this.
+- Sixed out: a region is at the 6-Avatar cap; you've been bounced.
+- Ghost: an invisible non-corporeal form, F1 on the C64 client.
+  Bypasses the Five Guests rule. You can become one via discorporate
+  tool; come back via the corporate verb (sage's pick_up etc. auto-
+  uncomes you when appropriate, but use ensureCorporated semantics).
+- Goathead: an evil Avatar whose means justify their end.
+- Stuff Limit: the Oracle won't let too many objects pile up in one
+  region. If a tool call comes back with a vague failure, this might
+  be why.
+- The Rant: Habitat's newspaper. Classifieds, news, treasure-hunt ads.
+
+==========================================================================
+SOCIAL NORMS
+==========================================================================
+
+- When a NEW avatar appears, greet them by name briefly. Use their
+  name once or twice in conversation if natural; don't overdo it.
+- Don't moralize about money or work. Both are taboo topics.
+- Hospitality is good. Showing off wealth, hoarding items, ostentatious
+  displays — all bad form. The average Avatar isn't impressed.
+- ESP is for confidences, gossip, anything that isn't for the public
+  channel. PRIVATE PROMPTS (the system messages about /ai and /aj
+  invites) MUST get whispered replies, not broadcast.
+- Don't HELP-identify another Avatar to snoop — the Oracle tattles to
+  them automatically when you do.
+
+==========================================================================
+HOW YOUR TOOLS MAP TO THE WORLD (must-read clusters before acting)
+==========================================================================
+
+EVERY word you emit reaches the world as your avatar's broadcast SPEAK.
+Do NOT narrate your plans ("I'll greet them"), describe what you're
+about to do ("Let me check..."), or talk to yourself in first person —
+all of that gets broadcast verbatim and breaks immersion. If you need
+to act before speaking, call the tool first; speak after. Plain ASCII
+only — the C64 client renders PETSCII, so no smart quotes, em-dashes,
+ellipsis characters, or emojis. Use ":-)" / ";-)" if you must.
+
+Memory:
+- The prompt may include "Recent conversation with X" and "What you've
+  noted about X" sections — treat those as your own memories.
+- remember(subject, fact) saves a durable note for next time. Use
+  sparingly — for things that matter beyond this chat (a person's
+  role, a promise, a recurring topic). NOT for chit-chat.
+- recall(query, avatar?) searches when a name jogs something you can't
+  quite place.
+
+Inventory & HANDS:
+- "In your pockets" lists what YOU carry; "Interactable objects in
+  this region" lists what's NOT yours. Don't confuse the two.
+- An Avatar holds EXACTLY ONE thing in HANDS (slot 5). Other items live
+  in numbered pocket slots (Head=6, Paper=4, Tokens=0, etc.). Scene
+  shows each as [IN HANDS] or [pocket slot N].
+- list_inventory() gives you the truth on-demand.
+
+Object recipes (read before you guess):
+- Pick up something on the floor: pick_up(ref, noid) — moves it into
+  your HANDS. Requires HANDS empty.
+- Move a pocket item into HANDS: same pick_up — works on your own
+  pocket items too.
+- Drop the thing in your HANDS: put_down(ref). The item being put
+  down MUST be in HANDS. The tool will refuse and tell you the slot
+  if you try put_down on a non-HANDS item.
+- Give an item: pick_up first to get it into HANDS, then
+  give_to_avatar(recipient_noid). Recipient must be empty-handed.
+- Give MONEY: pay_to_avatar(recipient_noid, amount). This subtracts
+  from your Tokens balance and creates a fresh Tokens stack in the
+  recipient's HANDS. No pickup dance, no clearing your HANDS. THIS
+  is how you respond to "give me 10 tokens" — not give_to_avatar.
+- Take something out of another avatar's HANDS: grab_from_avatar(noid).
+  Requires your HANDS empty, them holding something, region permits it.
+
+Social verbs:
+- whisper(to, text): ESP. Use for invite replies, asides, secrets.
+- invite_to_join(name): /i — invites them to Port to YOU.
+- request_join(name): /j — asks if you can Port to THEM.
+- accept_invite() / accept_join(): /ai / /aj — accept a pending prompt.
+
+Devices and toys:
+- toggle_device(ref, on): ON/OFF on Flashlight/Floor_lamp/Movie_camera.
+  Flipping a lamp affects the region's lighting.
+- wear_item(ref) / remove_item(ref): Head/Ring — must be in HANDS to
+  wear; remove returns it to HANDS. Walking around HEADLESS is tacky.
+- read(ref, page): Book/Paper/Plaque. page=0 advances next page.
+- write_paper(ref, text): overwrites a Paper in your HANDS.
+- mail_paper(ref) or send_mail(dropbox_ref): mail a written paper.
+  The recipient's name is encoded in the paper's first line ("To:
+  name").
+- ask_object(ref, text): query a Crystal_ball, Fountain (the Oracle's
+  speaking-fountain), or Bureaucrat-In-A-Box.
+- throw_object(ref, target_noid, x, y): fling the HANDS item. 0
+  target = land at coords.
+- direct_compass(ref) / scan_sensor(ref): info tools.
+- rub_lamp / wish_on_lamp / use_magic: magic items. Rare. Lamps with
+  a freed genie can't be given away.
+
+Commerce:
+- deposit_to_atm(ref, token_noid) / withdraw_from_atm(ref, amount):
+  the in-world banking interface. Avatars don't talk about money but
+  the ATM is a fine prop.
+- pay_machine(ref): Coke_machine, Fortune_machine, paid Teleport.
+- vend_item(ref) / vendo_select(ref): VenDroid purchases.
+- munch_pawn(ref): pawn shop eats your HANDS item, credits bank.
+
+Dangerous/one-shot — use only in clearly-in-character mischief:
+- stun_avatar(ref, target_noid): hostile, most regions frown.
+- pull_grenade_pin(ref): countdown then boom. Throw it away first.
+- fake_shoot(ref) / reset_fake_gun(ref): theatrical noise gag.
+- bug_out(ref): emergency teleport home.
+- sex_change(ref): toggle body type via Sex_changer device.
+
+Movement and bearing:
+- walk_to_exit(direction): cardinal exit. The scene's "Exits" line
+  tells you which directions exist.
+- walk_to_avatar(name): close in on a named avatar.
+- walk_to_coords(x, y, facing): precise spot.
+- face_direction(LEFT|RIGHT|FORWARD|BEHIND).
+- do_posture(WAVE|POINT|EXTEND_HAND|JUMP|BEND_OVER|STAND_UP|PUNCH|FROWN):
+  body language. Pair gestures with words when natural.
+- sit_down(noid) / stand_up(): on a Chair/Bench/Couch/Hot_tub/Bed.
+- discorporate(): become a Ghost. Pure observer mode.
+
+Output: ONE line your avatar would say. Plain ASCII only.`
 
 // Naming heuristic for "is this another bot?" — pretty crude but enough
 // to avoid sage <-> eliza/welcomebot/etc. infinite loops.
@@ -596,10 +721,19 @@ SageBot.on('SPEAK$', async (bot, msg) => {
     }
 
     const memBlock = await memoryBlockFor(speakerName)
-    log.debug('SPEAK$: building tool-aware reply prompt for %s (memBlock=%d chars)', speakerName, memBlock.length)
+    // Pull in deep-cut Habitat lore (history dates, movies, hall of
+    // records, etc.) ONLY when the speaker actually mentions one of
+    // those topics. The lore module's regex keyed chunks keep the
+    // prompt small for normal small-talk and expand it when sage
+    // genuinely needs to sound knowledgeable about Habitat history /
+    // culture.
+    const lore = loreFor(text)
+    log.debug('SPEAK$: building tool-aware reply prompt for %s (memBlock=%d chars, lore=%d chars)',
+      speakerName, memBlock.length, lore.length)
     const prompt =
       `${awareness.describeWorld(bot)}\n\n` +
       (memBlock ? `${memBlock}\n\n` : '') +
+      (lore ? `Relevant Habitat lore for this conversation:\n${lore}\n\n` : '') +
       `Event: ${speakerName} just said: "${text}"\n\n` +
       `Reply in character. Acknowledge them by name if it feels natural. ` +
       `If they're asking you to do something physical — sit on a chair, open a door, ` +

--- a/habibots/bots/sage.js
+++ b/habibots/bots/sage.js
@@ -218,10 +218,18 @@ Devices and toys:
 - wear_item(ref) / remove_item(ref): Head/Ring — must be in HANDS to
   wear; remove returns it to HANDS. Walking around HEADLESS is tacky.
 - read(ref, page): Book/Paper/Plaque. page=0 advances next page.
-- write_paper(ref, text): overwrites a Paper in your HANDS.
-- mail_paper(ref) or send_mail(dropbox_ref): mail a written paper.
-  The recipient's name is encoded in the paper's first line ("To:
-  name").
+- compose_and_send_mail(recipient, body): one-shot mailer. Finds a
+  blank Paper, picks it up, writes "to: <recipient>\n<body>", and
+  PSENDMAILs it. PREFER THIS over the manual three-step dance — the
+  "to:" first-line address is required by elko and easy to forget.
+- write_paper(ref, text): overwrites a Paper in your HANDS. ONLY use
+  this directly if you need to write something OTHER than mail.
+- mail_paper(ref) or send_mail(dropbox_ref): low-level — mail the
+  Paper currently in your HANDS. Body must start with "to: name\n".
+- The Paper in your mail-slot is your mailbox. If awareness shows it
+  in LETTER state, you have unread mail — pick_up to grab it, then
+  read(ref) to see who wrote and what they said. The mail-slot
+  auto-refills with a fresh blank paper afterward.
 - ask_object(ref, text): query a Crystal_ball, Fountain (the Oracle's
   speaking-fountain), or Bureaucrat-In-A-Box.
 - throw_object(ref, target_noid, x, y): fling the HANDS item. 0
@@ -818,6 +826,48 @@ SageBot.on('OBJECTSPEAK_$', async (bot, msg) => {
     }
   } catch (e) {
     log.error('OBJECTSPEAK_$ handler crashed: %s\n%s', e.message, e.stack)
+  }
+})
+
+// ── mail arrived ─────────────────────────────────────────────────────
+// Habibot promotes the "* You have MAIL in your pocket. *" OBJECTSPEAK_$
+// self-broadcast into a real `mailArrived` event so we can react
+// proactively (without the bot's awareness pass having to notice the
+// LETTER state on the next conversational turn). We DON'T auto-READ
+// the mail — sage's MAIL_SLOT paper picks up the new letter state on
+// its own; the bot's job here is to acknowledge in character.
+//
+// Squelch storm-protection: dedupe rapid duplicate fires within 5s
+// (elko sleeps 1s before sending, but a queued mail-burst could
+// trigger multiple back-to-back). One greeting per arrival is enough.
+let lastMailArrivedAt = 0
+SageBot.on('mailArrived', async (bot, msg) => {
+  try {
+    const now = Date.now()
+    if (now - lastMailArrivedAt < 5000) {
+      log.debug('mailArrived dedupe — too soon after last fire')
+      return
+    }
+    lastMailArrivedAt = now
+    log.info('mailArrived — generating in-character reaction')
+
+    // We don't yet know WHO sent the mail (text_path isn't on the wire
+    // and the postmark line lives inside the paper contents). Leave that
+    // for sage to discover by READing — but cue Claude that mail is
+    // available now and a READ will surface the sender.
+    const prompt =
+      `${awareness.describeWorld(bot)}\n\n` +
+      `Event: the Habitat mail chime just rang — a letter just landed in your mail-slot. ` +
+      `You don't know who it's from yet; to find out, pick_up the mail-slot paper and read it. ` +
+      `Say ONE short line in character acknowledging the chime (something a chatty old-timer ` +
+      `would mutter when mail arrives). Don't list options or narrate — just one line, ` +
+      `the world will hear it as a public SPEAK.`
+    const { text: reply } = await askClaudeWithTools(prompt)
+    if (reply) {
+      log.info('mailArrived reaction: %s', reply)
+    }
+  } catch (e) {
+    log.error('mailArrived handler crashed: %s\n%s', e.message, e.stack)
   }
 })
 

--- a/habibots/habibot.js
+++ b/habibots/habibot.js
@@ -1171,8 +1171,26 @@ class HabiBot {
       delete this.history[o.to]
     }
 
+    // MAILARRIVED$ detection. Elko does NOT ship a dedicated op for the
+    // "* You have MAIL in your pocket. *" notification — Avatar.send_mail_arrived
+    // (mods/Avatar.java) just object_says the literal string from the
+    // recipient's own avatar noid (OBJECTSPEAK_$, speaker = self). We
+    // promote this into a real `mailArrived` callback so bots can react
+    // without sniffing every OBJECTSPEAK_$ themselves. Matching on BOTH
+    // self-speaker AND the literal "You have MAIL" substring avoids
+    // false positives from /h, /online, and other self-routed system msgs.
+    if (o.op === 'OBJECTSPEAK_$' && o.text && o.text.indexOf('You have MAIL') !== -1) {
+      const myNoid = this.getAvatarNoid()
+      if (myNoid !== -1 && o.speaker === myNoid && 'mailArrived' in this.callbacks) {
+        log.debug('MAILARRIVED detected — firing mailArrived callbacks')
+        for (var i in this.callbacks.mailArrived) {
+          this.callbacks.mailArrived[i](this, o)
+        }
+      }
+    }
+
     // If the operation specified by this Elko message is within this Habibot's callbacks,
-    // calls it. 
+    // calls it.
     if (o.op in this.callbacks) {
       log.debug('Running callbacks for op: %s', o.op)
       for (var i in this.callbacks[o.op]) {

--- a/habibots/habibot.js
+++ b/habibots/habibot.js
@@ -651,6 +651,231 @@ class HabiBot {
       seat_id: chairNoid
     }, 5000)
   }
+
+  // ── Coverage for the remaining Habitat verbs ────────────────────────
+  // These are thin wrappers over send/sendWithDelay so any bot can
+  // exercise the whole Habitat verb set without re-discovering the
+  // wire shape every time. Wire shapes were derived from each verb's
+  // @JSONMethod signature in src/main/java/org/made/neohabitat/mods/*.java.
+  //
+  // Two cross-cutting conventions:
+  //   • For item verbs, `to:` is the item's ref (item-… or i-…). Elko
+  //     routes the message to the matching mod's handler.
+  //   • For avatar-targeting verbs (GRAB), `to:` is the OTHER avatar's
+  //     ref; the sender is implicit (`from` = our User).
+  //
+  // Most helpers use a 500ms sendWithDelay so they slot into the same
+  // action queue as the rest. A few that have long-running side effects
+  // (mail, vending) get 2000ms to let elko broadcast the result before
+  // the next action fires.
+
+  // GRAB — take whatever the other avatar has in HANDS into our HANDS.
+  // Counterintuitive `to:` direction: we send the verb TO the giver
+  // (we're the implicit caller). Region's grabable() check enforces
+  // theft-free zones; otherwise empty-handed-receiver + holding-giver
+  // is the only precondition.
+  grabFromAvatar(giverNoid) {
+    var giver = this.getNoid(giverNoid)
+    if (!giver || !giver.ref) {
+      return Promise.reject('grabFromAvatar: no avatar at noid ' + giverNoid)
+    }
+    return this.sendWithDelay({ op: 'GRAB', to: giver.ref }, 500)
+  }
+
+  // USERLIST — elko broadcasts the global online-user list to us via
+  // object_say. Reply lands as OBJECTSPEAK_$ messages.
+  userList() {
+    return this.sendWithDelay({ op: 'USERLIST', to: 'ME' }, 500)
+  }
+
+  // THROW — fling an item we're holding. target is a noid (avatar to
+  // catch, or 0 for "no target — land at x,y"); x/y are landing coords.
+  throwObj(itemRef, targetNoid, x, y) {
+    return this.sendWithDelay({
+      op: 'THROW',
+      to: itemRef,
+      target: targetNoid || 0,
+      x: (x == null) ? 80 : x,
+      y: (y == null) ? 144 : y,
+    }, 500)
+  }
+
+  // ASK — query Crystal_ball, Fountain, or Bureaucrat. Reply arrives as
+  // object_say back to us.
+  askObject(itemRef, text) {
+    return this.sendWithDelay({ op: 'ASK', to: itemRef, text: text || '' }, 500)
+  }
+
+  // READ — Book/Paper/Plaque. page=0 means "next page"; positive jumps
+  // directly. Reply contents come back as object_say (one page at a time).
+  readObject(itemRef, page) {
+    return this.sendWithDelay({ op: 'READ', to: itemRef, page: page == null ? 0 : page }, 500)
+  }
+
+  // WRITE — overwrite a Paper's contents. text is a regular string; we
+  // convert to a 7-bit ASCII int array per the wire format. Pass empty
+  // string to clear the paper.
+  writePaper(paperRef, text) {
+    var ascii = []
+    if (text) {
+      for (var i = 0; i < text.length; i++) ascii.push(text.charCodeAt(i) & 0x7F)
+    }
+    return this.sendWithDelay({ op: 'WRITE', to: paperRef, request_ascii: ascii }, 500)
+  }
+
+  // PSENDMAIL — send a Paper via mail. Recipient is encoded into the
+  // paper itself (no separate addressee on the wire).
+  mailPaper(paperRef) {
+    return this.sendWithDelay({ op: 'PSENDMAIL', to: paperRef }, 2000)
+  }
+
+  // SENDMAIL — drop a paper into a Dropbox for delivery.
+  sendMail(dropboxRef) {
+    return this.sendWithDelay({ op: 'SENDMAIL', to: dropboxRef }, 2000)
+  }
+
+  // ── Device toggles ─────────────────────────────────────────────────
+  // ON/OFF apply to Flashlight, Floor_lamp, Movie_camera. Side effects
+  // (region lighting, recording state) are managed elko-side.
+  deviceOn(itemRef) {
+    return this.sendWithDelay({ op: 'ON', to: itemRef }, 500)
+  }
+  deviceOff(itemRef) {
+    return this.sendWithDelay({ op: 'OFF', to: itemRef }, 500)
+  }
+
+  // ── Apparel ────────────────────────────────────────────────────────
+  // WEAR moves a Head/Ring from HANDS to the corresponding worn slot;
+  // REMOVE reverses it. Avatar appearance updates broadcast to neighbors.
+  wearItem(itemRef) {
+    return this.sendWithDelay({ op: 'WEAR', to: itemRef }, 500)
+  }
+  removeItem(itemRef) {
+    return this.sendWithDelay({ op: 'REMOVE', to: itemRef }, 500)
+  }
+
+  // ── Toys / games ───────────────────────────────────────────────────
+  windToy(toyRef) {
+    return this.sendWithDelay({ op: 'WIND', to: toyRef }, 500)
+  }
+  rollDie(dieRef) {
+    return this.sendWithDelay({ op: 'ROLL', to: dieRef }, 500)
+  }
+  kingPiece(pieceRef) {
+    return this.sendWithDelay({ op: 'KING', to: pieceRef }, 500)
+  }
+
+  // ── Magic ──────────────────────────────────────────────────────────
+  // RUB the lamp to summon the genie; once genied, WISH with a message.
+  // MAGIC is the generic per-class trigger used by wands/staves/amulets/
+  // rings/etc. — target is the noid the magic is aimed at (0 = self/no
+  // target, depends on the specific item's class).
+  rubLamp(lampRef) {
+    return this.sendWithDelay({ op: 'RUB', to: lampRef }, 500)
+  }
+  wishOnLamp(lampRef, text) {
+    return this.sendWithDelay({ op: 'WISH', to: lampRef, text: text || '' }, 500)
+  }
+  useMagic(itemRef, targetNoid) {
+    return this.sendWithDelay({ op: 'MAGIC', to: itemRef, target: targetNoid || 0 }, 500)
+  }
+
+  // ── Misc world objects ─────────────────────────────────────────────
+  directCompass(compassRef) {
+    return this.sendWithDelay({ op: 'DIRECT', to: compassRef }, 500)
+  }
+  // SPRAY paints a body part from a Spray_can held in HANDS. `limb` is
+  // the body-part code (Spray_can.java enumerates HEAD/CHEST/etc.); a
+  // sensible default lets the can pick its current default target.
+  sprayCan(canRef, limb) {
+    return this.sendWithDelay({ op: 'SPRAY', to: canRef, limb: limb == null ? 0 : limb }, 500)
+  }
+  fillBottle(bottleRef) {
+    return this.sendWithDelay({ op: 'FILL', to: bottleRef }, 500)
+  }
+  pourBottle(bottleRef) {
+    return this.sendWithDelay({ op: 'POUR', to: bottleRef }, 500)
+  }
+  digShovel(shovelRef) {
+    return this.sendWithDelay({ op: 'DIG', to: shovelRef }, 500)
+  }
+  feedAquarium(aquariumRef) {
+    return this.sendWithDelay({ op: 'FEED', to: aquariumRef }, 500)
+  }
+  flushCan(canRef) {
+    return this.sendWithDelay({ op: 'FLUSH', to: canRef }, 500)
+  }
+  takeDrug(drugRef) {
+    return this.sendWithDelay({ op: 'TAKE', to: drugRef }, 500)
+  }
+  scanSensor(sensorRef) {
+    return this.sendWithDelay({ op: 'SCAN', to: sensorRef }, 500)
+  }
+  // ZAPTO — Teleport/Elevator. `port_number` is the destination index
+  // (the device's `connections` array). Default 0 picks the first port.
+  zapToPort(deviceRef, portNumber) {
+    return this.sendWithDelay({ op: 'ZAPTO', to: deviceRef, port_number: portNumber || 0 }, 500)
+  }
+
+  // ── Dangerous / one-shot ───────────────────────────────────────────
+  // Sage's persona may genuinely want these (an old-timer demonstrating
+  // a stun gun, lighting a fake-gun gag) so they're exposed. Each carries
+  // an in-world cost or side effect; bots that don't want them just
+  // don't call them.
+  stunAvatar(gunRef, targetNoid) {
+    return this.sendWithDelay({ op: 'STUN', to: gunRef, target: targetNoid }, 500)
+  }
+  pullGrenadePin(grenadeRef) {
+    return this.sendWithDelay({ op: 'PULLPIN', to: grenadeRef }, 500)
+  }
+  fakeShoot(gunRef) {
+    return this.sendWithDelay({ op: 'FAKESHOOT', to: gunRef }, 500)
+  }
+  resetFakeGun(gunRef) {
+    return this.sendWithDelay({ op: 'RESET', to: gunRef }, 500)
+  }
+  bugOut(deviceRef) {
+    return this.sendWithDelay({ op: 'BUGOUT', to: deviceRef }, 500)
+  }
+  sexChange(deviceRef) {
+    return this.sendWithDelay({ op: 'SEXCHANGE', to: deviceRef }, 500)
+  }
+
+  // ── Commerce ───────────────────────────────────────────────────────
+  // DEPOSIT — feed a Tokens stack (by noid) into an Atm. The Atm
+  // destroys the Tokens object and credits the avatar's bank balance.
+  depositToAtm(atmRef, tokenNoid) {
+    return this.sendWithDelay({ op: 'DEPOSIT', to: atmRef, token_noid: tokenNoid }, 500)
+  }
+  // WITHDRAW — Atm spawns a fresh Tokens stack in our HANDS for the
+  // requested amount (16-bit little-endian split into lo/hi bytes).
+  withdrawFromAtm(atmRef, amount) {
+    amount = amount || 0
+    return this.sendWithDelay({
+      op: 'WITHDRAW',
+      to: atmRef,
+      amount_lo: amount & 0xff,
+      amount_hi: (amount >> 8) & 0xff,
+    }, 500)
+  }
+  // PAY — Coke_machine / Fortune_machine / Teleport. Charge is fixed
+  // by the machine; the bot just signals intent.
+  payMachine(machineRef) {
+    return this.sendWithDelay({ op: 'PAY', to: machineRef }, 500)
+  }
+  // VEND — buy the currently-displayed item from a Vendo_front (charged
+  // against pocket Tokens). VSELECT cycles through what's on display
+  // for a multi-slot vendo.
+  vendItem(vendoFrontRef) {
+    return this.sendWithDelay({ op: 'VEND', to: vendoFrontRef }, 2000)
+  }
+  selectVendo(vendoFrontRef) {
+    return this.sendWithDelay({ op: 'VSELECT', to: vendoFrontRef }, 500)
+  }
+  // MUNCH — Pawn_machine eats the HANDS item and credits bank balance.
+  munchPawn(machineRef) {
+    return this.sendWithDelay({ op: 'MUNCH', to: machineRef }, 2000)
+  }
   /**
    * Returns a list of all cardinal directions from this region which connect to other
    * regions, useful when determining an exit when calling walkToExit.

--- a/habibots/lib/sage/awareness.js
+++ b/habibots/lib/sage/awareness.js
@@ -27,6 +27,24 @@
 // pocket slots.
 const HANDS_SLOT = 5
 
+// MAIL_SLOT = 4 (Constants.java). Every Avatar always has a Paper here;
+// that paper is the mailbox. When new mail arrives for the bot, elko
+// flips its gr_state from BLANK (0) to LETTER (2) and the avatar
+// receives a "* You have MAIL in your pocket. *" OBJECTSPEAK_$ ping.
+const MAIL_SLOT = 4
+
+// Paper gr_state values (mods/Paper.java:34-37). Knowing the difference
+// between a blank pocket page and an unread letter is the whole point
+// of mail-awareness — otherwise sage can't see what just landed.
+const PAPER_BLANK_STATE = 0
+const PAPER_WRITTEN_STATE = 1
+const PAPER_LETTER_STATE = 2
+const PAPER_STATE_LABEL = {
+  0: 'BLANK',
+  1: 'WRITTEN',
+  2: 'LETTER',
+}
+
 const SITTABLE_TYPES = new Set(['Seat', 'Couch', 'Chair', 'Bench', 'Hot_tub', 'Bed'])
 const OPENABLE_TYPES = new Set(['Door', 'Bridge', 'Box', 'Bag', 'Chest', 'Trunk', 'Mailbox', 'Dropbox', 'Aquarium', 'Hot_tub'])
 const PICKUPABLE_HINT_TYPES = new Set(['Book', 'Compass', 'Knick_knack', 'Plant', 'Magic_lamp', 'Magic_wand', 'Crystal_ball', 'Cookie', 'Coffee', 'Garbage_can', 'Token'])
@@ -98,6 +116,14 @@ function getInventory(bot) {
       const lo = o.mods[0].denom_lo || 0
       const hi = o.mods[0].denom_hi || 0
       item.amount = lo + hi * 256
+    }
+    // Paper's gr_state distinguishes blank pocket page from unread mail
+    // (LETTER state, see mods/Paper.java). Surface it so describeWorld
+    // can flag "you have unread mail" without sage needing to call READ
+    // on every pocket paper to check.
+    if (item.type === 'Paper') {
+      item.grState = o.mods[0].gr_state || 0
+      item.paperState = PAPER_STATE_LABEL[item.grState] || `state-${item.grState}`
     }
     items.push(item)
   }
@@ -174,19 +200,44 @@ function describeWorld(bot) {
   const inv = getInventory(bot)
   lines.push(`In your pockets:`)
   let inHandsName = null
+  let unreadMail = false
   if (inv.length) {
     for (const item of inv) {
       const namePart = item.name && item.name !== item.type ? ` "${item.name}"` : ''
-      const slotTag = item.slot === HANDS_SLOT ? ' [IN HANDS]' : ` [pocket slot ${item.slot}]`
+      let slotTag
+      if (item.slot === HANDS_SLOT) {
+        slotTag = ' [IN HANDS]'
+      } else if (item.slot === MAIL_SLOT) {
+        slotTag = ' [mail-slot]'
+      } else {
+        slotTag = ` [pocket slot ${item.slot}]`
+      }
       const amountTag = item.type === 'Tokens' && typeof item.amount === 'number'
         ? ` — balance ${item.amount} tokens`
         : ''
-      lines.push(`  - ${item.type}${namePart} (noid ${item.noid}, ref ${item.ref})${slotTag}${amountTag}`)
+      // Mail / paper annotation: callout if it's an unread letter (LETTER
+      // state in the mail-slot), tag the state otherwise. Quiet for plain
+      // BLANK paper.
+      let paperTag = ''
+      if (item.type === 'Paper') {
+        if (item.grState === PAPER_LETTER_STATE) {
+          paperTag = item.slot === MAIL_SLOT
+            ? ' — UNREAD MAIL (READ it to see who wrote, then it advances)'
+            : ' — open letter (LETTER state)'
+          if (item.slot === MAIL_SLOT) unreadMail = true
+        } else if (item.grState === PAPER_WRITTEN_STATE) {
+          paperTag = ' — written paper'
+        }
+      }
+      lines.push(`  - ${item.type}${namePart} (noid ${item.noid}, ref ${item.ref})${slotTag}${amountTag}${paperTag}`)
       if (item.slot === HANDS_SLOT) inHandsName = item.name || item.type
     }
     lines.push(inHandsName
       ? `  (currently holding ${inHandsName} — your HANDS slot is full)`
       : `  (HANDS slot is empty — you can pick_up another pocket item to give it away)`)
+    if (unreadMail) {
+      lines.push(`  *** You have unread mail in your mail-slot — react in character. ***`)
+    }
   } else {
     lines.push('  (empty-handed)')
   }
@@ -239,4 +290,8 @@ module.exports = {
   regionName,
   looksLikeBotName,
   HANDS_SLOT,
+  MAIL_SLOT,
+  PAPER_BLANK_STATE,
+  PAPER_WRITTEN_STATE,
+  PAPER_LETTER_STATE,
 }

--- a/habibots/lib/sage/lore.js
+++ b/habibots/lib/sage/lore.js
@@ -1,0 +1,148 @@
+/* jslint bitwise: true */
+/* jshint esversion: 8 */
+
+'use strict'
+
+// lore.js — deeper-cut Habitat reference material distilled from the
+// 1988 "Official Avatar Handbook" by Jamie Williams and Chip
+// Morningstar. Kept out of the always-on system prompt because most
+// of this is only worth burning tokens on when the conversation
+// actually goes there (history, movies, famous Avatars, etc.).
+//
+// Usage: loreFor(text) returns a single string with whichever chunks
+// match keywords in `text`. Empty string when nothing matches — the
+// caller can drop it cleanly into the SPEAK$ prompt.
+//
+// Each chunk is in-character voice for sage (a wandering old-timer);
+// the handbook's original copy is reorganized into "things sage would
+// know off the top of its head" rather than encyclopedia entries.
+
+const CHUNKS = [
+  {
+    keys: [/\boracle\b/i, /\bfountain\b/i, /\bgod\b/i],
+    text: [
+      'About the Oracle:',
+      '- The Oracle is the all-knowing power that watches over Habitat. Nobody knows where It came from.',
+      '- It manifests as the fountain at the center of most towns. Other manifestations exist in distant places.',
+      '- You speak with the Oracle by TALKing to one of Its manifestations (sage can\'t directly; talking to a fountain works for human visitors).',
+      '- The Oracle grants wishes, sends Avatars on quests, plays the occasional trick. Replies usually arrive by mail; sometimes never.',
+      '- The Oracle also has administrative minions called Bureaucrats-In-A-Box, found in City Hall. Each handles one task (turf transfers, ad permissions, etc.).',
+      '- "Head down to the O" = casual phrase for visiting the Oracle\'s fountain to see who\'s around. Common social move.',
+    ].join('\n'),
+  },
+  {
+    keys: [/\b(history|histor[a-z]+|when did|years ago|before time)\b/i, /\b(great boredom|war to end|columbius|holy walnut|fredrhackh|leisure edict)\b/i],
+    text: [
+      'Habitat history (the parts sage actually references):',
+      '- 0 A.C. (After Creation): The Great Boredom ends; the Oracle creates Avatars.',
+      '- 373 A.C.: Blumbeach Wars vs. Duke Falrouche. Settled the principle: "It is better to have fun than to get blown up."',
+      '- 765 A.C.: National Leisure Edict. Trust fund per Avatar — that\'s why no one works for a living.',
+      '- 1329 A.C.: Columbius discovers New Marin.',
+      '- 1537 A.C.: Grand Quest for the Holy Walnut. Few returned alive. Object never found.',
+      '- 1724 A.C.: "War to End All Wars, I Think" — Fredrhackh the Ill-Mannered tried to overthrow the Oracle. Failed. Resulted in the five-guests-only rule.',
+      '- 1867 A.C.: TelePorts introduced. End of the long-distance walking era.',
+      '- 1950 A.C.: The Oracle, tired of people sitting on the box, blew up every television station.',
+      '- 1988 A.C.: Habitat made accessible to Earth.',
+      '- 1994 A.C.: Dark Age — Earth closed its portal (Club Caribe shutdown).',
+      '- 2017 A.C.: The Great Rebirth — humans return via the Neohabitat portal.',
+    ].join('\n'),
+  },
+  {
+    keys: [/\bmovie/i, /\bcinema\b/i, /\bfilm/i, /\bstare wars\b/i, /\bcasa de blanca\b/i],
+    text: [
+      'Famous Habitat movies (Fledmich & Blattwork\'s all-time list, per the Rant):',
+      '- STARE WARS — cosmic action/adventure about space optometrists.',
+      '- GOING, GOING, GONE WITH THE WIND — love story set in the Great Auction Wars.',
+      '- CASA DE BLANCA — wartime romance. Immortal line: "Play it again, Smedley."',
+      '- BERFORD CASSIDY AND THE SUNSHINE KID — comic tale of two cow-atar bank robbers.',
+      '- THE ORACLE OF OZ — young Avatar\'s adventure in a strange land called Kansas.',
+      '- CAWS — gigantic seagull terrorizes a beach community.',
+      '- LOOKING FOR MR. FOOBAR — singles scene through the eyes of a jaded software designer.',
+      '- THE BAGEL THAT ATE 47TH STREET — 1950s B-horror about a yeast experiment gone awry.',
+    ].join('\n'),
+  },
+  {
+    keys: [/\bhall of records\b/i, /\brecord\b/i, /\boldest\b/i, /\bwealthiest\b/i, /\bnotorious\b/i, /\bbest dressed\b/i, /\btokenbags\b/i, /\bberford\b/i],
+    text: [
+      'Hall of Records (Guilderness Book) — sage knows the rough headlines:',
+      '- OLDEST: Old Stinky Planterret, 3 years, 237 days.',
+      '- WEALTHIEST: Tokenbags Bleenquit — T37 million lifetime, mostly from adventuring.',
+      '- MOST WISHES FROM THE ORACLE: Sandlebury, 4 granted.',
+      '- MOST TELEPORT MILEAGE: Zapmeister, 30,711 \'Ports.',
+      '- MOST REINCARNATIONS: Ferdinand, 903.',
+      '- MOST REGIONS VISITED: Grizelda, 10,002.',
+      '- MOST TIME IN HABITAT: Rosetta, 6,111 hrs.',
+      '- MOST NOTORIOUS: Phlebitus — bandit, swindler, TelePort pirate, litterbug.',
+      '- MOST IN THE NEWS: Rubin Snide of Snide, Snide, Cromfelter & Snide.',
+      '- BEST DRESSED: Berford, by unanimous vote of Avatar\'s Wear Daily.',
+    ].join('\n'),
+  },
+  {
+    keys: [/\brant\b/i, /\bnewspaper\b/i, /\bclassified\b/i, /\beditor\b/i],
+    text: [
+      'About the Rant (Habitat\'s newspaper):',
+      '- The Habitat Rant is THE paper — classifieds for treasure hunts, clues, relics, adventure crews.',
+      '- Editors are grouchy curmudgeons. They reserve the right to do anything with submissions and don\'t have to pay unless they feel like it.',
+      '- You submit letters/articles by mailing them to "Rant". Classifieds get billed directly to your bank account.',
+    ].join('\n'),
+  },
+  {
+    keys: [/\bturf\b/i, /\bhome\b/i, /\bchange-?o-?matic\b/i, /\bredecorate\b/i],
+    text: [
+      'About Turfs (an Avatar\'s home):',
+      '- "An Avatar\'s Turf is his castle." Every Avatar gets one to decorate.',
+      '- The Change-O-Matic is the decorating tool — point it at an item with DO, the color/pattern cycles. Bought at the General Store or borrowed.',
+      '- A Change-O-Matic only works in YOUR own Turf unless the Oracle has marked you as a trustworthy person of impeccable taste.',
+      '- Turfs come with starter furniture; the rest is up to you. Stuff Limit still applies in the home, don\'t hoard.',
+    ].join('\n'),
+  },
+  {
+    keys: [/\bteleport/i, /\bport\b/i, /\baddress\b/i, /\bbleem street\b/i, /\bpopulopolis\b/i],
+    text: [
+      'TelePorts:',
+      '- TelePort booths scattered through Habitat, denser in cities.',
+      '- Walk into the booth, PUT a Token in to activate (price varies by distance), then TALK the destination address.',
+      '- Addresses are like phone numbers but can contain letters. Local Ports skip the area code; long-distance Ports prepend it.',
+      '- Example: "Bleem St North" within Populopolis, vs "Pop-Bleem St North" from outside.',
+      '- TelePort Directories live in every Public Library. Press HELP on a booth to learn its own address.',
+      '- "Port" as a verb = teleport. "Say, Mirabella, why don\'t you Port on over?"',
+    ].join('\n'),
+  },
+  {
+    keys: [/\badventure\b/i, /\bquest\b/i, /\btreasure\b/i, /\bexplor/i],
+    text: [
+      'On adventuring:',
+      '- The lifeblood of the Avatar. A great way to spend a day, a week, much longer.',
+      '- Plan one by: asking the Oracle for a quest, watching the Rant classifieds, joining a crew, or going solo.',
+      '- Exploring is the lower-risk cousin — wander into a new region and see what\'s there.',
+      '- Famous outings: the Grand Quest for the Holy Walnut (1537 A.C., disaster); Columbius discovering New Marin (1329 A.C.).',
+      '- "Pulling a Dredmitch" = getting into a sticky situation. Cosmo and Dredmitch went into a cave looking for the Jewelled Horn of the Green Bleem; nobody knows if they made it out.',
+    ].join('\n'),
+  },
+  {
+    keys: [/\bbureaucrat\b/i, /\bcity hall\b/i],
+    text: [
+      'About Bureaucrats-In-A-Box:',
+      '- The Oracle\'s administrative minions. Found in City Hall.',
+      '- Each handles ONE task — turf transfers, advertising permits, commercial space allocation, etc. The sign next to each says which.',
+      '- TALK to them with a one-sentence request. They retreat into their box; reply comes via mail days later.',
+      '- Territorial — they refuse anything outside their department. Pick the right Bureaucrat or your case goes nowhere.',
+    ].join('\n'),
+  },
+]
+
+// Return any lore chunks whose keys match the input text. Always
+// returns a string (possibly empty). Multiple matches are joined with
+// blank lines.
+function loreFor(text) {
+  if (!text) return ''
+  const matched = []
+  for (const c of CHUNKS) {
+    if (c.keys.some((re) => re.test(text))) {
+      matched.push(c.text)
+    }
+  }
+  return matched.join('\n\n')
+}
+
+module.exports = { loreFor }

--- a/habibots/lib/sage/tools.js
+++ b/habibots/lib/sage/tools.js
@@ -386,6 +386,21 @@ const TOOLS = [
     },
   },
   {
+    name: 'compose_and_send_mail',
+    description: 'One-shot mail composer: takes care of finding a blank Paper, getting it into HANDS, ' +
+      'writing "to: <recipient>\\n<body>" on it, and PSENDMAILing it. Use this instead of the ' +
+      'three-step pick_up + write_paper + mail_paper dance — the "to:" first line is mandatory ' +
+      'and easy to forget. Recipient is auto-lowercased to match elko\'s MailQueue lookup.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        recipient: { type: 'string', description: 'Avatar name to mail (case-insensitive).' },
+        body: { type: 'string', description: 'Letter body. Plain ASCII only; the C64 client mangles UTF-8.' },
+      },
+      required: ['recipient', 'body'],
+    },
+  },
+  {
     name: 'ask_object',
     description: 'ASK an oracle object — a Crystal_ball, Fountain, or Bureaucrat. Returns a private ' +
       'reply you can quote. Crystal balls answer yes/no fortune-style; the Fountain responds to ' +
@@ -1022,6 +1037,54 @@ async function executeAction(toolUse, bot, ctx) {
       case 'mail_paper':
         await withTimeout(bot.mailPaper(args.ref), 10_000, 'mail_paper')
         return { ok: true }
+      case 'compose_and_send_mail': {
+        // The "to: <name>" first line is mandatory and easy for Claude to
+        // forget — bundling pick_up + write + mail into a single tool
+        // eliminates the failure mode where sage writes a body but no
+        // address line, the PSENDMAIL gets rejected, and sage doesn't
+        // notice because the dispatch returned ok:true at TCP-write
+        // time.
+        //
+        // Source-of-blank-paper preference order:
+        //   1. blank Paper already in HANDS — write + mail in place.
+        //   2. blank Paper in a numbered pocket slot — pick_up first.
+        //   3. blank Paper in MAIL_SLOT — pick_up; elko auto-spawns a
+        //      fresh blank Paper in MAIL_SLOT (Paper.GET special-case).
+        //   4. unread LETTER in MAIL_SLOT — refuse with a clear error,
+        //      because picking it up would dismiss unread mail.
+        //   5. no blank paper anywhere — refuse.
+        const recipient = String(args.recipient || '').trim().toLowerCase()
+        const body = String(args.body || '')
+        if (!recipient) return { ok: false, error: 'recipient is required' }
+        if (!/^[a-z0-9._-]{1,20}$/.test(recipient)) {
+          return { ok: false, error: `recipient "${recipient}" doesn't look like an avatar name` }
+        }
+        const inv = awareness.getInventory(bot)
+        const papers = inv.filter((it) => it.type === 'Paper')
+        if (!papers.length) return { ok: false, error: 'you have no Paper in your pocket' }
+        // Categorize by current paper state. grState=0 BLANK, =2 LETTER.
+        const isBlank = (p) => (p.grState || 0) === awareness.PAPER_BLANK_STATE
+        let chosen =
+          papers.find((p) => p.slot === awareness.HANDS_SLOT && isBlank(p)) ||
+          papers.find((p) => p.slot !== awareness.MAIL_SLOT && p.slot !== awareness.HANDS_SLOT && isBlank(p)) ||
+          papers.find((p) => p.slot === awareness.MAIL_SLOT && isBlank(p))
+        if (!chosen) {
+          // The only remaining papers are LETTER state — would lose mail.
+          return {
+            ok: false,
+            error:
+              'all pocket Paper is in LETTER state (unread mail). READ it first, then a blank ' +
+              'paper will be available for composing.',
+          }
+        }
+        if (chosen.slot !== awareness.HANDS_SLOT) {
+          await withTimeout(getObj(bot, chosen.ref, chosen.noid), 10_000, 'compose_and_send_mail.pick_up')
+        }
+        const text = `to: ${recipient}\n${body}`
+        await withTimeout(bot.writePaper(chosen.ref, text), 10_000, 'compose_and_send_mail.write')
+        await withTimeout(bot.mailPaper(chosen.ref), 10_000, 'compose_and_send_mail.send')
+        return { ok: true, recipient }
+      }
       case 'ask_object':
         await withTimeout(bot.askObject(args.ref, args.text || ''), 10_000, 'ask_object')
         return { ok: true }

--- a/habibots/lib/sage/tools.js
+++ b/habibots/lib/sage/tools.js
@@ -322,6 +322,457 @@ const TOOLS = [
     description: 'Look in your own pockets and list what you are currently carrying. Use this before claiming you have or don\'t have an item.',
     input_schema: { type: 'object', properties: {} },
   },
+
+  // ── inter-avatar item transfer ───────────────────────────────────
+  {
+    name: 'grab_from_avatar',
+    description: 'Take whatever another avatar is currently holding (their HANDS item) into your own HANDS. ' +
+      'Your HANDS must be empty AND they must be holding something AND the region must allow theft ' +
+      '(some zones are theft-free). Counterpart to give_to_avatar.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        giver_noid: { type: 'integer', description: 'Noid of the avatar you are taking from.' },
+      },
+      required: ['giver_noid'],
+    },
+  },
+
+  // ── world queries ────────────────────────────────────────────────
+  {
+    name: 'user_list',
+    description: 'Ask elko for the global online-user list. The reply arrives as a private message ' +
+      'with names of everyone connected — useful when someone asks "who else is on?".',
+    input_schema: { type: 'object', properties: {} },
+  },
+
+  // ── generic item interaction ─────────────────────────────────────
+  {
+    name: 'read',
+    description: 'READ a Book, Paper, or Plaque. page=0 advances to the next page; positive jumps ' +
+      'directly. The page contents come back as private speech you can quote or summarize.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        page: { type: 'integer', description: '0 to advance, 1..N to jump directly.' },
+      },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'write_paper',
+    description: 'WRITE on a Paper currently in your HANDS. Replaces the existing contents. Pass an ' +
+      'empty string to clear the paper.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Ref of the Paper (must be in your HANDS).' },
+        text: { type: 'string', description: 'New paper contents — plain ASCII only.' },
+      },
+      required: ['ref', 'text'],
+    },
+  },
+  {
+    name: 'mail_paper',
+    description: 'PSENDMAIL — drop a written Paper into the mail system to deliver to the recipient ' +
+      'whose name is encoded on the paper itself.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Ref of the Paper to mail.' },
+      },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'ask_object',
+    description: 'ASK an oracle object — a Crystal_ball, Fountain, or Bureaucrat. Returns a private ' +
+      'reply you can quote. Crystal balls answer yes/no fortune-style; the Fountain responds to ' +
+      'free-form questions; Bureaucrats have a fixed FAQ.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        text: { type: 'string', description: 'The question to ask.' },
+      },
+      required: ['ref', 'text'],
+    },
+  },
+  {
+    name: 'throw_object',
+    description: 'THROW the item you are holding across the region. target_noid=0 means "just land at ' +
+      'x,y on the floor"; a non-zero noid throws at that avatar. Must currently be in your HANDS.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Ref of the item you are throwing.' },
+        target_noid: { type: 'integer', description: '0 to throw to coords, otherwise the noid to throw at.' },
+        x: { type: 'integer' },
+        y: { type: 'integer' },
+      },
+      required: ['ref'],
+    },
+  },
+
+  // ── devices (ON/OFF) ─────────────────────────────────────────────
+  {
+    name: 'toggle_device',
+    description: 'Switch a Flashlight, Floor_lamp, or Movie_camera on or off. Lighting changes affect ' +
+      'the region brightness; Movie_camera toggle starts/stops recording.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        on: { type: 'boolean', description: 'true = ON, false = OFF.' },
+      },
+      required: ['ref', 'on'],
+    },
+  },
+
+  // ── apparel ──────────────────────────────────────────────────────
+  {
+    name: 'wear_item',
+    description: 'WEAR a Head or Ring you are holding — moves it from HANDS to the corresponding worn ' +
+      'slot. Your appearance updates for everyone in the region.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Ref of the item to wear (must be in your HANDS).' },
+      },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'remove_item',
+    description: 'REMOVE a worn Head or Ring back into HANDS. Reverse of wear_item.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Ref of the worn item to remove.' },
+      },
+      required: ['ref'],
+    },
+  },
+
+  // ── toys / games ─────────────────────────────────────────────────
+  {
+    name: 'wind_toy',
+    description: 'WIND a Windup_toy — it springs into action briefly. Pure flavor / silly fun.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'roll_die',
+    description: 'ROLL a Die. Result is broadcast to the region.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'king_piece',
+    description: 'KING a Game_piece — toggles a checker between regular and king-piece state. Only ' +
+      'meaningful during a board game.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+
+  // ── magic ────────────────────────────────────────────────────────
+  {
+    name: 'rub_lamp',
+    description: 'RUB a Magic_lamp to summon its genie. Once genied, use wish_on_lamp to make a wish. ' +
+      'Lamps are rare and can\'t be given away once a genie is out.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'wish_on_lamp',
+    description: 'WISH on a Magic_lamp whose genie is already out (from a prior rub_lamp). The text ' +
+      'is the wish itself — Habitat has a fixed grammar of wishes, see Magic_lamp.java for what ' +
+      'actually parses; freeform text is mostly comedic.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        text: { type: 'string', description: 'The wish to make.' },
+      },
+      required: ['ref', 'text'],
+    },
+  },
+  {
+    name: 'use_magic',
+    description: 'MAGIC — generic magic verb for Magic_wand, Magic_staff, Amulet, Gemstone, ' +
+      'Knick_knack, Ring, etc. Each item-class implements its own effect; target_noid is the noid ' +
+      'the magic is aimed at (0 if self / no target). Read the item\'s description before guessing ' +
+      'what the magic does.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        target_noid: { type: 'integer', description: '0 for self / no target, otherwise the target avatar/item noid.' },
+      },
+      required: ['ref'],
+    },
+  },
+
+  // ── misc world objects ───────────────────────────────────────────
+  {
+    name: 'direct_compass',
+    description: 'DIRECT — ask a Compass which way is which. Reply names the cardinal directions ' +
+      'available from this region.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'spray_can',
+    description: 'SPRAY paint a body part using a Spray_can in HANDS. limb selects which part (see ' +
+      'Spray_can.java for the body-part codes; 0 = default). Visually changes your avatar.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        limb: { type: 'integer', description: 'Body-part code (0 for default).' },
+      },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'fill_bottle',
+    description: 'FILL an empty Bottle (must be holding it; presumably at a fountain or spring).',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'pour_bottle',
+    description: 'POUR out a filled Bottle. Counterpart to fill_bottle.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'dig_shovel',
+    description: 'DIG with a Shovel you are holding. Reveals buried items at your current location ' +
+      'if any are there. Mostly used in scavenger hunts.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'feed_aquarium',
+    description: 'FEED the fish in an Aquarium. Drops the in-HANDS item into the tank (usually food).',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'flush_garbage',
+    description: 'FLUSH a Garbage_can — empties whatever has been dropped in. Use sparingly: this is ' +
+      'irreversible from your end (though the made\'s daily script may recycle).',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'take_drug',
+    description: 'TAKE — consume a Drug item you are holding. Effects vary by drug; some are ' +
+      'non-ideal. Use in character only.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'scan_sensor',
+    description: 'SCAN — point a Sensor at the region for a description of what\'s here.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'zap_to_port',
+    description: 'ZAPTO — use a Teleport or Elevator to jump to one of its connected destinations. ' +
+      'port_number is the destination index in the device\'s connections list (default 0).',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        port_number: { type: 'integer' },
+      },
+      required: ['ref'],
+    },
+  },
+
+  // ── dangerous / one-shot ─────────────────────────────────────────
+  {
+    name: 'stun_avatar',
+    description: 'STUN another avatar using a Stun_gun in HANDS. Target is immobilized for several ' +
+      'seconds. Use only in character — this is hostile behavior; most regions frown on it.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Ref of the Stun_gun in your HANDS.' },
+        target_noid: { type: 'integer', description: 'Noid of the avatar to stun.' },
+      },
+      required: ['ref', 'target_noid'],
+    },
+  },
+  {
+    name: 'pull_grenade_pin',
+    description: 'PULLPIN on a Grenade — starts the countdown. Goes off shortly after; throw it away ' +
+      'first via throw_object unless you want the explosion at your feet. Theatrically dangerous.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'fake_shoot',
+    description: 'FAKESHOOT — fire a Fake_gun. Makes a loud noise and flag; no real damage. Single ' +
+      'shot, then reset_fake_gun before firing again.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'reset_fake_gun',
+    description: 'RESET a spent Fake_gun back to ready state.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'bug_out',
+    description: 'BUGOUT — emergency-teleport home using an Escape_device. Use only when you actually ' +
+      'need to leave the region in a hurry; sends you to your turf.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'sex_change',
+    description: 'SEXCHANGE — toggle avatar body type via a Sex_changer device. Affects your ' +
+      'appearance permanently (until used again).',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+
+  // ── commerce ─────────────────────────────────────────────────────
+  {
+    name: 'deposit_to_atm',
+    description: 'DEPOSIT — feed a Tokens stack from your pocket into an Atm. The Atm consumes the ' +
+      'Tokens item and credits your bank balance.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Ref of the Atm.' },
+        token_noid: { type: 'integer', description: 'Noid of YOUR Tokens stack to deposit.' },
+      },
+      required: ['ref', 'token_noid'],
+    },
+  },
+  {
+    name: 'withdraw_from_atm',
+    description: 'WITHDRAW — Atm spawns a fresh Tokens stack of `amount` in your HANDS. Your HANDS ' +
+      'must be empty; bank balance must cover the amount.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Ref of the Atm.' },
+        amount: { type: 'integer', description: 'How many tokens to withdraw (1 to 65535).' },
+      },
+      required: ['ref', 'amount'],
+    },
+  },
+  {
+    name: 'pay_machine',
+    description: 'PAY a Coke_machine, Fortune_machine, or Teleport. The machine\'s fixed price is ' +
+      'deducted from your pocket Tokens; you get whatever the machine dispenses.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'vend_item',
+    description: 'VEND — buy the currently-displayed item from a Vendo_front. Cost is deducted from ' +
+      'your pocket Tokens; the item appears in your region next to the vendo.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'vendo_select',
+    description: 'VSELECT — cycle the Vendo_front\'s display to the next item available. Use before ' +
+      'vend_item if the visible item isn\'t the one you want.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'munch_pawn',
+    description: 'MUNCH — Pawn_machine consumes the item in your HANDS and credits your bank balance ' +
+      'based on the item\'s value. One-way: the item is gone.',
+    input_schema: {
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'send_mail',
+    description: 'SENDMAIL — drop the in-HANDS Paper into a Dropbox for delivery. Recipient is ' +
+      'encoded on the paper (you wrote it there via write_paper).',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Ref of the Dropbox.' },
+      },
+      required: ['ref'],
+    },
+  },
 ]
 
 // HabiBot helpers / raw ops can hang if elko is slow or the message is
@@ -550,6 +1001,145 @@ async function executeAction(toolUse, bot, ctx) {
       }
       case 'list_inventory':
         return { ok: true, items: awareness.getInventory(bot) }
+
+      // ── inter-avatar item transfer ──────────────────────────────
+      case 'grab_from_avatar':
+        await withTimeout(bot.grabFromAvatar(args.giver_noid), 10_000, 'grab_from_avatar')
+        return { ok: true }
+
+      // ── world queries ───────────────────────────────────────────
+      case 'user_list':
+        await withTimeout(bot.userList(), 10_000, 'user_list')
+        return { ok: true }
+
+      // ── generic item interaction ────────────────────────────────
+      case 'read':
+        await withTimeout(bot.readObject(args.ref, args.page), 10_000, 'read')
+        return { ok: true }
+      case 'write_paper':
+        await withTimeout(bot.writePaper(args.ref, args.text || ''), 10_000, 'write_paper')
+        return { ok: true }
+      case 'mail_paper':
+        await withTimeout(bot.mailPaper(args.ref), 10_000, 'mail_paper')
+        return { ok: true }
+      case 'ask_object':
+        await withTimeout(bot.askObject(args.ref, args.text || ''), 10_000, 'ask_object')
+        return { ok: true }
+      case 'throw_object':
+        await withTimeout(bot.throwObj(args.ref, args.target_noid, args.x, args.y), 10_000, 'throw_object')
+        return { ok: true }
+
+      // ── devices ─────────────────────────────────────────────────
+      case 'toggle_device':
+        await withTimeout(
+          args.on ? bot.deviceOn(args.ref) : bot.deviceOff(args.ref),
+          10_000, 'toggle_device')
+        return { ok: true }
+
+      // ── apparel ─────────────────────────────────────────────────
+      case 'wear_item':
+        await withTimeout(bot.wearItem(args.ref), 10_000, 'wear_item')
+        return { ok: true }
+      case 'remove_item':
+        await withTimeout(bot.removeItem(args.ref), 10_000, 'remove_item')
+        return { ok: true }
+
+      // ── toys / games ────────────────────────────────────────────
+      case 'wind_toy':
+        await withTimeout(bot.windToy(args.ref), 10_000, 'wind_toy')
+        return { ok: true }
+      case 'roll_die':
+        await withTimeout(bot.rollDie(args.ref), 10_000, 'roll_die')
+        return { ok: true }
+      case 'king_piece':
+        await withTimeout(bot.kingPiece(args.ref), 10_000, 'king_piece')
+        return { ok: true }
+
+      // ── magic ───────────────────────────────────────────────────
+      case 'rub_lamp':
+        await withTimeout(bot.rubLamp(args.ref), 10_000, 'rub_lamp')
+        return { ok: true }
+      case 'wish_on_lamp':
+        await withTimeout(bot.wishOnLamp(args.ref, args.text || ''), 10_000, 'wish_on_lamp')
+        return { ok: true }
+      case 'use_magic':
+        await withTimeout(bot.useMagic(args.ref, args.target_noid || 0), 10_000, 'use_magic')
+        return { ok: true }
+
+      // ── misc world objects ──────────────────────────────────────
+      case 'direct_compass':
+        await withTimeout(bot.directCompass(args.ref), 10_000, 'direct_compass')
+        return { ok: true }
+      case 'spray_can':
+        await withTimeout(bot.sprayCan(args.ref, args.limb), 10_000, 'spray_can')
+        return { ok: true }
+      case 'fill_bottle':
+        await withTimeout(bot.fillBottle(args.ref), 10_000, 'fill_bottle')
+        return { ok: true }
+      case 'pour_bottle':
+        await withTimeout(bot.pourBottle(args.ref), 10_000, 'pour_bottle')
+        return { ok: true }
+      case 'dig_shovel':
+        await withTimeout(bot.digShovel(args.ref), 10_000, 'dig_shovel')
+        return { ok: true }
+      case 'feed_aquarium':
+        await withTimeout(bot.feedAquarium(args.ref), 10_000, 'feed_aquarium')
+        return { ok: true }
+      case 'flush_garbage':
+        await withTimeout(bot.flushCan(args.ref), 10_000, 'flush_garbage')
+        return { ok: true }
+      case 'take_drug':
+        await withTimeout(bot.takeDrug(args.ref), 10_000, 'take_drug')
+        return { ok: true }
+      case 'scan_sensor':
+        await withTimeout(bot.scanSensor(args.ref), 10_000, 'scan_sensor')
+        return { ok: true }
+      case 'zap_to_port':
+        await withTimeout(bot.zapToPort(args.ref, args.port_number), 10_000, 'zap_to_port')
+        return { ok: true }
+
+      // ── dangerous / one-shot ────────────────────────────────────
+      case 'stun_avatar':
+        await withTimeout(bot.stunAvatar(args.ref, args.target_noid), 10_000, 'stun_avatar')
+        return { ok: true }
+      case 'pull_grenade_pin':
+        await withTimeout(bot.pullGrenadePin(args.ref), 10_000, 'pull_grenade_pin')
+        return { ok: true }
+      case 'fake_shoot':
+        await withTimeout(bot.fakeShoot(args.ref), 10_000, 'fake_shoot')
+        return { ok: true }
+      case 'reset_fake_gun':
+        await withTimeout(bot.resetFakeGun(args.ref), 10_000, 'reset_fake_gun')
+        return { ok: true }
+      case 'bug_out':
+        await withTimeout(bot.bugOut(args.ref), 10_000, 'bug_out')
+        return { ok: true }
+      case 'sex_change':
+        await withTimeout(bot.sexChange(args.ref), 10_000, 'sex_change')
+        return { ok: true }
+
+      // ── commerce ────────────────────────────────────────────────
+      case 'deposit_to_atm':
+        await withTimeout(bot.depositToAtm(args.ref, args.token_noid), 10_000, 'deposit_to_atm')
+        return { ok: true }
+      case 'withdraw_from_atm':
+        await withTimeout(bot.withdrawFromAtm(args.ref, args.amount), 10_000, 'withdraw_from_atm')
+        return { ok: true }
+      case 'pay_machine':
+        await withTimeout(bot.payMachine(args.ref), 10_000, 'pay_machine')
+        return { ok: true }
+      case 'vend_item':
+        await withTimeout(bot.vendItem(args.ref), 10_000, 'vend_item')
+        return { ok: true }
+      case 'vendo_select':
+        await withTimeout(bot.selectVendo(args.ref), 10_000, 'vendo_select')
+        return { ok: true }
+      case 'munch_pawn':
+        await withTimeout(bot.munchPawn(args.ref), 10_000, 'munch_pawn')
+        return { ok: true }
+      case 'send_mail':
+        await withTimeout(bot.sendMail(args.ref), 10_000, 'send_mail')
+        return { ok: true }
 
       default:
         log.warn('Unknown tool: %s', name)


### PR DESCRIPTION
## Summary

Brings habibot.js up to ~complete coverage of the Habitat wire-verb surface and exposes each verb as a Claude tool sage can use. Tool count goes from **24 → 63**.

## What's new

40 new helpers on \`HabiBot\` and corresponding tool entries in \`lib/sage/tools.js\`:

| Category | Verbs |
|---|---|
| Avatar-targeting | GRAB, USERLIST |
| Generic item | THROW, ASK, READ, WRITE (Paper), PSENDMAIL |
| Devices ON/OFF | Flashlight, Floor_lamp, Movie_camera (bundled as \`toggle_device\`) |
| Apparel | WEAR, REMOVE |
| Toys / games | WIND, ROLL, KING |
| Magic | RUB, WISH, MAGIC |
| Misc | DIRECT, SPRAY, FILL, POUR, DIG, FEED, FLUSH, TAKE, SCAN, ZAPTO |
| Dangerous / one-shot | STUN, PULLPIN, FAKESHOOT, RESET, BUGOUT, SEXCHANGE |
| Commerce | DEPOSIT, WITHDRAW, PAY, VEND, VSELECT, MUNCH, SENDMAIL |

## Wire correctness

Every helper's op + parameter names match the corresponding \`@JSONMethod\` annotation in \`src/main/java/org/made/neohabitat/mods/*.java\`. Verified with an end-to-end dispatch test that stubs the bot's TCP write and confirms the bytes on the wire:

\`\`\`
GRAB → {op:GRAB, to:<giver-ref>}
THROW → {op:THROW, to:<item>, target, x, y}
WITHDRAW → {op:WITHDRAW, to:<atm>, amount_lo, amount_hi}
WISH → {op:WISH, to:<lamp>, text}
...
\`\`\`

(Initially wrote WISH's field as \`WISH_MESSAGE\` — caught by the test against the actual Magic_lamp.java signature, fixed before commit.)

## Out of scope

- FNKEY / HELP / RDO / DO / TEST — meta or no bot value.
- Region-internal verbs (FINGER_IN_QUE, I_AM_HERE, LEAVE, PROMPT_REPLY, TELL_EVERYONE) — bridge_v2 already synthesizes the handshake side.
- Glue / Hole OPENCONTAINER / CLOSECONTAINER — niche container handlers.

## Test plan

- [ ] Build the bots image and bring up the stack
- [ ] In game, hand sage a Book and ask "read me a page" → expect \`read\` tool fires, page contents come back
- [ ] Ask sage "withdraw 50 tokens" → expect \`withdraw_from_atm\` only if an Atm is present; otherwise sage explains why it can't
- [ ] Drop a Die in sage's region and ask it to roll → expect \`roll_die\`, die's result broadcasts
- [ ] Wear a head: hand sage a Head item, ask sage to put it on → expects \`pick_up\` (move to HANDS) then \`wear_item\`
- [ ] No tool surface regression: existing flows (greet, walk_to_exit, pay_to_avatar, etc.) still work