### PR TITLE
Handle polymorphic obj + container_noid in ElkoMessage unmarshal (#502)

### DIFF
--- a/bridge_v2/bridge/issue_502_test.go
+++ b/bridge_v2/bridge/issue_502_test.go
@@ -156,6 +156,68 @@ func TestMarshal_ContainerNoidStillEmitsCamelCaseForElkoInbound(t *testing.T) {
 	}
 }
 
+func TestUnmarshal_PutBroadcastWithUnassignedNoidNarrowsToGhost(t *testing.T) {
+	// When a fresh JSON-passthrough avatar (whose region noid hasn't
+	// been assigned) does a PUT, elko broadcasts the resulting PUT$
+	// with the avatar's UNASSIGNED_NOID (256) in the top-level noid
+	// slot. Pre-fix, the whole message dropped on the *uint8 unmarshal;
+	// post-fix, 256 narrows to GHOST_NOID (255) so the broadcast
+	// survives and gets relayed.
+	raw := []byte(`{"type":"neighbor","noid":256,"op":"PUT$","obj":256,"cont":0,"x":60,"y":130,"how":0,"orient":16}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Noid == nil || *msg.Noid != GHOST_NOID {
+		t.Errorf("Noid = %v, want %d (GHOST_NOID)", msg.Noid, GHOST_NOID)
+	}
+	if msg.ObjectNoid == nil || *msg.ObjectNoid != GHOST_NOID {
+		t.Errorf("ObjectNoid = %v, want %d (GHOST_NOID — obj=256 narrows the same way)", msg.ObjectNoid, GHOST_NOID)
+	}
+}
+
+func TestUnmarshal_GoawayBroadcastWithUnassignedTargetNarrowsToGhost(t *testing.T) {
+	// GOAWAY_$ broadcasts the departing avatar's noid in the `target`
+	// slot. Same UNASSIGNED_NOID problem; same fix.
+	raw := []byte(`{"type":"broadcast","noid":0,"op":"GOAWAY_$","target":256}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Target == nil || *msg.Target != GHOST_NOID {
+		t.Errorf("Target = %v, want %d (GHOST_NOID)", msg.Target, GHOST_NOID)
+	}
+}
+
+func TestUnmarshal_NoidAndTargetNormalValues(t *testing.T) {
+	// Regular noid / target values (0..255) must pass through unchanged
+	// — the narrowing path should only fold the 256 sentinel.
+	raw := []byte(`{"type":"neighbor","noid":19,"op":"SPEAK$","target":42}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Noid == nil || *msg.Noid != 19 {
+		t.Errorf("Noid = %v, want 19", msg.Noid)
+	}
+	if msg.Target == nil || *msg.Target != 42 {
+		t.Errorf("Target = %v, want 42", msg.Target)
+	}
+}
+
+func TestUnmarshal_NoidOverflowAboveUnassignedRejected(t *testing.T) {
+	// 257+ isn't a documented sentinel and isn't a valid wire shape.
+	// The narrowing path uses uint16 so values up to 65535 unmarshal
+	// fine; 65537 and above would fail. We don't strictly need to
+	// reject 257..65535, but verify malformed input (non-numeric) does
+	// still return an error rather than silently swallowing it.
+	raw := []byte(`{"noid":"not a number"}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err == nil {
+		t.Errorf("expected error for non-numeric noid, got nil with Noid=%v", msg.Noid)
+	}
+}
+
 func TestUnmarshal_BodyShapesUnchanged(t *testing.T) {
 	// Sanity check: the existing body handling (object vs the bare-zero
 	// sentinel) is not regressed by the obj-handling addition.

--- a/bridge_v2/bridge/issue_502_test.go
+++ b/bridge_v2/bridge/issue_502_test.go
@@ -1,0 +1,204 @@
+package bridge
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Regression coverage for issue #502: ElkoMessage's `obj` field is
+// polymorphic on the wire — a bare noid integer in PUT$/THROW$
+// neighbor broadcasts, an embedded HabitatObject in make/HEREIS_$.
+// Previously the JSON unmarshaler dropped the whole message with
+// "json: cannot unmarshal number into Go struct field ... of type
+// bridge.HabitatObject" whenever Elko sent the bare-noid shape.
+
+func TestUnmarshal_PutBroadcastBareObjNoid(t *testing.T) {
+	// Real prod payload from issue #502.
+	raw := []byte(`{"type":"neighbor","noid":19,"op":"PUT$","obj":11,"cont":0,"x":38,"y":148,"how":0,"orient":17}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Obj != nil {
+		t.Errorf("Obj should be nil for bare-noid shape, got %+v", msg.Obj)
+	}
+	if msg.ObjectNoid == nil || *msg.ObjectNoid != 11 {
+		t.Errorf("ObjectNoid = %v, want 11", msg.ObjectNoid)
+	}
+	if msg.Op == nil || *msg.Op != "PUT$" {
+		t.Errorf("Op = %v, want PUT$", msg.Op)
+	}
+	if msg.Noid == nil || *msg.Noid != 19 {
+		t.Errorf("Noid = %v, want 19", msg.Noid)
+	}
+	if msg.Cont == nil || *msg.Cont != 0 {
+		t.Errorf("Cont = %v, want 0", msg.Cont)
+	}
+	if msg.X == nil || *msg.X != 38 || msg.Y == nil || *msg.Y != 148 {
+		t.Errorf("X/Y = %v/%v, want 38/148", msg.X, msg.Y)
+	}
+	if msg.How == nil || *msg.How != 0 {
+		t.Errorf("How = %v, want 0", msg.How)
+	}
+	if msg.Orient == nil || *msg.Orient != 17 {
+		t.Errorf("Orient = %v, want 17", msg.Orient)
+	}
+}
+
+func TestUnmarshal_ThrowBroadcastBareObjNoid(t *testing.T) {
+	// Same shape as PUT$ — HabitatMod.java:987 emits "obj" as bare noid.
+	raw := []byte(`{"type":"neighbor","noid":19,"op":"THROW$","obj":7,"x":100,"y":120,"hit":1}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.ObjectNoid == nil || *msg.ObjectNoid != 7 {
+		t.Errorf("ObjectNoid = %v, want 7", msg.ObjectNoid)
+	}
+	if msg.Hit == nil || *msg.Hit != 1 {
+		t.Errorf("Hit = %v, want 1", msg.Hit)
+	}
+}
+
+func TestUnmarshal_MakeWithEmbeddedObject(t *testing.T) {
+	// Object shape: must still decode into m.Obj as a full HabitatObject.
+	raw := []byte(`{"op":"make","to":"context-Downtown_5f","obj":{"type":"item","ref":"item-thing-1","name":"Thing","mods":[{"type":"Knick_knack","noid":42,"x":80,"y":120}]}}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Obj == nil {
+		t.Fatalf("Obj should be populated for object-shape payload")
+	}
+	if msg.Obj.Ref != "item-thing-1" {
+		t.Errorf("Obj.Ref = %q, want item-thing-1", msg.Obj.Ref)
+	}
+	if len(msg.Obj.Mods) != 1 || msg.Obj.Mods[0].Type == nil || *msg.Obj.Mods[0].Type != "Knick_knack" {
+		t.Errorf("Obj.Mods not decoded: %+v", msg.Obj.Mods)
+	}
+	if msg.ObjectNoid != nil {
+		t.Errorf("ObjectNoid should be nil for object-shape payload, got %v", msg.ObjectNoid)
+	}
+}
+
+func TestUnmarshal_ObjNullOrAbsentDoesNothing(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"absent", `{"op":"make","to":"region","noid":5}`},
+		{"null", `{"op":"make","to":"region","noid":5,"obj":null}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var msg ElkoMessage
+			if err := json.Unmarshal([]byte(c.raw), &msg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if msg.Obj != nil {
+				t.Errorf("Obj should be nil for %s", c.name)
+			}
+			if msg.ObjectNoid != nil {
+				t.Errorf("ObjectNoid should be nil for %s", c.name)
+			}
+		})
+	}
+}
+
+func TestUnmarshal_ChangeContainersBroadcast(t *testing.T) {
+	// Full CHANGE_CONTAINERS_$ broadcast from Avatar.java:1434. Elko
+	// emits snake_case `object_noid` and `container_noid`. ObjectNoid
+	// has always been correct via its standard json tag; ContainerNoid's
+	// struct tag is camelCase (matches the PUT verb's inbound shape),
+	// so the snake_case inbound was silently lost until the polymorphic
+	// container_noid routing was added.
+	raw := []byte(`{"type":"broadcast","noid":0,"op":"CHANGE_CONTAINERS_$","object_noid":42,"container_noid":7,"x":50,"y":140}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.ObjectNoid == nil || *msg.ObjectNoid != 42 {
+		t.Errorf("ObjectNoid = %v, want 42", msg.ObjectNoid)
+	}
+	if msg.ContainerNoid == nil || *msg.ContainerNoid != 7 {
+		t.Errorf("ContainerNoid = %v, want 7", msg.ContainerNoid)
+	}
+	if msg.X == nil || *msg.X != 50 || msg.Y == nil || *msg.Y != 140 {
+		t.Errorf("X/Y = %v/%v, want 50/140", msg.X, msg.Y)
+	}
+}
+
+func TestMarshal_ContainerNoidStillEmitsCamelCaseForElkoInbound(t *testing.T) {
+	// The outbound (bridge→elko) PUT verb needs `containerNoid`
+	// (camelCase) — that's what elko's @JSONMethod expects (HabitatMod.PUT).
+	// The struct tag remains camelCase to satisfy this. Verify that the
+	// new container_noid envelope handling didn't accidentally break
+	// the marshal path.
+	noid := uint8(3)
+	to := "item-foo"
+	op := "PUT"
+	msg := ElkoMessage{
+		To:            &to,
+		Op:            &op,
+		ContainerNoid: &noid,
+	}
+	out, err := json.Marshal(&msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `"containerNoid":3`) {
+		t.Errorf("marshal did not emit containerNoid camelCase key: %s", got)
+	}
+	if strings.Contains(got, `"container_noid"`) {
+		t.Errorf("marshal should NOT emit container_noid for outbound PUT: %s", got)
+	}
+}
+
+func TestUnmarshal_BodyShapesUnchanged(t *testing.T) {
+	// Sanity check: the existing body handling (object vs the bare-zero
+	// sentinel) is not regressed by the obj-handling addition.
+	cases := []struct {
+		name      string
+		raw       string
+		bodyNil   bool
+		bodyRef   string
+	}{
+		{
+			name:    "body object",
+			raw:     `{"op":"make","body":{"type":"User","ref":"user-foo","name":"Foo","mods":[{"type":"Avatar","noid":13}]}}`,
+			bodyRef: "user-foo",
+		},
+		{
+			name:    "body bare zero",
+			raw:     `{"op":"CORPORATE","body":0}`,
+			bodyNil: true,
+		},
+		{
+			name:    "body null",
+			raw:     `{"op":"DISCORPORATE","body":null}`,
+			bodyNil: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var msg ElkoMessage
+			if err := json.Unmarshal([]byte(c.raw), &msg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if c.bodyNil {
+				if msg.Body != nil {
+					t.Errorf("Body should be nil, got %+v", msg.Body)
+				}
+				return
+			}
+			if msg.Body == nil {
+				t.Fatalf("Body should be populated")
+			}
+			if msg.Body.Ref != c.bodyRef {
+				t.Errorf("Body.Ref = %q, want %q", msg.Body.Ref, c.bodyRef)
+			}
+		})
+	}
+}

--- a/bridge_v2/bridge/schema.go
+++ b/bridge_v2/bridge/schema.go
@@ -149,6 +149,17 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 	//     the field on the floor (issue #502 caught this via the PUT$
 	//     unmarshal failure, but it'd been silently latent for any
 	//     inventory-handoff CHANGE_CONTAINERS_$ broadcast as well).
+	//   - `noid` and `target` are typed *uint8 on the struct (matches
+	//     what binary-mode encoders need at write time), but Elko can
+	//     legitimately put 256 (UNASSIGNED_NOID) in either slot when
+	//     the broadcasting / targeted avatar has no assigned region noid
+	//     yet (e.g. a fresh JSON-passthrough avatar mid-PUT). The
+	//     standard unmarshal would fail with "cannot unmarshal number
+	//     256 into uint8" and the whole message would be dropped —
+	//     including the PUT$ / GOAWAY_$ broadcasts that other clients
+	//     in the region needed to see. Peel both as RawMessage and
+	//     narrow UNASSIGNED_NOID (256) → GHOST_NOID (255), matching how
+	//     Appearing and Speaker handle the same sentinel.
 	//
 	// Matches the legacy JS bridge, which tolerates either shape because
 	// JavaScript is dynamically typed.
@@ -157,6 +168,8 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 		Body          json.RawMessage `json:"body,omitempty"`
 		Obj           json.RawMessage `json:"obj,omitempty"`
 		ContainerNoid json.RawMessage `json:"container_noid,omitempty"`
+		Noid          json.RawMessage `json:"noid,omitempty"`
+		Target        json.RawMessage `json:"target,omitempty"`
 		*elkoMessage
 	}
 	aux := envelope{
@@ -194,11 +207,14 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 			// on. An explicit `object_noid` from the same message (if
 			// any) would have been set by the standard unmarshal above;
 			// re-setting it here from `obj` keeps the two consistent.
-			var noid uint8
-			if err := json.Unmarshal(aux.Obj, &noid); err != nil {
-				return fmt.Errorf("parsing elko message obj as noid: %w", err)
+			// Use the same UNASSIGNED_NOID→GHOST_NOID narrowing as Noid /
+			// Target — a fresh JSON-passthrough avatar mid-PUT broadcasts
+			// `obj:256` for an unbound-noid object.
+			narrowed, err := narrowNoidField(aux.Obj, "obj")
+			if err != nil {
+				return err
 			}
-			m.ObjectNoid = &noid
+			m.ObjectNoid = narrowed
 		}
 	}
 
@@ -209,7 +225,44 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 		}
 		m.ContainerNoid = &noid
 	}
+
+	// noid and target may carry UNASSIGNED_NOID (256), which doesn't fit
+	// in the *uint8 schema fields. Narrow to GHOST_NOID (255) on the way
+	// in — matches the Appearing/Speaker convention and downstream
+	// encoders treat 255 as "the ghost slot" so the binary path stays
+	// internally consistent.
+	if narrowed, err := narrowNoidField(aux.Noid, "noid"); err != nil {
+		return err
+	} else if narrowed != nil {
+		m.Noid = narrowed
+	}
+	if narrowed, err := narrowNoidField(aux.Target, "target"); err != nil {
+		return err
+	} else if narrowed != nil {
+		m.Target = narrowed
+	}
+
 	return nil
+}
+
+// narrowNoidField decodes a JSON noid-shaped field into a *uint8,
+// folding the elko UNASSIGNED_NOID (256) sentinel down to GHOST_NOID
+// (255). Returns (nil, nil) when the raw is absent or explicitly null.
+func narrowNoidField(raw json.RawMessage, name string) (*uint8, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var wide uint16
+	if err := json.Unmarshal(raw, &wide); err != nil {
+		return nil, fmt.Errorf("parsing elko message %s: %w", name, err)
+	}
+	var narrow uint8
+	if wide == UNASSIGNED_NOID {
+		narrow = GHOST_NOID
+	} else {
+		narrow = uint8(wide)
+	}
+	return &narrow, nil
 }
 
 func (e *ElkoMessage) String() string {

--- a/bridge_v2/bridge/schema.go
+++ b/bridge_v2/bridge/schema.go
@@ -125,16 +125,38 @@ type ElkoMessage struct {
 }
 
 func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
-	// Elko sends `"body":0` as a no-body sentinel in CORPORATE /
-	// DISCORPORATE replies (and anywhere else the body slot is empty),
-	// but Body is typed *HabitatObject so a bare `0` would fail to
-	// unmarshal. Peel Body off as a RawMessage and only decode it into
-	// a HabitatObject if it actually looks like an object. Matches the
-	// legacy JS bridge, which tolerates o.body being numeric 0 because
+	// Elko's wire format for several fields is polymorphic OR uses a
+	// different key on the inbound (server→bridge) path than the
+	// outbound (bridge→server) path. We can't capture that with a
+	// single struct tag, so we peel the affected fields as RawMessage
+	// and route them by shape / source:
+	//
+	//   - `body` is either an embedded HabitatObject (make, HEREIS_$) or
+	//     the bare integer 0 (CORPORATE / DISCORPORATE replies — no body).
+	//   - `obj` is either an embedded HabitatObject (make, HEREIS_$) or
+	//     a bare noid integer (PUT$ / THROW$ neighbor broadcasts — see
+	//     HabitatMod.java:828, :987). In the bare-noid case the value is
+	//     the noid of the object being put down / thrown, which the
+	//     downstream handlers read as `*o.ObjectNoid` (the same Go field
+	//     CHANGE_CONTAINERS_$ populates via the `object_noid` key).
+	//   - `container_noid` (snake_case) is what elko emits on the
+	//     CHANGE_CONTAINERS_$ broadcast (Avatar.java:1436). The
+	//     ContainerNoid struct tag is `containerNoid` (camelCase) because
+	//     that's what elko expects on the inbound PUT verb
+	//     (HabitatMod.PUT @JSONMethod). Same Go field, different wire
+	//     keys in each direction — route the snake_case key into
+	//     ContainerNoid manually so CHANGE_CONTAINERS_$ no longer drops
+	//     the field on the floor (issue #502 caught this via the PUT$
+	//     unmarshal failure, but it'd been silently latent for any
+	//     inventory-handoff CHANGE_CONTAINERS_$ broadcast as well).
+	//
+	// Matches the legacy JS bridge, which tolerates either shape because
 	// JavaScript is dynamically typed.
 	type elkoMessage ElkoMessage
 	type envelope struct {
-		Body json.RawMessage `json:"body,omitempty"`
+		Body          json.RawMessage `json:"body,omitempty"`
+		Obj           json.RawMessage `json:"obj,omitempty"`
+		ContainerNoid json.RawMessage `json:"container_noid,omitempty"`
 		*elkoMessage
 	}
 	aux := envelope{
@@ -147,6 +169,7 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 		return err
 	}
 	*m = ElkoMessage(*aux.elkoMessage)
+
 	body := string(aux.Body)
 	if len(body) > 0 && body != "0" && body != "null" {
 		var ho HabitatObject
@@ -154,6 +177,37 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 			return fmt.Errorf("parsing elko message body: %w", err)
 		}
 		m.Body = &ho
+	}
+
+	if len(aux.Obj) > 0 && string(aux.Obj) != "null" {
+		switch aux.Obj[0] {
+		case '{':
+			var ho HabitatObject
+			if err := json.Unmarshal(aux.Obj, &ho); err != nil {
+				return fmt.Errorf("parsing elko message obj: %w", err)
+			}
+			m.Obj = &ho
+		default:
+			// Bare integer noid (PUT$/THROW$). Decode into ObjectNoid so
+			// the existing ServerOps handlers Just Work — they already
+			// read *o.ObjectNoid for the noid of the object being acted
+			// on. An explicit `object_noid` from the same message (if
+			// any) would have been set by the standard unmarshal above;
+			// re-setting it here from `obj` keeps the two consistent.
+			var noid uint8
+			if err := json.Unmarshal(aux.Obj, &noid); err != nil {
+				return fmt.Errorf("parsing elko message obj as noid: %w", err)
+			}
+			m.ObjectNoid = &noid
+		}
+	}
+
+	if len(aux.ContainerNoid) > 0 && string(aux.ContainerNoid) != "null" {
+		var noid uint8
+		if err := json.Unmarshal(aux.ContainerNoid, &noid); err != nil {
+			return fmt.Errorf("parsing elko message container_noid: %w", err)
+		}
+		m.ContainerNoid = &noid
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

The reported PUT$ unmarshal failure surfaced two related bugs:

- **`obj` is polymorphic on the wire.** `make` / `HEREIS_$` send an embedded HabitatObject; `PUT$` / `THROW$` neighbor broadcasts send a bare noid integer (`HabitatMod.java:828`, `:987`). The Go tag typed it as `*HabitatObject`, so the bare-integer shape failed unmarshal and dropped the whole message. Result: every PUT/THROW silently vanished for neighbors. The PUT$ / THROW$ handlers in `server_ops.go` already read `*o.ObjectNoid` (same Go field CHANGE_CONTAINERS_$ uses via `object_noid`) — once unmarshal survives, the existing dispatch Just Works. The custom `UnmarshalJSON` now peels `obj` as `RawMessage` and routes by shape: object literal → `m.Obj`, bare integer → `m.ObjectNoid`.

- **Latent twin: `container_noid` (snake_case) vs `containerNoid` (camelCase).** Auditing the schema turned up that CHANGE_CONTAINERS_$ emits `container_noid` (`Avatar.java:1436`) but the `ContainerNoid` struct tag is camelCase — because that's what the inbound PUT verb's `@JSONMethod` expects. Same Go field, different wire keys per direction. The unmarshaler now also accepts `container_noid` and routes it into `ContainerNoid`; the marshal path is unchanged so outbound PUT verbs still emit the camelCase key elko expects.

Other camelCase fields (`argCount`, `newNoid`, `targetNoid`, `suppressReply`) were audited against the elko-side emitters and all match — no further mismatches.

Closes #502.

## Test plan

- [x] `go vet ./...` clean on Linux target
- [x] `go test -race -count=1 ./...` — full bridge_v2 suite passes (7 new tests, no regressions)
- [ ] Deploy to prod; observe that PUT$ / THROW$ neighbor broadcasts no longer log "json: cannot unmarshal number" errors
- [ ] Confirm visually: another avatar puts down or throws an item in a region with a connected QLink / SageBot client → the item appears for the observer
- [ ] Confirm CHANGE_CONTAINERS_$ propagates: gift/hand-off between two avatars renders correctly on both sides