### PR TITLE
Fix half-open bot session on neohabitat container restart (#505)

### DIFF
--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -244,9 +244,19 @@ func (c *ClientSession) elkoReader() {
 		if err != nil {
 			if closing {
 				c.log.Debug().Err(err).Msg("Elko reader exiting (teardown)")
-			} else {
-				c.log.Error().Err(err).Msg("Error reading message from Elko")
+				return
 			}
+			// Unplanned elko-side disconnect (habiproxy/elko restarted,
+			// network blip, etc.) — issue #505. Without an explicit
+			// teardown here the bot's client TCP stays open, HabiBot
+			// never sees a disconnect, and any in-flight elko writes
+			// vanish silently. Tear the whole session down so the bot
+			// detects EOF on its socket and triggers its reconnect-with-
+			// backoff loop; bridge.Close() drops this session from the
+			// bridge's map so the reconnect lands on a clean ClientSession
+			// that re-dials habiproxy.
+			c.log.Error().Err(err).Msg("Error reading message from Elko; tearing down session")
+			go c.Close()
 			return
 		}
 		if len(nextLine) == 0 {
@@ -326,7 +336,22 @@ func (c *ClientSession) elkoWriter() {
 				outbound.writeDone <- err
 			}
 			if err != nil {
-				c.log.Error().Err(err).Str("raw", string(msgBytes)).Msg("Error writing Elko message")
+				// Same teardown rationale as elkoReader (issue #505).
+				// elkoWriter normally exits on c.elkoDone / c.done from
+				// the select above; reaching here means the underlying
+				// elkoConn died mid-session. Trigger the full session
+				// close so the bot's client TCP gets EOF'd and HabiBot
+				// reconnects, instead of leaving the session half-open
+				// with subsequent bot writes silently failing.
+				c.closeMutex.Lock()
+				closing := c.doneClosed
+				c.closeMutex.Unlock()
+				if !closing {
+					c.log.Error().Err(err).Str("raw", string(msgBytes)).Msg("Error writing Elko message; tearing down session")
+					go c.Close()
+				} else {
+					c.log.Debug().Err(err).Msg("Elko writer exiting after write error (teardown)")
+				}
 				span.RecordError(err)
 				span.End()
 				return

--- a/bridge_v2/bridge/issue_505_test.go
+++ b/bridge_v2/bridge/issue_505_test.go
@@ -1,0 +1,192 @@
+package bridge
+
+import (
+	"bufio"
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Regression coverage for issue #505: when the bridge's elko-facing TCP
+// dies (habiproxy/elko restart, network blip), elkoReader and elkoWriter
+// must trigger a full session teardown so the bot's client TCP is
+// EOF'd and HabiBot's reconnect loop kicks in. Previously both just
+// `return`-ed silently, leaving the bot stuck reading from a half-open
+// session that no longer routed writes to/from elko.
+
+func newIssue505Session(t *testing.T) (*ClientSession, *recordingConn, *recordingConn, *Bridge) {
+	t.Helper()
+	bridge := &Bridge{
+		DataRate: 1 << 20,
+		Sessions: make(map[string]*ClientSession),
+	}
+	clientRC := newRecordingConn(nil)
+	elkoRC := newRecordingConn(nil)
+	cc := NewClientConnection(bridge, clientRC)
+	sess := &ClientSession{
+		NoidClassList:   []uint8{},
+		NoidContents:    make(map[uint8][]uint8),
+		RefToNoid:       make(map[string]uint8),
+		bridge:          bridge,
+		clientConn:      cc,
+		clientReader:    bufio.NewReader(cc),
+		ctx:             context.Background(),
+		done:            make(chan struct{}),
+		elkoConn:        elkoRC,
+		elkoDone:        make(chan struct{}),
+		elkoSendChan:    make(chan *outboundElkoMessage, MaxClientMessages),
+		firstConnection: true,
+		jsonPassthrough: true,
+		objects:         make(map[uint8]*ElkoMessage),
+	}
+	sess.contentsVector = NewContentsVector(sess, nil, &REGION_NOID, nil, nil)
+	// Register so RemoveSession has something to delete; also serves as
+	// a teardown-completion sentinel.
+	bridge.Sessions[sess.TableKey()] = sess
+	return sess, clientRC, elkoRC, bridge
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, name string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", name)
+}
+
+func TestIssue505_ElkoReaderTeardownOnUnplannedDisconnect(t *testing.T) {
+	sess, clientRC, elkoRC, bridge := newIssue505Session(t)
+
+	// Mirror what connectToElko does: register reader+writer wgs before
+	// launching the goroutines.
+	sess.wg.Add(2)
+	sess.elkoWg.Add(2)
+	sess.elkoConnInitWg.Add(2)
+	go sess.elkoReader()
+	go sess.elkoWriter()
+	sess.elkoConnInitWg.Wait()
+
+	// Simulate habiproxy/elko going away: close the elko-side socket.
+	// recordingConn.Close flips closed=true so subsequent Reads return
+	// io.EOF — the same observable behavior as a real FIN/RST.
+	if err := elkoRC.Close(); err != nil {
+		t.Fatalf("close elkoRC: %v", err)
+	}
+
+	// elkoReader should detect EOF, log the error, and schedule
+	// `go c.Close()`. The cascade closes clientConn and removes the
+	// session from the bridge's Sessions map.
+	waitForCondition(t, 2*time.Second, "clientConn closed", func() bool {
+		clientRC.mu.Lock()
+		defer clientRC.mu.Unlock()
+		return clientRC.closed
+	})
+
+	waitForCondition(t, 2*time.Second, "session removed from bridge", func() bool {
+		bridge.sessionsMutex.Lock()
+		defer bridge.sessionsMutex.Unlock()
+		_, found := bridge.Sessions[sess.TableKey()]
+		return !found
+	})
+}
+
+func TestIssue505_ElkoWriterTeardownOnWriteFailure(t *testing.T) {
+	sess, clientRC, elkoRC, bridge := newIssue505Session(t)
+
+	sess.wg.Add(2)
+	sess.elkoWg.Add(2)
+	sess.elkoConnInitWg.Add(2)
+	go sess.elkoReader()
+	go sess.elkoWriter()
+	sess.elkoConnInitWg.Wait()
+
+	// Close elko side, then push a write through elkoSendChan. The
+	// elkoWriter wakes up, attempts to write, gets io.ErrClosedPipe,
+	// and must schedule `go c.Close()` rather than returning silently.
+	if err := elkoRC.Close(); err != nil {
+		t.Fatalf("close elkoRC: %v", err)
+	}
+
+	// Sending to elkoSendChan synchronously is fine — the channel is
+	// buffered. The writeDone signal is best-effort here; we care about
+	// the side effect (session teardown), not the per-write reply.
+	op := "WALK"
+	to := "user-sagebot"
+	msg := &ElkoMessage{To: &to, Op: &op}
+	writeDone := make(chan error, 1)
+	sess.elkoSendChan <- &outboundElkoMessage{msg: msg, writeDone: writeDone}
+
+	// elkoReader may also race to teardown first (EOF on the already-
+	// closed elko conn); either way the observable result is the same:
+	// client TCP closed + session removed.
+	waitForCondition(t, 2*time.Second, "clientConn closed", func() bool {
+		clientRC.mu.Lock()
+		defer clientRC.mu.Unlock()
+		return clientRC.closed
+	})
+
+	waitForCondition(t, 2*time.Second, "session removed from bridge", func() bool {
+		bridge.sessionsMutex.Lock()
+		defer bridge.sessionsMutex.Unlock()
+		_, found := bridge.Sessions[sess.TableKey()]
+		return !found
+	})
+}
+
+func TestIssue505_PlannedCloseDoesNotDoubleTeardown(t *testing.T) {
+	// Sanity check: when teardown is initiated by something else (e.g.
+	// client disconnect), elkoReader's error path observes doneClosed=true
+	// and exits quietly without firing another `go c.Close()`. Verifies
+	// that the !closing guard in the fix actually distinguishes the
+	// planned-teardown case.
+	sess, clientRC, elkoRC, _ := newIssue505Session(t)
+
+	sess.wg.Add(2)
+	sess.elkoWg.Add(2)
+	sess.elkoConnInitWg.Add(2)
+	go sess.elkoReader()
+	go sess.elkoWriter()
+	sess.elkoConnInitWg.Wait()
+
+	// Trigger planned teardown first.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		sess.Close()
+	}()
+
+	// Then close the elko side a hair later, racing with the planned
+	// teardown. The reader will see closing=true via doneClosed and
+	// should exit via the debug branch (no second Close cascade,
+	// which would deadlock the wg.Wait inside Close).
+	time.Sleep(20 * time.Millisecond)
+	_ = elkoRC.Close()
+
+	// Wait for Close() to complete — if the second Close were fired,
+	// it'd deadlock here because the wg.Wait inside it would race the
+	// original.
+	doneCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+		// Good — Close returned cleanly.
+	case <-time.After(2 * time.Second):
+		t.Fatal("planned Close deadlocked, indicating double-teardown")
+	}
+
+	clientRC.mu.Lock()
+	closed := clientRC.closed
+	clientRC.mu.Unlock()
+	if !closed {
+		t.Errorf("expected clientConn closed after planned teardown")
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause:** When the neohabitat container restarts, the bridge's TCP to habiproxy/elko dies. `elkoReader` and `elkoWriter` both `return` silently on the resulting error, leaving the bot's client TCP open. HabiBot doesn't see a disconnect, never reconnects, and bot messages continue to vanish into the half-open session.
- **Fix:** Both elko goroutines now schedule `go c.Close()` on unplanned errors. Close cascades through the client conn, the bot sees EOF, HabiBot's reconnect-with-backoff loop fires, and the next reconnect lands on a fresh ClientSession that re-dials the restarted habiproxy cleanly.
- **Planned-teardown path preserved:** the `!closing` guard ensures Close() initiated by something else (client disconnect, etc.) doesn't fire a second cascade that would deadlock on `wg.Wait()`.
- **Coverage:** 3 new tests — reader-side EOF triggers teardown, writer-side write failure triggers teardown, and planned Close doesn't deadlock via double-teardown.

Closes #505.

## Test plan

- [x] `go vet ./...` clean on Linux target
- [x] `go test -race -count=1 ./...` — full bridge_v2 suite passes (3 new tests, no regressions)
- [ ] Deploy to prod; restart `neohabitat-neohabitat-1` while SageBot is connected and idle
- [ ] Verify bridge logs show "Error reading message from Elko; tearing down session" followed by HabiBot reconnect within ~5 seconds
- [ ] Confirm `/join SageBot` after restart actually notifies SageBot (the original symptom)
- [ ] Confirm SageBot can change regions after restart (NEWREGION → changeContext round-trip works)