### PR TITLE
Silently reconnect to habiproxy on elko-side disconnect (#505, supersedes #507)

### DIFF
--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -89,7 +89,6 @@ type ClientSession struct {
 	done              chan struct{}
 	doneClosed        bool
 	elkoConn          net.Conn
-	elkoConnInitWg    sync.WaitGroup
 	elkoDone          chan struct{}
 	elkoDoneClosed    bool
 	elkoSendChan      chan *outboundElkoMessage
@@ -130,6 +129,14 @@ type ClientSession struct {
 	waitingForAvatarContents bool
 	wg                       sync.WaitGroup
 	who                      string
+
+	// elkoRecovering serializes silent-reconnect attempts triggered by
+	// elkoReader EOF and elkoWriter error firing in parallel — without
+	// the guard, two recovery goroutines race to close + redial the
+	// same elkoConn and leave the session with two live writer
+	// goroutines pulling from one elkoSendChan. Accessed with
+	// closeMutex held for cheap reuse of an existing mutex.
+	elkoRecovering bool
 
 	// restoredSession is true after RestoreSession has rebuilt this
 	// ClientSession from a snapshot — i.e. we are about to re-enter the
@@ -225,12 +232,14 @@ func (c *ClientSession) closeChannels() {
 	}
 }
 
-func (c *ClientSession) elkoReader() {
+func (c *ClientSession) elkoReader(ready chan<- struct{}) {
 	defer c.elkoWg.Done()
 	defer c.wg.Done()
 	reader := bufio.NewReader(c.elkoConn)
 	tp := textproto.NewReader(reader)
-	c.elkoConnInitWg.Done()
+	if ready != nil {
+		ready <- struct{}{}
+	}
 	for {
 		nextLine, err := tp.ReadLineBytes()
 		// Cheap one-shot teardown probe shared by the read-error
@@ -244,9 +253,29 @@ func (c *ClientSession) elkoReader() {
 		if err != nil {
 			if closing {
 				c.log.Debug().Err(err).Msg("Elko reader exiting (teardown)")
-			} else {
-				c.log.Error().Err(err).Msg("Error reading message from Elko")
+				return
 			}
+			// Unplanned elko-side disconnect. The common cause is NOT
+			// elko actually dying — it's habiproxy cycling the
+			// bridge-side TCP after elko closed the server-side
+			// following a normal changeContext (pushserver/habiproxy/
+			// session.js:251 disconnectProxy fires after elko sends
+			// changeContext, ~ms before the next entercontext could
+			// reach it). Silently returning here leaves the next
+			// elkoWriter write to fail against the dead conn, the
+			// entercontext for the new region never reaches elko, and
+			// the client sits forever in an infinite region transfer
+			// (issue #505).
+			//
+			// Schedule a silent reconnect to habiproxy on a fresh
+			// goroutine; if it succeeds we resume operations on the
+			// existing client TCP and the region transit completes
+			// normally. If the reconnect cycle gives up (true
+			// container outage), the recovery path tears the bot's
+			// session down so HabiBot's reconnect-with-backoff loop
+			// kicks in cleanly.
+			c.log.Warn().Err(err).Msg("Elko-side disconnect; attempting silent reconnect")
+			go c.recoverElkoConnection()
 			return
 		}
 		if len(nextLine) == 0 {
@@ -277,10 +306,12 @@ func (c *ClientSession) elkoReader() {
 	}
 }
 
-func (c *ClientSession) elkoWriter() {
+func (c *ClientSession) elkoWriter(ready chan<- struct{}) {
 	defer c.elkoWg.Done()
 	defer c.wg.Done()
-	c.elkoConnInitWg.Done()
+	if ready != nil {
+		ready <- struct{}{}
+	}
 	for {
 		select {
 		case outbound := <-c.elkoSendChan:
@@ -326,7 +357,22 @@ func (c *ClientSession) elkoWriter() {
 				outbound.writeDone <- err
 			}
 			if err != nil {
-				c.log.Error().Err(err).Str("raw", string(msgBytes)).Msg("Error writing Elko message")
+				// Same teardown-vs-recover decision as elkoReader: most
+				// "Write failed" events here are habiproxy already
+				// having closed our bridge-side TCP after a
+				// changeContext cycle. Drop into the silent reconnect
+				// path so the post-recovery enterContext gets re-sent
+				// rather than dropped. The closing probe keeps planned
+				// teardown silent (Close() flips doneClosed first).
+				c.closeMutex.Lock()
+				closing := c.doneClosed
+				c.closeMutex.Unlock()
+				if !closing {
+					c.log.Warn().Err(err).Str("raw", string(msgBytes)).Msg("Elko write failed; attempting silent reconnect")
+					go c.recoverElkoConnection()
+				} else {
+					c.log.Debug().Err(err).Msg("Elko writer exiting after write error (teardown)")
+				}
 				span.RecordError(err)
 				span.End()
 				return
@@ -1201,10 +1247,16 @@ func (c *ClientSession) connectToElko() error {
 	// goroutine, before they're started, to satisfy sync.WaitGroup's contract.
 	c.wg.Add(2)
 	c.elkoWg.Add(2)
-	c.elkoConnInitWg.Add(2)
-	go c.elkoReader()
-	go c.elkoWriter()
-	c.elkoConnInitWg.Wait()
+	// Per-call ready channels instead of a shared WaitGroup — reconnect
+	// cycles would otherwise have Add and a previous Wait race without
+	// explicit happens-before (race detector flags this; in pathological
+	// scheduling it can deadlock the WaitGroup mid-reuse).
+	readerReady := make(chan struct{}, 1)
+	writerReady := make(chan struct{}, 1)
+	go c.elkoReader(readerReady)
+	go c.elkoWriter(writerReady)
+	<-readerReady
+	<-writerReady
 	return nil
 }
 
@@ -1223,6 +1275,96 @@ func (c *ClientSession) reconnectToElko(immediate bool, context string) {
 	}
 	if immediate {
 		c.enterContext(context)
+	}
+}
+
+// recoverElkoConnection is the silent-reconnect path invoked from
+// elkoReader / elkoWriter when the bridge-side TCP to habiproxy
+// drops mid-session. The typical trigger isn't a real outage — it's
+// habiproxy's disconnectProxy() firing after elko closed its
+// server-side TCP at the end of a normal changeContext, which races
+// the bridge's followup entercontext.
+//
+// Recovery is bounded: dial habiproxy a few times with backoff, and
+// if every attempt fails (real container outage, network blip
+// extending past ~30s) fall back to tearing down the bot session via
+// Close() — that preserves the issue #505 idle-bot-during-restart
+// recovery behavior by surfacing the disconnect to HabiBot's
+// reconnect loop. On success the bridge re-enters the most recent
+// context so the in-flight region transit completes.
+//
+// Idempotent: parallel firings from elkoReader EOF and elkoWriter
+// error coalesce via the elkoRecovering guard, so we don't end up
+// with two live writer goroutines pulling from one elkoSendChan.
+func (c *ClientSession) recoverElkoConnection() {
+	c.closeMutex.Lock()
+	if c.doneClosed || c.elkoRecovering {
+		c.closeMutex.Unlock()
+		return
+	}
+	c.elkoRecovering = true
+	c.closeMutex.Unlock()
+	defer func() {
+		c.closeMutex.Lock()
+		c.elkoRecovering = false
+		c.closeMutex.Unlock()
+	}()
+
+	// Tear down the current reader/writer goroutines cleanly. Close
+	// the conn so any blocked read returns, signal the writer's done
+	// channel non-blocking, wait for both to exit.
+	_ = c.elkoConn.Close()
+	select {
+	case c.elkoDone <- struct{}{}:
+	default:
+	}
+	c.elkoWg.Wait()
+
+	// Decide which region to re-enter. nextRegion is set during an
+	// in-flight changeContext that hasn't been confirmed yet;
+	// regionRef is the avatar's last known live region.
+	region := c.nextRegion
+	if region == "" {
+		region = c.regionRef
+	}
+
+	var dialErr error
+	backoff := 250 * time.Millisecond
+	for attempt := 1; attempt <= 5; attempt++ {
+		c.closeMutex.Lock()
+		bailingOut := c.doneClosed
+		c.closeMutex.Unlock()
+		if bailingOut {
+			return
+		}
+		if dialErr = c.connectToElko(); dialErr == nil {
+			c.log.Info().Int("attempt", attempt).Str("region", region).
+				Msg("Silent reconnect to Elko succeeded")
+			break
+		}
+		c.log.Warn().Err(dialErr).Int("attempt", attempt).Dur("backoff", backoff).
+			Msg("Silent reconnect to Elko failed; will retry")
+		time.Sleep(backoff)
+		if backoff < 4*time.Second {
+			backoff *= 2
+		}
+	}
+	if dialErr != nil {
+		c.log.Error().Err(dialErr).
+			Msg("Silent reconnect cycle exhausted; tearing down session for HabiBot to retry")
+		go c.Close()
+		return
+	}
+
+	// Re-enter the region the bot/client was in (or moving to). For
+	// JSON-passthrough this drives the bot back into the world
+	// immediately. For binary clients this preempts the client's
+	// MESSAGE_DESCRIBE so the new region's make storm starts flowing
+	// without waiting on the C64 to notice the timeout — which it
+	// often doesn't, hence the historical "infinite region transfer"
+	// symptom.
+	if region != "" {
+		c.enterContext(region)
 	}
 }
 
@@ -2410,10 +2552,12 @@ func (c *ClientSession) StartRestored() {
 		// Start Elko reader/writer goroutines on the inherited connection.
 		c.wg.Add(2)
 		c.elkoWg.Add(2)
-		c.elkoConnInitWg.Add(2)
-		go c.elkoReader()
-		go c.elkoWriter()
-		c.elkoConnInitWg.Wait()
+		readerReady := make(chan struct{}, 1)
+		writerReady := make(chan struct{}, 1)
+		go c.elkoReader(readerReady)
+		go c.elkoWriter(writerReady)
+		<-readerReady
+		<-writerReady
 
 		c.log.Info().Msg("StartRestored: elko goroutines ready")
 

--- a/bridge_v2/bridge/elko_recover_test.go
+++ b/bridge_v2/bridge/elko_recover_test.go
@@ -1,0 +1,222 @@
+package bridge
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Regression coverage for the silent-reconnect path on elko-side
+// disconnect (issue #505).
+//
+// The trigger in production is habiproxy closing the bridge-side TCP
+// after elko closed the server-side following a normal changeContext.
+// Pre-fix the bridge silently let elkoReader exit and the next
+// entercontext write fell into the void, leaving the client stuck in
+// an infinite region transfer. The fix reconnects to a fresh elko
+// dial and re-enters the most recent context so transit completes.
+
+// fakeElkoListener is a minimal accept-and-immediately-close TCP
+// server used to drive ClientSession's reconnect logic. Successful
+// dials keep the socket open until the test ends so the new
+// elkoReader/Writer goroutines have something to read from.
+type fakeElkoListener struct {
+	ln       net.Listener
+	mu       sync.Mutex
+	accepted []net.Conn
+}
+
+func newFakeElkoListener(t *testing.T) *fakeElkoListener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	f := &fakeElkoListener{ln: ln}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			f.mu.Lock()
+			f.accepted = append(f.accepted, conn)
+			f.mu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		f.mu.Lock()
+		for _, c := range f.accepted {
+			_ = c.Close()
+		}
+		f.mu.Unlock()
+		_ = ln.Close()
+	})
+	return f
+}
+
+func (f *fakeElkoListener) addr() string { return f.ln.Addr().String() }
+
+// waitForRecoveryCondition is a tiny polling helper used by the
+// recovery tests. Kept local to avoid colliding with a similarly-
+// named helper that lands on the parallel issue-502 branch.
+func waitForRecoveryCondition(t *testing.T, timeout time.Duration, name string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", name)
+}
+
+func (f *fakeElkoListener) acceptedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.accepted)
+}
+
+func (f *fakeElkoListener) closeAllAccepted() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.accepted {
+		_ = c.Close()
+	}
+	f.accepted = f.accepted[:0]
+}
+
+// recoverTestSession wires up a ClientSession with a real-ish elko
+// connection dialed against the fake listener. The client side is a
+// recordingConn so we can assert the client TCP stays open through
+// the silent reconnect.
+func recoverTestSession(t *testing.T, elkoAddr string, regionRef string) (*ClientSession, *recordingConn) {
+	t.Helper()
+	bridge := &Bridge{
+		DataRate: 1 << 20,
+		elkoHost: elkoAddr,
+		Sessions: make(map[string]*ClientSession),
+	}
+	clientRC := newRecordingConn(nil)
+	cc := NewClientConnection(bridge, clientRC)
+	sess := &ClientSession{
+		NoidClassList:   []uint8{},
+		NoidContents:    make(map[uint8][]uint8),
+		RefToNoid:       make(map[string]uint8),
+		bridge:          bridge,
+		clientConn:      cc,
+		clientReader:    bufio.NewReader(cc),
+		ctx:             context.Background(),
+		done:            make(chan struct{}),
+		elkoDone:        make(chan struct{}),
+		elkoSendChan:    make(chan *outboundElkoMessage, MaxClientMessages),
+		jsonPassthrough: true,
+		objects:         make(map[uint8]*ElkoMessage),
+		regionRef:       regionRef,
+		userRef:         "user-test",
+	}
+	sess.contentsVector = NewContentsVector(sess, nil, &REGION_NOID, nil, nil)
+	bridge.Sessions[sess.TableKey()] = sess
+	if err := sess.connectToElko(); err != nil {
+		t.Fatalf("connectToElko: %v", err)
+	}
+	return sess, clientRC
+}
+
+func TestRecover_SilentReconnectAfterElkoDisconnect(t *testing.T) {
+	elko := newFakeElkoListener(t)
+	sess, clientRC := recoverTestSession(t, elko.addr(), "context-Downtown_5f")
+
+	// Wait for the initial dial to register.
+	waitForRecoveryCondition(t, 2*time.Second, "initial elko dial", func() bool {
+		return elko.acceptedCount() >= 1
+	})
+
+	// Simulate habiproxy closing the bridge-side TCP (the real-world
+	// trigger). elkoReader hits EOF and schedules recovery.
+	// closeAllAccepted clears the listener's tracked accept list, so
+	// after recovery successfully re-dials we should see exactly one
+	// fresh accept land.
+	elko.closeAllAccepted()
+	waitForRecoveryCondition(t, 5*time.Second, "recovery re-dial", func() bool {
+		return elko.acceptedCount() >= 1
+	})
+
+	// Client TCP must stay open through the recovery — the whole
+	// point of silent reconnect is to NOT surface the disconnect to
+	// the client.
+	clientRC.mu.Lock()
+	closed := clientRC.closed
+	clientRC.mu.Unlock()
+	if closed {
+		t.Errorf("client conn should NOT be closed after silent reconnect")
+	}
+
+	// Session should still be in the bridge's map.
+	sess.bridge.sessionsMutex.Lock()
+	_, present := sess.bridge.Sessions[sess.TableKey()]
+	sess.bridge.sessionsMutex.Unlock()
+	if !present {
+		t.Errorf("session removed from bridge after silent reconnect — should have stayed")
+	}
+
+	// Cleanup
+	sess.Close()
+}
+
+func TestRecover_FailsOpenWhenDialKeepsFailing(t *testing.T) {
+	// Listener that's never reachable.
+	elko := newFakeElkoListener(t)
+	addr := elko.addr()
+	sess, clientRC := recoverTestSession(t, addr, "context-Downtown_5f")
+	waitForRecoveryCondition(t, 2*time.Second, "initial elko dial", func() bool {
+		return elko.acceptedCount() >= 1
+	})
+
+	// Stop the listener so future dials fail.
+	_ = elko.ln.Close()
+	elko.closeAllAccepted()
+
+	// Recovery should exhaust retries and tear down the session.
+	waitForRecoveryCondition(t, 20*time.Second, "session removed after dial exhaustion", func() bool {
+		sess.bridge.sessionsMutex.Lock()
+		defer sess.bridge.sessionsMutex.Unlock()
+		_, present := sess.bridge.Sessions[sess.TableKey()]
+		return !present
+	})
+
+	// And the client TCP gets closed so HabiBot reconnects.
+	waitForRecoveryCondition(t, 2*time.Second, "client closed after teardown", func() bool {
+		clientRC.mu.Lock()
+		defer clientRC.mu.Unlock()
+		return clientRC.closed
+	})
+}
+
+func TestRecover_PlannedCloseDoesNotTriggerRecovery(t *testing.T) {
+	// When Close() is what flipped doneClosed, the elkoReader EOF
+	// must NOT spin up a doomed recovery goroutine that races the
+	// Close().
+	elko := newFakeElkoListener(t)
+	sess, _ := recoverTestSession(t, elko.addr(), "context-Downtown_5f")
+	waitForRecoveryCondition(t, 2*time.Second, "initial dial", func() bool {
+		return elko.acceptedCount() >= 1
+	})
+
+	initialAccepts := elko.acceptedCount()
+
+	// Planned close. recoverElkoConnection should see doneClosed and
+	// no-op; no second dial should land at the listener.
+	sess.Close()
+
+	// Brief settle — if recovery spuriously fires, we'd see another
+	// accept here.
+	time.Sleep(500 * time.Millisecond)
+	if got := elko.acceptedCount(); got != initialAccepts {
+		t.Errorf("recovery dialed during planned close (accepts: %d → %d)", initialAccepts, got)
+	}
+}

--- a/bridge_v2/bridge/json_passthrough_test.go
+++ b/bridge_v2/bridge/json_passthrough_test.go
@@ -92,9 +92,9 @@ func newJsonTestSession(t *testing.T, clientIn []byte) (*ClientSession, *recordi
 	sess.contentsVector = NewContentsVector(sess, nil, &REGION_NOID, nil, nil)
 	sess.wg.Add(1)
 	sess.elkoWg.Add(1)
-	sess.elkoConnInitWg.Add(1)
-	go sess.elkoWriter()
-	sess.elkoConnInitWg.Wait()
+	writerReady := make(chan struct{}, 1)
+	go sess.elkoWriter(writerReady)
+	<-writerReady
 	t.Cleanup(func() {
 		sess.closeChannels()
 		sess.elkoWg.Wait()


### PR DESCRIPTION
## Summary

PR #507's approach to issue #505 — tear down the session on elko-side EOF so HabiBot reconnects — broke region transit for every session (binary AND JSON-passthrough). Verified live with \`//g sagebot\`: elko sends \`changeContext\` then closes the server-side, habiproxy closes the bridge-side a few ms later (\`pushserver/habiproxy/session.js:251\`), elkoReader hits EOF, the #507 teardown fires, and both Steve's session and SageBot get yanked mid-transit. The C64 hangs in an infinite region transfer; SageBot's HabiBot takes ~3 min to notice the dropped TCP and reconnect.

This PR replaces teardown with a silent reconnect: drain the old reader/writer, redial habiproxy with backoff, and re-enter the most recent context. If every dial attempt fails (true container outage), fall back to \`c.Close()\` — preserving #505's original goal of surfacing the disconnect to HabiBot's retry loop when habiproxy is genuinely gone.

Closes #505. Supersedes #507 — please close that one.

## What changed

- New \`recoverElkoConnection()\` orchestrator: idempotent via \`elkoRecovering\` guard so parallel reader-EOF / writer-error firings coalesce; bounded retry (5 dials, exponential backoff to 4s); on success re-enters \`c.nextRegion\` (in-flight transit) or \`c.regionRef\` (steady state); on exhaustion does \`go c.Close()\`.
- \`elkoReader\` / \`elkoWriter\` on unplanned error: \`go c.recoverElkoConnection()\` instead of \`go c.Close()\`. Planned teardown (\`doneClosed\` set) still exits silently.
- Replaced \`elkoConnInitWg\` (shared sync.WaitGroup reused across connect cycles, race-detector hostile) with per-call ready channels passed into \`elkoReader\` / \`elkoWriter\`. Removes the WaitGroup reuse hazard cleanly.

## Test plan

- [x] \`go vet ./...\` clean on Linux target
- [x] \`go test -race -count=1 ./...\` — full bridge_v2 suite passes (3 new tests + no regressions)
- [x] **Live verified:** Air hot-reloaded the change into the dev container; SageBot NEWREGION → elko EOF → \"Elko-side disconnect; attempting silent reconnect\" → make storm for the new region arrives on the SAME session_id → \`CAUGHT_UP_$\` + \`APPEARING_$\` confirm normal operation resumed. No client teardown, no HabiBot reconnect cycle.
- [ ] Production deploy: run \`//g sagebot\` from a C64 client and confirm transit completes without infinite-region-transfer hang
- [ ] Restart \`neohabitat-neohabitat-1\` container while bots are connected; confirm bots reconnect cleanly after the dial-retry exhaustion path triggers