### PR TITLE
Fix TCP_REPAIR contents-vector corruption on tableflip (#499)

### DIFF
--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -750,17 +750,34 @@ func (c *ClientSession) unpackHabitatObject(o *ElkoMessage, containerRef string)
 			elkoNoid16 := uint16(savedNoid)
 			mod.Noid = &elkoNoid16
 		}
-		// SittingIn is a nested noid reference (the seat the avatar is
-		// currently on). If we've already mapped that seat's elko noid
-		// to a saved noid earlier in the make storm, swap it too — or
-		// the client will look at SittingIn=42 (elko) and not match its
-		// own seat noid (e.g. 37 from the saved CONTENTS).
-		if mod.SittingIn != nil {
-			if saved, found := c.restoreElkoToSaved[*mod.SittingIn]; found && saved != *mod.SittingIn {
-				newSittingIn := saved
-				mod.SittingIn = &newSittingIn
+		// Nested noid references that elko_state_encoders.go writes raw
+		// from state.* (rather than through container or RefToNoid) and
+		// PROTOCOL.md documents as object NOIDs. Each one points at
+		// another object in the same region; if THAT object's noid
+		// shifted across the tableflip, the C64 will look at a noid
+		// (e.g. SittingIn=42 from elko's view) that doesn't match its
+		// own table (e.g. 37 from the saved CONTENTS). Translate via
+		// restoreElkoToSaved if we've already seen the target ref's
+		// make this restore burst.
+		//
+		// SittingIn  — Avatar — seat the avatar is currently sitting on
+		// Restrainer — Avatar — restraining object NOID (handcuffs etc;
+		//              dormant today but reserved in the wire format)
+		// Wisher     — Magic_lamp — avatar noid mid-wish; UNASSIGNED_NOID
+		//              when no wish is in flight, but switches to a real
+		//              avatar noid via Magic_lamp.java's wisher = avatar.noid
+		rewriteNestedNoid := func(field **uint8) {
+			if field == nil || *field == nil {
+				return
+			}
+			if saved, found := c.restoreElkoToSaved[**field]; found && saved != **field {
+				newVal := saved
+				*field = &newVal
 			}
 		}
+		rewriteNestedNoid(&mod.SittingIn)
+		rewriteNestedNoid(&mod.Restrainer)
+		rewriteNestedNoid(&mod.Wisher)
 	}
 
 	if clientMessages, found := ObjectClientMessages[*mod.Type]; found {

--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -131,6 +131,40 @@ type ClientSession struct {
 	wg                       sync.WaitGroup
 	who                      string
 
+	// restoredSession is true after RestoreSession has rebuilt this
+	// ClientSession from a snapshot — i.e. we are about to re-enter the
+	// region's elko context on a FRESH elko TCP, and the client already
+	// holds a CONTENTS vector from the parent process with noids that
+	// the parent assigned. Elko allocates noids dynamically and does NOT
+	// pin them across sessions, so its fresh `make` storm carries
+	// DIFFERENT noids than the ones the client knows. Without
+	// reconciliation: (1) we'd send a second CONTENTS that corrupts the
+	// client's noid table, and (2) every subsequent client→elko verb
+	// would arrive with a noid the bridge can't resolve to a ref.
+	//
+	// We address both by: (1) suppressing the post-restore CONTENTS Send
+	// in the `ready` handler, and (2) rewriting Elko's freshly-allocated
+	// noids back to the saved client noids in unpackHabitatObject so
+	// c.objects / c.RefToNoid match the C64's view. The flag is cleared
+	// the moment the first post-restore `ready` lands, after which the
+	// session resumes normal Elko-noid-equals-client-noid operation.
+	restoredSession bool
+
+	// savedRefToNoid preserves the snapshot's ref→noid map across the
+	// initializeState() wipe that enterContext triggers. Lookup target
+	// during the post-restore make storm: any ref we already know gets
+	// its incoming Elko noid rewritten to the saved client noid before
+	// being stored. Refs that are NOT in this map (new objects that
+	// appeared after the snapshot was taken) keep Elko's assignment.
+	savedRefToNoid map[string]uint8
+
+	// restoreElkoToSaved maps Elko's fresh noid → the saved client noid
+	// for refs that already existed before the tableflip. Populated as
+	// the post-restore make storm rewrites noids; consulted for nested
+	// noid fields on later messages in the same burst (e.g. an avatar
+	// arriving with SittingIn pointing at a seat noid we already saw).
+	restoreElkoToSaved map[uint8]uint8
+
 	// snapshotReq is used by SnapshotAll to request a snapshot at a
 	// clean frame boundary. The SIGHUP handler sends a response channel;
 	// the reader goroutine creates the snapshot and sends it back, then
@@ -449,6 +483,27 @@ func (c *ClientSession) handleElkoMessage(msg *ElkoMessage) {
 				Str("user_ref", c.userRef).
 				Str("region_ref", c.regionRef).
 				Msg("Avatar known and placed in region")
+			// Tableflip restore: the client already has a CONTENTS vector
+			// from the parent process. We rebuilt c.objects / c.RefToNoid
+			// from Elko's fresh make storm (with noids rewritten back to
+			// the saved client noids in unpackHabitatObject), so the
+			// bridge's internal view matches what the client believes —
+			// but we MUST NOT send a second CONTENTS or the C64 will
+			// overlay two inconsistent noid maps on top of each other
+			// (issue #499). Suppress the Send, clear the restore flags,
+			// and resume normal Elko-noid-equals-client-noid operation.
+			if c.restoredSession {
+				c.log.Info().
+					Str("region_ref", c.regionRef).
+					Int("objects", len(c.objects)).
+					Int("rewrites", len(c.restoreElkoToSaved)).
+					Msg("Restore: suppressing post-tableflip CONTENTS send; client already has it")
+				c.restoredSession = false
+				c.savedRefToNoid = nil
+				c.restoreElkoToSaved = nil
+				c.contentsVector = NewContentsVector(c, nil, nil, nil, nil)
+				return
+			}
 			err := c.contentsVector.Send()
 			if err != nil {
 				c.log.Error().Err(err).Msg("Could not send contents vector")
@@ -670,6 +725,42 @@ func (c *ClientSession) unpackHabitatObject(o *ElkoMessage, containerRef string)
 		// so the remaining values fit in uint8.
 		localNoid := uint8(*mod.Noid)
 		o.Noid = &localNoid
+	}
+
+	// Post-tableflip noid reconciliation. The client (C64) still holds
+	// the noid assignments that the PARENT process committed via its
+	// CONTENTS vector; Elko, on its fresh TCP, re-allocates noids
+	// independently for the same refs. If we let Elko's fresh noids
+	// flow into c.objects / c.RefToNoid, every subsequent client→Elko
+	// verb arrives with a noid the bridge can't resolve. So during the
+	// restore window: for any ref we already know about, rewrite the
+	// incoming noid (on both o.Noid AND mod.Noid, plus the bookkeeping
+	// translation map for nested fields like SittingIn) back to the
+	// saved client noid before any downstream code stores it.
+	if c.restoredSession && o.Noid != nil {
+		if savedNoid, found := c.savedRefToNoid[o.ref]; found && savedNoid != *o.Noid {
+			elkoNoid := *o.Noid
+			c.log.Debug().
+				Str("ref", o.ref).
+				Uint8("elko_noid", elkoNoid).
+				Uint8("saved_noid", savedNoid).
+				Msg("Restore: rewriting elko noid to saved client noid")
+			c.restoreElkoToSaved[elkoNoid] = savedNoid
+			*o.Noid = savedNoid
+			elkoNoid16 := uint16(savedNoid)
+			mod.Noid = &elkoNoid16
+		}
+		// SittingIn is a nested noid reference (the seat the avatar is
+		// currently on). If we've already mapped that seat's elko noid
+		// to a saved noid earlier in the make storm, swap it too — or
+		// the client will look at SittingIn=42 (elko) and not match its
+		// own seat noid (e.g. 37 from the saved CONTENTS).
+		if mod.SittingIn != nil {
+			if saved, found := c.restoreElkoToSaved[*mod.SittingIn]; found && saved != *mod.SittingIn {
+				newSittingIn := saved
+				mod.SittingIn = &newSittingIn
+			}
+		}
 	}
 
 	if clientMessages, found := ObjectClientMessages[*mod.Type]; found {
@@ -2252,6 +2343,21 @@ func RestoreSession(b *Bridge, snap *SessionSnapshot, clientConn net.Conn, elkoC
 
 	// Rebuild derived fields
 	sess.contentsVector = NewContentsVector(sess, nil, &REGION_NOID, nil, nil)
+
+	// Post-restore noid reconciliation. The client already holds a
+	// CONTENTS vector from the parent process using the noids in
+	// snap.RefToNoid; Elko (on its fresh TCP) will re-allocate noids
+	// independently when we re-enter the region. We stash a private copy
+	// of the saved map so it survives initializeState()'s wipe, and arm
+	// the per-message rewrite path. See ClientSession.restoredSession
+	// docs for the full rationale.
+	sess.restoredSession = true
+	sess.savedRefToNoid = make(map[string]uint8, len(snap.RefToNoid))
+	for ref, noid := range snap.RefToNoid {
+		sess.savedRefToNoid[ref] = noid
+	}
+	sess.restoreElkoToSaved = make(map[uint8]uint8)
+
 	// Set up the session logger directly instead of calling bindAvatar,
 	// which would go through TableKey() → RemoteAddr(). The inherited
 	// conn's RemoteAddr is valid but we can build the logger from the
@@ -2295,17 +2401,17 @@ func (c *ClientSession) StartRestored() {
 		c.log.Info().Msg("StartRestored: elko goroutines ready")
 
 		// The Elko connection is fresh (not TCP_REPAIR'd). Re-enter the
-		// same context so Elko knows we're here. The C64 client won't
-		// see a region transition because we don't send the contents
-		// vector — just the server-side session setup.
+		// same context so Elko knows we're here. We've armed
+		// c.restoredSession + c.savedRefToNoid in RestoreSession; the
+		// post-restore make storm rewrites elko's fresh noids back to
+		// the saved client noids in unpackHabitatObject, and the eventual
+		// `ready` handler suppresses the second CONTENTS Send so the
+		// client keeps its existing noid table intact. Without this
+		// dance the C64 would receive two CONTENTS payloads with
+		// inconsistent noid maps and render garbage sprites from the
+		// previous region (issue #499).
 		if c.regionRef != "" {
 			c.log.Info().Str("context", c.regionRef).Msg("StartRestored: re-entering context on fresh Elko conn")
-			// Re-enter the region via the bridge's normal enterContext
-			// path. This wipes and rebuilds the bridge's object maps
-			// from Elko's fresh state, and sends a full contents
-			// vector to the C64. The client sees a brief region reload
-			// (~1-2s) but gets fully consistent state — no ref
-			// mismatches between bridge/Elko/client.
 			c.enterContext(c.regionRef)
 		}
 

--- a/bridge_v2/bridge/restore_noid_rewrite_test.go
+++ b/bridge_v2/bridge/restore_noid_rewrite_test.go
@@ -1,0 +1,154 @@
+package bridge
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// Regression coverage for issue #499: after a tableflip with TCP_REPAIR,
+// the client still holds noids the parent process committed via CONTENTS,
+// but Elko re-allocates noids independently on the fresh TCP. The bridge
+// must rewrite those fresh-from-Elko noids back to the saved client
+// noids so c.objects / c.RefToNoid stay consistent with the C64's view.
+
+// strP and uint16P live in other test files; bridge_test.go already
+// defines newTestSession + a discardConn we reuse here.
+
+func newRestoredTestSession(saved map[string]uint8) *ClientSession {
+	sess := newTestSession()
+	sess.log = zerolog.Nop()
+	sess.restoredSession = true
+	sess.savedRefToNoid = make(map[string]uint8, len(saved))
+	for k, v := range saved {
+		sess.savedRefToNoid[k] = v
+	}
+	sess.restoreElkoToSaved = make(map[uint8]uint8)
+	return sess
+}
+
+// makeMsg fabricates a minimal "make" ElkoMessage carrying a single
+// HabitatMod with the supplied class, ref, and elko-assigned noid.
+func makeMsg(class, ref string, elkoNoid uint8) *ElkoMessage {
+	n := uint16(elkoNoid)
+	classP := class
+	return &ElkoMessage{
+		Obj: &HabitatObject{
+			Ref: ref,
+			Mods: []*HabitatMod{
+				{
+					Type: &classP,
+					Noid: &n,
+				},
+			},
+		},
+	}
+}
+
+func TestRestore_RewritesNoidForKnownRef(t *testing.T) {
+	saved := map[string]uint8{
+		"item-fountain-1": 50,
+	}
+	sess := newRestoredTestSession(saved)
+
+	msg := makeMsg("Fountain", "item-fountain-1", 31)
+	if err := sess.unpackHabitatObject(msg, "context-Downtown_5c"); err != nil {
+		t.Fatalf("unpackHabitatObject: %v", err)
+	}
+
+	if _, found := sess.objects[50]; !found {
+		t.Errorf("objects[50] not set; have %v", sess.objects)
+	}
+	if _, conflict := sess.objects[31]; conflict {
+		t.Errorf("objects[31] should not exist after rewrite")
+	}
+	if got := sess.RefToNoid["item-fountain-1"]; got != 50 {
+		t.Errorf("RefToNoid[item-fountain-1] = %d, want 50", got)
+	}
+	if got := sess.restoreElkoToSaved[31]; got != 50 {
+		t.Errorf("restoreElkoToSaved[31] = %d, want 50", got)
+	}
+	if msg.Obj.Mods[0].Noid == nil || *msg.Obj.Mods[0].Noid != 50 {
+		t.Errorf("mod.Noid not rewritten to 50: %v", msg.Obj.Mods[0].Noid)
+	}
+	if msg.Noid == nil || *msg.Noid != 50 {
+		t.Errorf("o.Noid not rewritten to 50: %v", msg.Noid)
+	}
+}
+
+func TestRestore_PreservesUnknownRefNoid(t *testing.T) {
+	// Object not in the saved snapshot (new arrival post-tableflip).
+	// Should keep Elko's noid assignment as-is.
+	sess := newRestoredTestSession(map[string]uint8{
+		"item-fountain-1": 50,
+	})
+
+	msg := makeMsg("Knick_knack", "item-stranger-trinket", 77)
+	if err := sess.unpackHabitatObject(msg, "context-Downtown_5c"); err != nil {
+		t.Fatalf("unpackHabitatObject: %v", err)
+	}
+
+	if _, found := sess.objects[77]; !found {
+		t.Errorf("objects[77] not set for unknown ref; have %v", sess.objects)
+	}
+	if got := sess.RefToNoid["item-stranger-trinket"]; got != 77 {
+		t.Errorf("RefToNoid[item-stranger-trinket] = %d, want 77 (no rewrite)", got)
+	}
+	if _, found := sess.restoreElkoToSaved[77]; found {
+		t.Errorf("restoreElkoToSaved should not record unknown-ref noid")
+	}
+}
+
+func TestRestore_RewritesSittingInUsingPriorMapping(t *testing.T) {
+	// Seat arrives first (with elko noid 42, saved client noid 37);
+	// then an avatar whose mod.SittingIn = 42 (elko's seat noid). The
+	// rewrite path should remap SittingIn to 37 so the C64's view stays
+	// internally consistent.
+	sess := newRestoredTestSession(map[string]uint8{
+		"item-seat-1":         37,
+		"user-randy-12345678": 50,
+	})
+
+	seatMsg := makeMsg("Chair", "item-seat-1", 42)
+	if err := sess.unpackHabitatObject(seatMsg, "context-Downtown_5c"); err != nil {
+		t.Fatalf("seat unpack: %v", err)
+	}
+
+	avatarMsg := makeMsg("Avatar", "user-randy-12345678", 31)
+	// Elko's view: avatar is sitting in seat noid 42 (elko's).
+	sittingIn := uint8(42)
+	avatarMsg.Obj.Mods[0].SittingIn = &sittingIn
+	if err := sess.unpackHabitatObject(avatarMsg, "context-Downtown_5c"); err != nil {
+		t.Fatalf("avatar unpack: %v", err)
+	}
+
+	avatarMod := avatarMsg.Obj.Mods[0]
+	if avatarMod.SittingIn == nil || *avatarMod.SittingIn != 37 {
+		t.Errorf("SittingIn not rewritten via restoreElkoToSaved: %v", avatarMod.SittingIn)
+	}
+	if avatarMod.Noid == nil || *avatarMod.Noid != 50 {
+		t.Errorf("avatar mod.Noid not rewritten: %v", avatarMod.Noid)
+	}
+}
+
+func TestRestore_FlagOffMeansNoRewrite(t *testing.T) {
+	// Sanity check: with restoredSession=false, the existing behavior
+	// (use Elko's noid as-is) is preserved even if savedRefToNoid is
+	// populated.
+	sess := newRestoredTestSession(map[string]uint8{
+		"item-fountain-1": 50,
+	})
+	sess.restoredSession = false
+
+	msg := makeMsg("Fountain", "item-fountain-1", 31)
+	if err := sess.unpackHabitatObject(msg, "context-Downtown_5c"); err != nil {
+		t.Fatalf("unpackHabitatObject: %v", err)
+	}
+
+	if _, found := sess.objects[31]; !found {
+		t.Errorf("objects[31] not set when restoredSession=false; have %v", sess.objects)
+	}
+	if got := sess.RefToNoid["item-fountain-1"]; got != 31 {
+		t.Errorf("RefToNoid[item-fountain-1] = %d, want 31 (elko's noid)", got)
+	}
+}

--- a/bridge_v2/bridge/restore_noid_rewrite_test.go
+++ b/bridge_v2/bridge/restore_noid_rewrite_test.go
@@ -131,6 +131,64 @@ func TestRestore_RewritesSittingInUsingPriorMapping(t *testing.T) {
 	}
 }
 
+func TestRestore_RewritesRestrainerUsingPriorMapping(t *testing.T) {
+	// Restrainer is an Avatar field documented in PROTOCOL.md:536 as
+	// "Restraining object NOID". elko_state_encoders.go writes it raw
+	// from state.Restrainer into the wire bundle, so if a tableflip
+	// shifts the restraining object's noid the client's view of who's
+	// holding the avatar gets corrupted. Verify it's rewritten when
+	// restoreElkoToSaved knows the target.
+	sess := newRestoredTestSession(map[string]uint8{
+		"item-handcuffs-1":    25,
+		"user-randy-12345678": 50,
+	})
+
+	cuffsMsg := makeMsg("Knick_knack", "item-handcuffs-1", 70)
+	if err := sess.unpackHabitatObject(cuffsMsg, "context-Downtown_5c"); err != nil {
+		t.Fatalf("cuffs unpack: %v", err)
+	}
+
+	avatarMsg := makeMsg("Avatar", "user-randy-12345678", 31)
+	restrainer := uint8(70) // elko's noid for the cuffs
+	avatarMsg.Obj.Mods[0].Restrainer = &restrainer
+	if err := sess.unpackHabitatObject(avatarMsg, "context-Downtown_5c"); err != nil {
+		t.Fatalf("avatar unpack: %v", err)
+	}
+
+	avatarMod := avatarMsg.Obj.Mods[0]
+	if avatarMod.Restrainer == nil || *avatarMod.Restrainer != 25 {
+		t.Errorf("Restrainer not rewritten via restoreElkoToSaved: %v", avatarMod.Restrainer)
+	}
+}
+
+func TestRestore_RewritesWisherUsingPriorMapping(t *testing.T) {
+	// Wisher is a Magic_lamp field (Magic_lamp.java:100 sets it to
+	// avatar.noid mid-wish). elko_state_encoders.go writes it raw,
+	// so a tableflip mid-wish corrupts which avatar the client thinks
+	// the lamp is bound to. Verify rewrite through restoreElkoToSaved.
+	sess := newRestoredTestSession(map[string]uint8{
+		"user-randy-12345678": 50,
+		"item-lamp-1":         18,
+	})
+
+	avatarMsg := makeMsg("Avatar", "user-randy-12345678", 31)
+	if err := sess.unpackHabitatObject(avatarMsg, "context-Downtown_5c"); err != nil {
+		t.Fatalf("avatar unpack: %v", err)
+	}
+
+	lampMsg := makeMsg("Magic_lamp", "item-lamp-1", 60)
+	wisher := uint8(31) // elko's noid for randy
+	lampMsg.Obj.Mods[0].Wisher = &wisher
+	if err := sess.unpackHabitatObject(lampMsg, "context-Downtown_5c"); err != nil {
+		t.Fatalf("lamp unpack: %v", err)
+	}
+
+	lampMod := lampMsg.Obj.Mods[0]
+	if lampMod.Wisher == nil || *lampMod.Wisher != 50 {
+		t.Errorf("Wisher not rewritten via restoreElkoToSaved: %v", lampMod.Wisher)
+	}
+}
+
 func TestRestore_FlagOffMeansNoRewrite(t *testing.T) {
 	// Sanity check: with restoredSession=false, the existing behavior
 	// (use Elko's noid as-is) is preserved even if savedRefToNoid is


### PR DESCRIPTION
## Summary

- **Root cause:** After a `systemctl reload` tableflip, `StartRestored` re-entered the region's Elko context on a fresh TCP and unconditionally sent a second CONTENTS vector to the C64 client. Elko allocates noids dynamically across sessions (Randy's avatar went 50 → 31 between parent and child), so the new CONTENTS layered an inconsistent noid map on top of the one the client already had, corrupting sprites and breaking subsequent noid-based ops.
- **Fix:** Arm a `restoredSession` flag during `RestoreSession` and stash a copy of the snapshot's `RefToNoid`. During the post-restore `make` storm, `unpackHabitatObject` rewrites each fresh Elko noid back to the saved client noid (and chains the translation through nested `mod.SittingIn` fields). The `ready` handler then suppresses the second `CONTENTS Send`, clears the flag, and the session resumes normal Elko-noid-equals-client-noid operation.
- **Coverage:** 4 new unit tests verify rewrite-on-known-ref, passthrough-on-unknown-ref, SittingIn chained translation, and flag-off no-op behavior.

Closes #499.

## Test plan

- [x] `go vet ./...` clean on Linux target
- [x] `go test -race -count=1 ./...` in `bridge_v2` — full suite passes (existing + 4 new tests)
- [ ] Deploy to prod; verify `systemctl reload bridge_v2` does NOT cause sprite corruption while a client is in a region
- [ ] Verify post-reload that the client can still issue ops (GET/PUT/SIT/SPEAK) without the bridge logging "Received client message for unknown noid"
- [ ] Confirm that fresh objects appearing post-reload (e.g. an avatar walking in) get Elko's noids as-is, not rewritten