### PR TITLE
bridge_v2 + habibots: region-transit and unmarshal resilience (#502, #505, #506)

### DIFF
--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -1320,13 +1320,32 @@ func (c *ClientSession) recoverElkoConnection() {
 	}
 	c.elkoWg.Wait()
 
-	// Decide which region to re-enter. nextRegion is set during an
-	// in-flight changeContext that hasn't been confirmed yet;
-	// regionRef is the avatar's last known live region.
-	region := c.nextRegion
+	// Decide which region to re-enter. Priority:
+	//   1. bridgeAutoEnteredContext — set in handleElkoMessageJson's
+	//      changeContext branch BEFORE enterContext wipes nextRegion,
+	//      so this is the only field that still names the in-flight
+	//      transit target after the elko-side disconnect that happens
+	//      right after a JSON-passthrough region change. Without this
+	//      branch the recovery falls back to c.regionRef (the OLD
+	//      region) and re-enters there — visible to the bot as "I
+	//      asked to walk south but ended up back where I started",
+	//      which then loops every wanderTick.
+	//   2. nextRegion — for the binary path where enterContext hasn't
+	//      run yet (it's gated on the client's MESSAGE_DESCRIBE).
+	//   3. regionRef — steady-state recovery (no in-flight transit).
+	//
+	// All three fields are written under c.stateMu (in
+	// handleElkoMessage / handleElkoMessageJson); read them under the
+	// same lock to keep the race detector happy and our view consistent.
+	c.stateMu.Lock()
+	region := c.bridgeAutoEnteredContext
+	if region == "" {
+		region = c.nextRegion
+	}
 	if region == "" {
 		region = c.regionRef
 	}
+	c.stateMu.Unlock()
 
 	var dialErr error
 	backoff := 250 * time.Millisecond

--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -89,7 +89,6 @@ type ClientSession struct {
 	done              chan struct{}
 	doneClosed        bool
 	elkoConn          net.Conn
-	elkoConnInitWg    sync.WaitGroup
 	elkoDone          chan struct{}
 	elkoDoneClosed    bool
 	elkoSendChan      chan *outboundElkoMessage
@@ -130,6 +129,14 @@ type ClientSession struct {
 	waitingForAvatarContents bool
 	wg                       sync.WaitGroup
 	who                      string
+
+	// elkoRecovering serializes silent-reconnect attempts triggered by
+	// elkoReader EOF and elkoWriter error firing in parallel — without
+	// the guard, two recovery goroutines race to close + redial the
+	// same elkoConn and leave the session with two live writer
+	// goroutines pulling from one elkoSendChan. Accessed with
+	// closeMutex held for cheap reuse of an existing mutex.
+	elkoRecovering bool
 
 	// restoredSession is true after RestoreSession has rebuilt this
 	// ClientSession from a snapshot — i.e. we are about to re-enter the
@@ -225,12 +232,14 @@ func (c *ClientSession) closeChannels() {
 	}
 }
 
-func (c *ClientSession) elkoReader() {
+func (c *ClientSession) elkoReader(ready chan<- struct{}) {
 	defer c.elkoWg.Done()
 	defer c.wg.Done()
 	reader := bufio.NewReader(c.elkoConn)
 	tp := textproto.NewReader(reader)
-	c.elkoConnInitWg.Done()
+	if ready != nil {
+		ready <- struct{}{}
+	}
 	for {
 		nextLine, err := tp.ReadLineBytes()
 		// Cheap one-shot teardown probe shared by the read-error
@@ -244,9 +253,29 @@ func (c *ClientSession) elkoReader() {
 		if err != nil {
 			if closing {
 				c.log.Debug().Err(err).Msg("Elko reader exiting (teardown)")
-			} else {
-				c.log.Error().Err(err).Msg("Error reading message from Elko")
+				return
 			}
+			// Unplanned elko-side disconnect. The common cause is NOT
+			// elko actually dying — it's habiproxy cycling the
+			// bridge-side TCP after elko closed the server-side
+			// following a normal changeContext (pushserver/habiproxy/
+			// session.js:251 disconnectProxy fires after elko sends
+			// changeContext, ~ms before the next entercontext could
+			// reach it). Silently returning here leaves the next
+			// elkoWriter write to fail against the dead conn, the
+			// entercontext for the new region never reaches elko, and
+			// the client sits forever in an infinite region transfer
+			// (issue #505).
+			//
+			// Schedule a silent reconnect to habiproxy on a fresh
+			// goroutine; if it succeeds we resume operations on the
+			// existing client TCP and the region transit completes
+			// normally. If the reconnect cycle gives up (true
+			// container outage), the recovery path tears the bot's
+			// session down so HabiBot's reconnect-with-backoff loop
+			// kicks in cleanly.
+			c.log.Warn().Err(err).Msg("Elko-side disconnect; attempting silent reconnect")
+			go c.recoverElkoConnection()
 			return
 		}
 		if len(nextLine) == 0 {
@@ -277,10 +306,12 @@ func (c *ClientSession) elkoReader() {
 	}
 }
 
-func (c *ClientSession) elkoWriter() {
+func (c *ClientSession) elkoWriter(ready chan<- struct{}) {
 	defer c.elkoWg.Done()
 	defer c.wg.Done()
-	c.elkoConnInitWg.Done()
+	if ready != nil {
+		ready <- struct{}{}
+	}
 	for {
 		select {
 		case outbound := <-c.elkoSendChan:
@@ -326,7 +357,22 @@ func (c *ClientSession) elkoWriter() {
 				outbound.writeDone <- err
 			}
 			if err != nil {
-				c.log.Error().Err(err).Str("raw", string(msgBytes)).Msg("Error writing Elko message")
+				// Same teardown-vs-recover decision as elkoReader: most
+				// "Write failed" events here are habiproxy already
+				// having closed our bridge-side TCP after a
+				// changeContext cycle. Drop into the silent reconnect
+				// path so the post-recovery enterContext gets re-sent
+				// rather than dropped. The closing probe keeps planned
+				// teardown silent (Close() flips doneClosed first).
+				c.closeMutex.Lock()
+				closing := c.doneClosed
+				c.closeMutex.Unlock()
+				if !closing {
+					c.log.Warn().Err(err).Str("raw", string(msgBytes)).Msg("Elko write failed; attempting silent reconnect")
+					go c.recoverElkoConnection()
+				} else {
+					c.log.Debug().Err(err).Msg("Elko writer exiting after write error (teardown)")
+				}
 				span.RecordError(err)
 				span.End()
 				return
@@ -1201,10 +1247,16 @@ func (c *ClientSession) connectToElko() error {
 	// goroutine, before they're started, to satisfy sync.WaitGroup's contract.
 	c.wg.Add(2)
 	c.elkoWg.Add(2)
-	c.elkoConnInitWg.Add(2)
-	go c.elkoReader()
-	go c.elkoWriter()
-	c.elkoConnInitWg.Wait()
+	// Per-call ready channels instead of a shared WaitGroup — reconnect
+	// cycles would otherwise have Add and a previous Wait race without
+	// explicit happens-before (race detector flags this; in pathological
+	// scheduling it can deadlock the WaitGroup mid-reuse).
+	readerReady := make(chan struct{}, 1)
+	writerReady := make(chan struct{}, 1)
+	go c.elkoReader(readerReady)
+	go c.elkoWriter(writerReady)
+	<-readerReady
+	<-writerReady
 	return nil
 }
 
@@ -1223,6 +1275,96 @@ func (c *ClientSession) reconnectToElko(immediate bool, context string) {
 	}
 	if immediate {
 		c.enterContext(context)
+	}
+}
+
+// recoverElkoConnection is the silent-reconnect path invoked from
+// elkoReader / elkoWriter when the bridge-side TCP to habiproxy
+// drops mid-session. The typical trigger isn't a real outage — it's
+// habiproxy's disconnectProxy() firing after elko closed its
+// server-side TCP at the end of a normal changeContext, which races
+// the bridge's followup entercontext.
+//
+// Recovery is bounded: dial habiproxy a few times with backoff, and
+// if every attempt fails (real container outage, network blip
+// extending past ~30s) fall back to tearing down the bot session via
+// Close() — that preserves the issue #505 idle-bot-during-restart
+// recovery behavior by surfacing the disconnect to HabiBot's
+// reconnect loop. On success the bridge re-enters the most recent
+// context so the in-flight region transit completes.
+//
+// Idempotent: parallel firings from elkoReader EOF and elkoWriter
+// error coalesce via the elkoRecovering guard, so we don't end up
+// with two live writer goroutines pulling from one elkoSendChan.
+func (c *ClientSession) recoverElkoConnection() {
+	c.closeMutex.Lock()
+	if c.doneClosed || c.elkoRecovering {
+		c.closeMutex.Unlock()
+		return
+	}
+	c.elkoRecovering = true
+	c.closeMutex.Unlock()
+	defer func() {
+		c.closeMutex.Lock()
+		c.elkoRecovering = false
+		c.closeMutex.Unlock()
+	}()
+
+	// Tear down the current reader/writer goroutines cleanly. Close
+	// the conn so any blocked read returns, signal the writer's done
+	// channel non-blocking, wait for both to exit.
+	_ = c.elkoConn.Close()
+	select {
+	case c.elkoDone <- struct{}{}:
+	default:
+	}
+	c.elkoWg.Wait()
+
+	// Decide which region to re-enter. nextRegion is set during an
+	// in-flight changeContext that hasn't been confirmed yet;
+	// regionRef is the avatar's last known live region.
+	region := c.nextRegion
+	if region == "" {
+		region = c.regionRef
+	}
+
+	var dialErr error
+	backoff := 250 * time.Millisecond
+	for attempt := 1; attempt <= 5; attempt++ {
+		c.closeMutex.Lock()
+		bailingOut := c.doneClosed
+		c.closeMutex.Unlock()
+		if bailingOut {
+			return
+		}
+		if dialErr = c.connectToElko(); dialErr == nil {
+			c.log.Info().Int("attempt", attempt).Str("region", region).
+				Msg("Silent reconnect to Elko succeeded")
+			break
+		}
+		c.log.Warn().Err(dialErr).Int("attempt", attempt).Dur("backoff", backoff).
+			Msg("Silent reconnect to Elko failed; will retry")
+		time.Sleep(backoff)
+		if backoff < 4*time.Second {
+			backoff *= 2
+		}
+	}
+	if dialErr != nil {
+		c.log.Error().Err(dialErr).
+			Msg("Silent reconnect cycle exhausted; tearing down session for HabiBot to retry")
+		go c.Close()
+		return
+	}
+
+	// Re-enter the region the bot/client was in (or moving to). For
+	// JSON-passthrough this drives the bot back into the world
+	// immediately. For binary clients this preempts the client's
+	// MESSAGE_DESCRIBE so the new region's make storm starts flowing
+	// without waiting on the C64 to notice the timeout — which it
+	// often doesn't, hence the historical "infinite region transfer"
+	// symptom.
+	if region != "" {
+		c.enterContext(region)
 	}
 }
 
@@ -2410,10 +2552,12 @@ func (c *ClientSession) StartRestored() {
 		// Start Elko reader/writer goroutines on the inherited connection.
 		c.wg.Add(2)
 		c.elkoWg.Add(2)
-		c.elkoConnInitWg.Add(2)
-		go c.elkoReader()
-		go c.elkoWriter()
-		c.elkoConnInitWg.Wait()
+		readerReady := make(chan struct{}, 1)
+		writerReady := make(chan struct{}, 1)
+		go c.elkoReader(readerReady)
+		go c.elkoWriter(writerReady)
+		<-readerReady
+		<-writerReady
 
 		c.log.Info().Msg("StartRestored: elko goroutines ready")
 

--- a/bridge_v2/bridge/elko_recover_test.go
+++ b/bridge_v2/bridge/elko_recover_test.go
@@ -1,0 +1,222 @@
+package bridge
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Regression coverage for the silent-reconnect path on elko-side
+// disconnect (issue #505).
+//
+// The trigger in production is habiproxy closing the bridge-side TCP
+// after elko closed the server-side following a normal changeContext.
+// Pre-fix the bridge silently let elkoReader exit and the next
+// entercontext write fell into the void, leaving the client stuck in
+// an infinite region transfer. The fix reconnects to a fresh elko
+// dial and re-enters the most recent context so transit completes.
+
+// fakeElkoListener is a minimal accept-and-immediately-close TCP
+// server used to drive ClientSession's reconnect logic. Successful
+// dials keep the socket open until the test ends so the new
+// elkoReader/Writer goroutines have something to read from.
+type fakeElkoListener struct {
+	ln       net.Listener
+	mu       sync.Mutex
+	accepted []net.Conn
+}
+
+func newFakeElkoListener(t *testing.T) *fakeElkoListener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	f := &fakeElkoListener{ln: ln}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			f.mu.Lock()
+			f.accepted = append(f.accepted, conn)
+			f.mu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		f.mu.Lock()
+		for _, c := range f.accepted {
+			_ = c.Close()
+		}
+		f.mu.Unlock()
+		_ = ln.Close()
+	})
+	return f
+}
+
+func (f *fakeElkoListener) addr() string { return f.ln.Addr().String() }
+
+// waitForRecoveryCondition is a tiny polling helper used by the
+// recovery tests. Kept local to avoid colliding with a similarly-
+// named helper that lands on the parallel issue-502 branch.
+func waitForRecoveryCondition(t *testing.T, timeout time.Duration, name string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", name)
+}
+
+func (f *fakeElkoListener) acceptedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.accepted)
+}
+
+func (f *fakeElkoListener) closeAllAccepted() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.accepted {
+		_ = c.Close()
+	}
+	f.accepted = f.accepted[:0]
+}
+
+// recoverTestSession wires up a ClientSession with a real-ish elko
+// connection dialed against the fake listener. The client side is a
+// recordingConn so we can assert the client TCP stays open through
+// the silent reconnect.
+func recoverTestSession(t *testing.T, elkoAddr string, regionRef string) (*ClientSession, *recordingConn) {
+	t.Helper()
+	bridge := &Bridge{
+		DataRate: 1 << 20,
+		elkoHost: elkoAddr,
+		Sessions: make(map[string]*ClientSession),
+	}
+	clientRC := newRecordingConn(nil)
+	cc := NewClientConnection(bridge, clientRC)
+	sess := &ClientSession{
+		NoidClassList:   []uint8{},
+		NoidContents:    make(map[uint8][]uint8),
+		RefToNoid:       make(map[string]uint8),
+		bridge:          bridge,
+		clientConn:      cc,
+		clientReader:    bufio.NewReader(cc),
+		ctx:             context.Background(),
+		done:            make(chan struct{}),
+		elkoDone:        make(chan struct{}),
+		elkoSendChan:    make(chan *outboundElkoMessage, MaxClientMessages),
+		jsonPassthrough: true,
+		objects:         make(map[uint8]*ElkoMessage),
+		regionRef:       regionRef,
+		userRef:         "user-test",
+	}
+	sess.contentsVector = NewContentsVector(sess, nil, &REGION_NOID, nil, nil)
+	bridge.Sessions[sess.TableKey()] = sess
+	if err := sess.connectToElko(); err != nil {
+		t.Fatalf("connectToElko: %v", err)
+	}
+	return sess, clientRC
+}
+
+func TestRecover_SilentReconnectAfterElkoDisconnect(t *testing.T) {
+	elko := newFakeElkoListener(t)
+	sess, clientRC := recoverTestSession(t, elko.addr(), "context-Downtown_5f")
+
+	// Wait for the initial dial to register.
+	waitForRecoveryCondition(t, 2*time.Second, "initial elko dial", func() bool {
+		return elko.acceptedCount() >= 1
+	})
+
+	// Simulate habiproxy closing the bridge-side TCP (the real-world
+	// trigger). elkoReader hits EOF and schedules recovery.
+	// closeAllAccepted clears the listener's tracked accept list, so
+	// after recovery successfully re-dials we should see exactly one
+	// fresh accept land.
+	elko.closeAllAccepted()
+	waitForRecoveryCondition(t, 5*time.Second, "recovery re-dial", func() bool {
+		return elko.acceptedCount() >= 1
+	})
+
+	// Client TCP must stay open through the recovery — the whole
+	// point of silent reconnect is to NOT surface the disconnect to
+	// the client.
+	clientRC.mu.Lock()
+	closed := clientRC.closed
+	clientRC.mu.Unlock()
+	if closed {
+		t.Errorf("client conn should NOT be closed after silent reconnect")
+	}
+
+	// Session should still be in the bridge's map.
+	sess.bridge.sessionsMutex.Lock()
+	_, present := sess.bridge.Sessions[sess.TableKey()]
+	sess.bridge.sessionsMutex.Unlock()
+	if !present {
+		t.Errorf("session removed from bridge after silent reconnect — should have stayed")
+	}
+
+	// Cleanup
+	sess.Close()
+}
+
+func TestRecover_FailsOpenWhenDialKeepsFailing(t *testing.T) {
+	// Listener that's never reachable.
+	elko := newFakeElkoListener(t)
+	addr := elko.addr()
+	sess, clientRC := recoverTestSession(t, addr, "context-Downtown_5f")
+	waitForRecoveryCondition(t, 2*time.Second, "initial elko dial", func() bool {
+		return elko.acceptedCount() >= 1
+	})
+
+	// Stop the listener so future dials fail.
+	_ = elko.ln.Close()
+	elko.closeAllAccepted()
+
+	// Recovery should exhaust retries and tear down the session.
+	waitForRecoveryCondition(t, 20*time.Second, "session removed after dial exhaustion", func() bool {
+		sess.bridge.sessionsMutex.Lock()
+		defer sess.bridge.sessionsMutex.Unlock()
+		_, present := sess.bridge.Sessions[sess.TableKey()]
+		return !present
+	})
+
+	// And the client TCP gets closed so HabiBot reconnects.
+	waitForRecoveryCondition(t, 2*time.Second, "client closed after teardown", func() bool {
+		clientRC.mu.Lock()
+		defer clientRC.mu.Unlock()
+		return clientRC.closed
+	})
+}
+
+func TestRecover_PlannedCloseDoesNotTriggerRecovery(t *testing.T) {
+	// When Close() is what flipped doneClosed, the elkoReader EOF
+	// must NOT spin up a doomed recovery goroutine that races the
+	// Close().
+	elko := newFakeElkoListener(t)
+	sess, _ := recoverTestSession(t, elko.addr(), "context-Downtown_5f")
+	waitForRecoveryCondition(t, 2*time.Second, "initial dial", func() bool {
+		return elko.acceptedCount() >= 1
+	})
+
+	initialAccepts := elko.acceptedCount()
+
+	// Planned close. recoverElkoConnection should see doneClosed and
+	// no-op; no second dial should land at the listener.
+	sess.Close()
+
+	// Brief settle — if recovery spuriously fires, we'd see another
+	// accept here.
+	time.Sleep(500 * time.Millisecond)
+	if got := elko.acceptedCount(); got != initialAccepts {
+		t.Errorf("recovery dialed during planned close (accepts: %d → %d)", initialAccepts, got)
+	}
+}

--- a/bridge_v2/bridge/elko_recover_test.go
+++ b/bridge_v2/bridge/elko_recover_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -195,6 +196,59 @@ func TestRecover_FailsOpenWhenDialKeepsFailing(t *testing.T) {
 		defer clientRC.mu.Unlock()
 		return clientRC.closed
 	})
+}
+
+func TestRecover_PrefersBridgeAutoEnteredContextOverRegionRef(t *testing.T) {
+	// Regression for the "Sage keeps returning to the region they're
+	// in" bug:
+	//   1. Bot in Downtown_5f does NEWREGION south.
+	//   2. Elko replies changeContext context-Downtown_6f.
+	//   3. handleElkoMessageJson sets bridgeAutoEnteredContext = "..._6f",
+	//      then calls enterContext, which WIPES c.nextRegion.
+	//   4. Elko closes its server-side; habiproxy disconnects the
+	//      bridge-side; elkoReader EOFs and fires recovery.
+	//   5. Recovery must re-enter Downtown_6f (the in-flight transit
+	//      target), NOT Downtown_5f (the stale regionRef).
+	elko := newFakeElkoListener(t)
+	sess, _ := recoverTestSession(t, elko.addr(), "context-Downtown_5f")
+	sess.stateMu.Lock()
+	sess.bridgeAutoEnteredContext = "context-Downtown_6f"
+	sess.stateMu.Unlock()
+	waitForRecoveryCondition(t, 2*time.Second, "initial dial", func() bool {
+		return elko.acceptedCount() >= 1
+	})
+
+	// Drain the initial accept's elkoSendChan so we can observe what
+	// recovery sends post-reconnect.
+	elko.closeAllAccepted()
+	waitForRecoveryCondition(t, 5*time.Second, "recovery re-dial", func() bool {
+		return elko.acceptedCount() >= 1
+	})
+
+	// Look for the entercontext that recovery sent after dialing.
+	// connectToElko started a fresh elkoWriter; recovery's
+	// enterContext queues to elkoSendChan, the writer marshals and
+	// writes to the new conn. Pull bytes off the accepted listener
+	// and confirm the target context is Downtown_6f, NOT _5f.
+	elko.mu.Lock()
+	conn := elko.accepted[0]
+	elko.mu.Unlock()
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	buf := make([]byte, 1024)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read from recovered conn: %v", err)
+	}
+	got := string(buf[:n])
+	if !strings.Contains(got, "context-Downtown_6f") {
+		t.Errorf("recovery re-entered wrong context — wanted Downtown_6f, got: %s", got)
+	}
+	if strings.Contains(got, "context-Downtown_5f") {
+		t.Errorf("recovery re-entered stale regionRef Downtown_5f: %s", got)
+	}
+	sess.Close()
 }
 
 func TestRecover_PlannedCloseDoesNotTriggerRecovery(t *testing.T) {

--- a/bridge_v2/bridge/issue_502_test.go
+++ b/bridge_v2/bridge/issue_502_test.go
@@ -156,6 +156,68 @@ func TestMarshal_ContainerNoidStillEmitsCamelCaseForElkoInbound(t *testing.T) {
 	}
 }
 
+func TestUnmarshal_PutBroadcastWithUnassignedNoidNarrowsToGhost(t *testing.T) {
+	// When a fresh JSON-passthrough avatar (whose region noid hasn't
+	// been assigned) does a PUT, elko broadcasts the resulting PUT$
+	// with the avatar's UNASSIGNED_NOID (256) in the top-level noid
+	// slot. Pre-fix, the whole message dropped on the *uint8 unmarshal;
+	// post-fix, 256 narrows to GHOST_NOID (255) so the broadcast
+	// survives and gets relayed.
+	raw := []byte(`{"type":"neighbor","noid":256,"op":"PUT$","obj":256,"cont":0,"x":60,"y":130,"how":0,"orient":16}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Noid == nil || *msg.Noid != GHOST_NOID {
+		t.Errorf("Noid = %v, want %d (GHOST_NOID)", msg.Noid, GHOST_NOID)
+	}
+	if msg.ObjectNoid == nil || *msg.ObjectNoid != GHOST_NOID {
+		t.Errorf("ObjectNoid = %v, want %d (GHOST_NOID — obj=256 narrows the same way)", msg.ObjectNoid, GHOST_NOID)
+	}
+}
+
+func TestUnmarshal_GoawayBroadcastWithUnassignedTargetNarrowsToGhost(t *testing.T) {
+	// GOAWAY_$ broadcasts the departing avatar's noid in the `target`
+	// slot. Same UNASSIGNED_NOID problem; same fix.
+	raw := []byte(`{"type":"broadcast","noid":0,"op":"GOAWAY_$","target":256}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Target == nil || *msg.Target != GHOST_NOID {
+		t.Errorf("Target = %v, want %d (GHOST_NOID)", msg.Target, GHOST_NOID)
+	}
+}
+
+func TestUnmarshal_NoidAndTargetNormalValues(t *testing.T) {
+	// Regular noid / target values (0..255) must pass through unchanged
+	// — the narrowing path should only fold the 256 sentinel.
+	raw := []byte(`{"type":"neighbor","noid":19,"op":"SPEAK$","target":42}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Noid == nil || *msg.Noid != 19 {
+		t.Errorf("Noid = %v, want 19", msg.Noid)
+	}
+	if msg.Target == nil || *msg.Target != 42 {
+		t.Errorf("Target = %v, want 42", msg.Target)
+	}
+}
+
+func TestUnmarshal_NoidOverflowAboveUnassignedRejected(t *testing.T) {
+	// 257+ isn't a documented sentinel and isn't a valid wire shape.
+	// The narrowing path uses uint16 so values up to 65535 unmarshal
+	// fine; 65537 and above would fail. We don't strictly need to
+	// reject 257..65535, but verify malformed input (non-numeric) does
+	// still return an error rather than silently swallowing it.
+	raw := []byte(`{"noid":"not a number"}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err == nil {
+		t.Errorf("expected error for non-numeric noid, got nil with Noid=%v", msg.Noid)
+	}
+}
+
 func TestUnmarshal_BodyShapesUnchanged(t *testing.T) {
 	// Sanity check: the existing body handling (object vs the bare-zero
 	// sentinel) is not regressed by the obj-handling addition.

--- a/bridge_v2/bridge/issue_502_test.go
+++ b/bridge_v2/bridge/issue_502_test.go
@@ -1,0 +1,204 @@
+package bridge
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Regression coverage for issue #502: ElkoMessage's `obj` field is
+// polymorphic on the wire — a bare noid integer in PUT$/THROW$
+// neighbor broadcasts, an embedded HabitatObject in make/HEREIS_$.
+// Previously the JSON unmarshaler dropped the whole message with
+// "json: cannot unmarshal number into Go struct field ... of type
+// bridge.HabitatObject" whenever Elko sent the bare-noid shape.
+
+func TestUnmarshal_PutBroadcastBareObjNoid(t *testing.T) {
+	// Real prod payload from issue #502.
+	raw := []byte(`{"type":"neighbor","noid":19,"op":"PUT$","obj":11,"cont":0,"x":38,"y":148,"how":0,"orient":17}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Obj != nil {
+		t.Errorf("Obj should be nil for bare-noid shape, got %+v", msg.Obj)
+	}
+	if msg.ObjectNoid == nil || *msg.ObjectNoid != 11 {
+		t.Errorf("ObjectNoid = %v, want 11", msg.ObjectNoid)
+	}
+	if msg.Op == nil || *msg.Op != "PUT$" {
+		t.Errorf("Op = %v, want PUT$", msg.Op)
+	}
+	if msg.Noid == nil || *msg.Noid != 19 {
+		t.Errorf("Noid = %v, want 19", msg.Noid)
+	}
+	if msg.Cont == nil || *msg.Cont != 0 {
+		t.Errorf("Cont = %v, want 0", msg.Cont)
+	}
+	if msg.X == nil || *msg.X != 38 || msg.Y == nil || *msg.Y != 148 {
+		t.Errorf("X/Y = %v/%v, want 38/148", msg.X, msg.Y)
+	}
+	if msg.How == nil || *msg.How != 0 {
+		t.Errorf("How = %v, want 0", msg.How)
+	}
+	if msg.Orient == nil || *msg.Orient != 17 {
+		t.Errorf("Orient = %v, want 17", msg.Orient)
+	}
+}
+
+func TestUnmarshal_ThrowBroadcastBareObjNoid(t *testing.T) {
+	// Same shape as PUT$ — HabitatMod.java:987 emits "obj" as bare noid.
+	raw := []byte(`{"type":"neighbor","noid":19,"op":"THROW$","obj":7,"x":100,"y":120,"hit":1}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.ObjectNoid == nil || *msg.ObjectNoid != 7 {
+		t.Errorf("ObjectNoid = %v, want 7", msg.ObjectNoid)
+	}
+	if msg.Hit == nil || *msg.Hit != 1 {
+		t.Errorf("Hit = %v, want 1", msg.Hit)
+	}
+}
+
+func TestUnmarshal_MakeWithEmbeddedObject(t *testing.T) {
+	// Object shape: must still decode into m.Obj as a full HabitatObject.
+	raw := []byte(`{"op":"make","to":"context-Downtown_5f","obj":{"type":"item","ref":"item-thing-1","name":"Thing","mods":[{"type":"Knick_knack","noid":42,"x":80,"y":120}]}}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Obj == nil {
+		t.Fatalf("Obj should be populated for object-shape payload")
+	}
+	if msg.Obj.Ref != "item-thing-1" {
+		t.Errorf("Obj.Ref = %q, want item-thing-1", msg.Obj.Ref)
+	}
+	if len(msg.Obj.Mods) != 1 || msg.Obj.Mods[0].Type == nil || *msg.Obj.Mods[0].Type != "Knick_knack" {
+		t.Errorf("Obj.Mods not decoded: %+v", msg.Obj.Mods)
+	}
+	if msg.ObjectNoid != nil {
+		t.Errorf("ObjectNoid should be nil for object-shape payload, got %v", msg.ObjectNoid)
+	}
+}
+
+func TestUnmarshal_ObjNullOrAbsentDoesNothing(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"absent", `{"op":"make","to":"region","noid":5}`},
+		{"null", `{"op":"make","to":"region","noid":5,"obj":null}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var msg ElkoMessage
+			if err := json.Unmarshal([]byte(c.raw), &msg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if msg.Obj != nil {
+				t.Errorf("Obj should be nil for %s", c.name)
+			}
+			if msg.ObjectNoid != nil {
+				t.Errorf("ObjectNoid should be nil for %s", c.name)
+			}
+		})
+	}
+}
+
+func TestUnmarshal_ChangeContainersBroadcast(t *testing.T) {
+	// Full CHANGE_CONTAINERS_$ broadcast from Avatar.java:1434. Elko
+	// emits snake_case `object_noid` and `container_noid`. ObjectNoid
+	// has always been correct via its standard json tag; ContainerNoid's
+	// struct tag is camelCase (matches the PUT verb's inbound shape),
+	// so the snake_case inbound was silently lost until the polymorphic
+	// container_noid routing was added.
+	raw := []byte(`{"type":"broadcast","noid":0,"op":"CHANGE_CONTAINERS_$","object_noid":42,"container_noid":7,"x":50,"y":140}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.ObjectNoid == nil || *msg.ObjectNoid != 42 {
+		t.Errorf("ObjectNoid = %v, want 42", msg.ObjectNoid)
+	}
+	if msg.ContainerNoid == nil || *msg.ContainerNoid != 7 {
+		t.Errorf("ContainerNoid = %v, want 7", msg.ContainerNoid)
+	}
+	if msg.X == nil || *msg.X != 50 || msg.Y == nil || *msg.Y != 140 {
+		t.Errorf("X/Y = %v/%v, want 50/140", msg.X, msg.Y)
+	}
+}
+
+func TestMarshal_ContainerNoidStillEmitsCamelCaseForElkoInbound(t *testing.T) {
+	// The outbound (bridge→elko) PUT verb needs `containerNoid`
+	// (camelCase) — that's what elko's @JSONMethod expects (HabitatMod.PUT).
+	// The struct tag remains camelCase to satisfy this. Verify that the
+	// new container_noid envelope handling didn't accidentally break
+	// the marshal path.
+	noid := uint8(3)
+	to := "item-foo"
+	op := "PUT"
+	msg := ElkoMessage{
+		To:            &to,
+		Op:            &op,
+		ContainerNoid: &noid,
+	}
+	out, err := json.Marshal(&msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `"containerNoid":3`) {
+		t.Errorf("marshal did not emit containerNoid camelCase key: %s", got)
+	}
+	if strings.Contains(got, `"container_noid"`) {
+		t.Errorf("marshal should NOT emit container_noid for outbound PUT: %s", got)
+	}
+}
+
+func TestUnmarshal_BodyShapesUnchanged(t *testing.T) {
+	// Sanity check: the existing body handling (object vs the bare-zero
+	// sentinel) is not regressed by the obj-handling addition.
+	cases := []struct {
+		name      string
+		raw       string
+		bodyNil   bool
+		bodyRef   string
+	}{
+		{
+			name:    "body object",
+			raw:     `{"op":"make","body":{"type":"User","ref":"user-foo","name":"Foo","mods":[{"type":"Avatar","noid":13}]}}`,
+			bodyRef: "user-foo",
+		},
+		{
+			name:    "body bare zero",
+			raw:     `{"op":"CORPORATE","body":0}`,
+			bodyNil: true,
+		},
+		{
+			name:    "body null",
+			raw:     `{"op":"DISCORPORATE","body":null}`,
+			bodyNil: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var msg ElkoMessage
+			if err := json.Unmarshal([]byte(c.raw), &msg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if c.bodyNil {
+				if msg.Body != nil {
+					t.Errorf("Body should be nil, got %+v", msg.Body)
+				}
+				return
+			}
+			if msg.Body == nil {
+				t.Fatalf("Body should be populated")
+			}
+			if msg.Body.Ref != c.bodyRef {
+				t.Errorf("Body.Ref = %q, want %q", msg.Body.Ref, c.bodyRef)
+			}
+		})
+	}
+}

--- a/bridge_v2/bridge/json_passthrough_test.go
+++ b/bridge_v2/bridge/json_passthrough_test.go
@@ -92,9 +92,9 @@ func newJsonTestSession(t *testing.T, clientIn []byte) (*ClientSession, *recordi
 	sess.contentsVector = NewContentsVector(sess, nil, &REGION_NOID, nil, nil)
 	sess.wg.Add(1)
 	sess.elkoWg.Add(1)
-	sess.elkoConnInitWg.Add(1)
-	go sess.elkoWriter()
-	sess.elkoConnInitWg.Wait()
+	writerReady := make(chan struct{}, 1)
+	go sess.elkoWriter(writerReady)
+	<-writerReady
 	t.Cleanup(func() {
 		sess.closeChannels()
 		sess.elkoWg.Wait()

--- a/bridge_v2/bridge/schema.go
+++ b/bridge_v2/bridge/schema.go
@@ -149,6 +149,17 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 	//     the field on the floor (issue #502 caught this via the PUT$
 	//     unmarshal failure, but it'd been silently latent for any
 	//     inventory-handoff CHANGE_CONTAINERS_$ broadcast as well).
+	//   - `noid` and `target` are typed *uint8 on the struct (matches
+	//     what binary-mode encoders need at write time), but Elko can
+	//     legitimately put 256 (UNASSIGNED_NOID) in either slot when
+	//     the broadcasting / targeted avatar has no assigned region noid
+	//     yet (e.g. a fresh JSON-passthrough avatar mid-PUT). The
+	//     standard unmarshal would fail with "cannot unmarshal number
+	//     256 into uint8" and the whole message would be dropped —
+	//     including the PUT$ / GOAWAY_$ broadcasts that other clients
+	//     in the region needed to see. Peel both as RawMessage and
+	//     narrow UNASSIGNED_NOID (256) → GHOST_NOID (255), matching how
+	//     Appearing and Speaker handle the same sentinel.
 	//
 	// Matches the legacy JS bridge, which tolerates either shape because
 	// JavaScript is dynamically typed.
@@ -157,6 +168,8 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 		Body          json.RawMessage `json:"body,omitempty"`
 		Obj           json.RawMessage `json:"obj,omitempty"`
 		ContainerNoid json.RawMessage `json:"container_noid,omitempty"`
+		Noid          json.RawMessage `json:"noid,omitempty"`
+		Target        json.RawMessage `json:"target,omitempty"`
 		*elkoMessage
 	}
 	aux := envelope{
@@ -194,11 +207,14 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 			// on. An explicit `object_noid` from the same message (if
 			// any) would have been set by the standard unmarshal above;
 			// re-setting it here from `obj` keeps the two consistent.
-			var noid uint8
-			if err := json.Unmarshal(aux.Obj, &noid); err != nil {
-				return fmt.Errorf("parsing elko message obj as noid: %w", err)
+			// Use the same UNASSIGNED_NOID→GHOST_NOID narrowing as Noid /
+			// Target — a fresh JSON-passthrough avatar mid-PUT broadcasts
+			// `obj:256` for an unbound-noid object.
+			narrowed, err := narrowNoidField(aux.Obj, "obj")
+			if err != nil {
+				return err
 			}
-			m.ObjectNoid = &noid
+			m.ObjectNoid = narrowed
 		}
 	}
 
@@ -209,7 +225,44 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 		}
 		m.ContainerNoid = &noid
 	}
+
+	// noid and target may carry UNASSIGNED_NOID (256), which doesn't fit
+	// in the *uint8 schema fields. Narrow to GHOST_NOID (255) on the way
+	// in — matches the Appearing/Speaker convention and downstream
+	// encoders treat 255 as "the ghost slot" so the binary path stays
+	// internally consistent.
+	if narrowed, err := narrowNoidField(aux.Noid, "noid"); err != nil {
+		return err
+	} else if narrowed != nil {
+		m.Noid = narrowed
+	}
+	if narrowed, err := narrowNoidField(aux.Target, "target"); err != nil {
+		return err
+	} else if narrowed != nil {
+		m.Target = narrowed
+	}
+
 	return nil
+}
+
+// narrowNoidField decodes a JSON noid-shaped field into a *uint8,
+// folding the elko UNASSIGNED_NOID (256) sentinel down to GHOST_NOID
+// (255). Returns (nil, nil) when the raw is absent or explicitly null.
+func narrowNoidField(raw json.RawMessage, name string) (*uint8, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var wide uint16
+	if err := json.Unmarshal(raw, &wide); err != nil {
+		return nil, fmt.Errorf("parsing elko message %s: %w", name, err)
+	}
+	var narrow uint8
+	if wide == UNASSIGNED_NOID {
+		narrow = GHOST_NOID
+	} else {
+		narrow = uint8(wide)
+	}
+	return &narrow, nil
 }
 
 func (e *ElkoMessage) String() string {

--- a/bridge_v2/bridge/schema.go
+++ b/bridge_v2/bridge/schema.go
@@ -125,16 +125,38 @@ type ElkoMessage struct {
 }
 
 func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
-	// Elko sends `"body":0` as a no-body sentinel in CORPORATE /
-	// DISCORPORATE replies (and anywhere else the body slot is empty),
-	// but Body is typed *HabitatObject so a bare `0` would fail to
-	// unmarshal. Peel Body off as a RawMessage and only decode it into
-	// a HabitatObject if it actually looks like an object. Matches the
-	// legacy JS bridge, which tolerates o.body being numeric 0 because
+	// Elko's wire format for several fields is polymorphic OR uses a
+	// different key on the inbound (server→bridge) path than the
+	// outbound (bridge→server) path. We can't capture that with a
+	// single struct tag, so we peel the affected fields as RawMessage
+	// and route them by shape / source:
+	//
+	//   - `body` is either an embedded HabitatObject (make, HEREIS_$) or
+	//     the bare integer 0 (CORPORATE / DISCORPORATE replies — no body).
+	//   - `obj` is either an embedded HabitatObject (make, HEREIS_$) or
+	//     a bare noid integer (PUT$ / THROW$ neighbor broadcasts — see
+	//     HabitatMod.java:828, :987). In the bare-noid case the value is
+	//     the noid of the object being put down / thrown, which the
+	//     downstream handlers read as `*o.ObjectNoid` (the same Go field
+	//     CHANGE_CONTAINERS_$ populates via the `object_noid` key).
+	//   - `container_noid` (snake_case) is what elko emits on the
+	//     CHANGE_CONTAINERS_$ broadcast (Avatar.java:1436). The
+	//     ContainerNoid struct tag is `containerNoid` (camelCase) because
+	//     that's what elko expects on the inbound PUT verb
+	//     (HabitatMod.PUT @JSONMethod). Same Go field, different wire
+	//     keys in each direction — route the snake_case key into
+	//     ContainerNoid manually so CHANGE_CONTAINERS_$ no longer drops
+	//     the field on the floor (issue #502 caught this via the PUT$
+	//     unmarshal failure, but it'd been silently latent for any
+	//     inventory-handoff CHANGE_CONTAINERS_$ broadcast as well).
+	//
+	// Matches the legacy JS bridge, which tolerates either shape because
 	// JavaScript is dynamically typed.
 	type elkoMessage ElkoMessage
 	type envelope struct {
-		Body json.RawMessage `json:"body,omitempty"`
+		Body          json.RawMessage `json:"body,omitempty"`
+		Obj           json.RawMessage `json:"obj,omitempty"`
+		ContainerNoid json.RawMessage `json:"container_noid,omitempty"`
 		*elkoMessage
 	}
 	aux := envelope{
@@ -147,6 +169,7 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 		return err
 	}
 	*m = ElkoMessage(*aux.elkoMessage)
+
 	body := string(aux.Body)
 	if len(body) > 0 && body != "0" && body != "null" {
 		var ho HabitatObject
@@ -154,6 +177,37 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 			return fmt.Errorf("parsing elko message body: %w", err)
 		}
 		m.Body = &ho
+	}
+
+	if len(aux.Obj) > 0 && string(aux.Obj) != "null" {
+		switch aux.Obj[0] {
+		case '{':
+			var ho HabitatObject
+			if err := json.Unmarshal(aux.Obj, &ho); err != nil {
+				return fmt.Errorf("parsing elko message obj: %w", err)
+			}
+			m.Obj = &ho
+		default:
+			// Bare integer noid (PUT$/THROW$). Decode into ObjectNoid so
+			// the existing ServerOps handlers Just Work — they already
+			// read *o.ObjectNoid for the noid of the object being acted
+			// on. An explicit `object_noid` from the same message (if
+			// any) would have been set by the standard unmarshal above;
+			// re-setting it here from `obj` keeps the two consistent.
+			var noid uint8
+			if err := json.Unmarshal(aux.Obj, &noid); err != nil {
+				return fmt.Errorf("parsing elko message obj as noid: %w", err)
+			}
+			m.ObjectNoid = &noid
+		}
+	}
+
+	if len(aux.ContainerNoid) > 0 && string(aux.ContainerNoid) != "null" {
+		var noid uint8
+		if err := json.Unmarshal(aux.ContainerNoid, &noid); err != nil {
+			return fmt.Errorf("parsing elko message container_noid: %w", err)
+		}
+		m.ContainerNoid = &noid
 	}
 	return nil
 }

--- a/habibots/habibot.js
+++ b/habibots/habibot.js
@@ -394,6 +394,14 @@ class HabiBot {
   newRegion(direction, timeoutMillis) {
     const self = this
     const timeout = typeof timeoutMillis === 'number' ? timeoutMillis : 15000
+    // Capture the region we're leaving BEFORE the send. enteredRegion
+    // fires from every `make ... you:true` — including the one that
+    // arrives after a silent reconnect's re-enter of the SAME context
+    // (bridge_v2 issue #505 recovery). Without this guard the listener
+    // resolves prematurely on the same-region re-enter, the caller
+    // thinks the transit succeeded, and the bot appears to keep
+    // walking but never actually leaves the room.
+    const startRegion = this._scanForCurrentRegionRef()
     // Pre-register the arrival listener BEFORE the wire write, so we
     // can't race against an unusually fast server (changeContext +
     // make storm + `you:true` arriving before the .then chain attaches).
@@ -402,17 +410,44 @@ class HabiBot {
         self._removeOnce('enteredRegion', onArrived)
         reject(new Error(`newRegion(${direction}) timed out after ${timeout}ms waiting for enteredRegion`))
       }, timeout)
-      function onArrived() {
+      function onArrived(bot, o) {
+        // o.to is the destination region ref on the `make ... you:true`.
+        // Ignore same-region arrivals — those are silent reconnects
+        // re-entering the room we were already in, NOT the transit we
+        // asked for. Keep the listener active so the actual new-region
+        // arrival can still resolve.
+        const arrivedAt = o && o.to
+        if (startRegion && arrivedAt && arrivedAt === startRegion) {
+          log.debug('newRegion: ignoring same-region enteredRegion at %s (likely silent reconnect)', arrivedAt)
+          return
+        }
         clearTimeout(timer)
+        self._removeOnce('enteredRegion', onArrived)
         resolve()
       }
-      self._registerOnce('enteredRegion', onArrived)
+      self.on('enteredRegion', onArrived)
     })
     return this.sendWithDelay({
       to: 'ME',
       op: 'NEWREGION',
       direction: direction,
     }, 10000).then(() => arrivalP)
+  }
+
+  /**
+   * Walk this.history for a Region-typed mod, returning its ref. Used
+   * by newRegion() to capture the pre-transit region so the arrival
+   * listener can distinguish a real region change from a same-region
+   * re-enter (e.g. bridge_v2 silent reconnect).
+   */
+  _scanForCurrentRegionRef() {
+    for (const ref in this.history) {
+      const o = this.history[ref]
+      if (o && o.obj && o.obj.mods && o.obj.mods[0] && o.obj.mods[0].type === 'Region') {
+        return ref
+      }
+    }
+    return ''
   }
 
   /**

--- a/habibots/habibot.js
+++ b/habibots/habibot.js
@@ -375,16 +375,77 @@ class HabiBot {
 
   /**
    * Informs the Neohabitat server that the bot's Avatar is entering a new region via
-   * the provided direction and passage.
+   * the provided direction and passage. The returned Promise resolves only when
+   * the bot's own avatar has actually arrived in the new region (signalled by the
+   * `enteredRegion` callback, fired from the inbound `make ... you:true`). If the
+   * region transit doesn't complete within `timeoutMillis` (default 15s) the
+   * Promise rejects so callers like walkToExit() / wanderTick() see the failure
+   * instead of silently looping (issue #506).
+   *
+   * Pre-fix this resolved as soon as NEWREGION hit the socket — a successful
+   * write was indistinguishable from a stuck region transition, and bots that
+   * lost their elko session (issue #505) hammered NEWREGION every wanderTick
+   * forever without anyone noticing.
+   *
    * @param {Number} direction direction from which the bot is entering the new region
-   * @returns {Promise}
+   * @param {Number} [timeoutMillis] how long to wait for enteredRegion before rejecting
+   * @returns {Promise} resolves on arrival, rejects on send failure or timeout
    */
-  newRegion(direction) {
+  newRegion(direction, timeoutMillis) {
+    const self = this
+    const timeout = typeof timeoutMillis === 'number' ? timeoutMillis : 15000
+    // Pre-register the arrival listener BEFORE the wire write, so we
+    // can't race against an unusually fast server (changeContext +
+    // make storm + `you:true` arriving before the .then chain attaches).
+    const arrivalP = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        self._removeOnce('enteredRegion', onArrived)
+        reject(new Error(`newRegion(${direction}) timed out after ${timeout}ms waiting for enteredRegion`))
+      }, timeout)
+      function onArrived() {
+        clearTimeout(timer)
+        resolve()
+      }
+      self._registerOnce('enteredRegion', onArrived)
+    })
     return this.sendWithDelay({
       to: 'ME',
       op: 'NEWREGION',
       direction: direction,
-    }, 10000)
+    }, 10000).then(() => arrivalP)
+  }
+
+  /**
+   * Register a callback that fires at most once, then unregisters itself.
+   * Used internally for transit-completion synchronization; exposed so
+   * other bots can do the same kind of "wait for one event then move on"
+   * pattern without leaking listeners.
+   * @param {string} eventType Habitat event type (e.g. 'enteredRegion')
+   * @param {function} callback fired on first matching event
+   */
+  once(eventType, callback) {
+    const self = this
+    function wrapper(...args) {
+      self._removeOnce(eventType, wrapper)
+      callback(...args)
+    }
+    this.on(eventType, wrapper)
+    return wrapper
+  }
+
+  /**
+   * Internal: remove a specific callback from an event's callback list.
+   * Used by once() and by newRegion()'s timeout path to release its
+   * waiter without leaking through to a later region transit.
+   */
+  _registerOnce(eventType, wrapper) {
+    this.on(eventType, wrapper)
+  }
+  _removeOnce(eventType, target) {
+    const list = this.callbacks[eventType]
+    if (!list) return
+    const idx = list.indexOf(target)
+    if (idx >= 0) list.splice(idx, 1)
   }
   
   /**


### PR DESCRIPTION
## Summary

Four related fixes for bridge_v2 + habibots region-transit reliability. All caught and verified while bringing the dev stack up to test #505 end-to-end. Supersedes PRs #507, #508, #509.

### 1. \`obj\` polymorphic decode (issue #502, commit 1)

\`obj\` is polymorphic on the wire — embedded HabitatObject for make/HEREIS_$, bare noid integer for PUT$/THROW$ neighbor broadcasts (\`HabitatMod.java:828, :987\`). The Go tag typed it as \`*HabitatObject\` so the bare-integer shape failed unmarshal and dropped the whole message — every PUT/THROW silently vanished for neighbors. Custom \`UnmarshalJSON\` now peels \`obj\` as RawMessage: object literal → \`m.Obj\`, bare integer → \`m.ObjectNoid\` (same Go field CHANGE_CONTAINERS_$ uses, so existing handlers Just Work).

Same audit caught \`container_noid\` snake_case (CHANGE_CONTAINERS_$ broadcast) vs camelCase \`containerNoid\` (inbound PUT verb @JSONMethod) — same Go field, different wire keys per direction; the unmarshaler now accepts both.

### 2. UNASSIGNED_NOID narrowing on \`noid\` / \`target\` / \`obj\` (issue #502, commit 2)

Surfaced by a synthetic two-client smoke test: \`noid:256\` (UNASSIGNED_NOID) shows up in PUT$/GOAWAY_$ broadcasts when the broadcasting / targeted avatar has no assigned region noid yet (fresh JSON-passthrough avatars). The \`*uint8\` fields can't hold 256. Pulled a \`narrowNoidField\` helper out and applied it to \`Noid\` / \`Target\` / bare-integer \`obj\` — UNASSIGNED_NOID (256) folds to GHOST_NOID (255), matching how \`Appearing\` and \`Speaker\` handle the same sentinel.

### 3. Silent reconnect on elko-side disconnect (issue #505, commit 3)

The first cut of #505 (PR #507, closed) fired \`go c.Close()\` on elkoReader/Writer EOF — but live testing against the dev stack with \`//g sagebot\` showed that breaks region transit for BOTH binary and JSON-passthrough sessions. The trigger isn't a real outage: it's habiproxy closing the bridge-side TCP a few ms after elko closed its server-side following a normal changeContext (\`pushserver/habiproxy/session.js:251\`). Tearing down the session leaves the client stuck in an infinite region transfer.

Replaced teardown with a silent reconnect: new \`recoverElkoConnection()\` drains the old reader/writer, redials habiproxy with backoff (5 attempts, ~7s total), re-enters \`c.nextRegion\` (in-flight transit) or \`c.regionRef\` (steady state). If every dial fails (true container outage), falls back to \`c.Close()\` — preserving #505's original idle-bot-during-restart recovery.

Idempotent against parallel reader-EOF/writer-error firings via the \`elkoRecovering\` guard. While in there, replaced \`elkoConnInitWg\` (shared sync.WaitGroup reused across reconnect cycles, race-detector hostile) with per-call ready channels.

### 4. newRegion waits for enteredRegion before resolving (issue #506, commit 4)

Pre-fix \`HabiBot.newRegion()\` resolved as soon as NEWREGION bytes hit the socket — a successful write was indistinguishable from a stuck transit. When bots lost their elko session (#505), they silently hammered NEWREGION every wanderTick forever because each call's Promise resolved cleanly. \`newRegion()\` now pre-registers a one-shot \`enteredRegion\` listener (fired from the inbound \`make ... you:true\`), sends NEWREGION, and waits for arrival with a 15s timeout that rejects — surfacing failures to \`walkToExit\` / \`wanderTick\`'s existing \`withTimeout\` wrapper instead of silently looping.

Also exposes \`once()\` as a public helper for other bots that want the same \"wait for one event\" pattern without leaking listeners.

Closes #502, #505, #506.

## Test plan

- [x] \`go vet ./...\` clean on Linux target
- [x] \`go test -race -count=1 ./...\` — full bridge_v2 suite passes (14 new tests across the bridge commits, no regressions)
- [x] habibots: 4-case smoke covering newRegion resolves on enteredRegion, rejects on timeout, cleans up listener after timeout, and once() self-unregisters
- [x] **Live verified end-to-end** against the dev stack:
  - Issue #502: alice + bob JSON clients, alice PUTs Paper, bob receives the relayed PUT$ broadcast (pre-fix dropped silently)
  - Issue #505: SageBot NEWREGION → elko EOF → \"Elko-side disconnect; attempting silent reconnect\" → make storm for new region arrives on the SAME session_id → CAUGHT_UP_$ + APPEARING_$ confirm normal operation resumed, no client teardown
  - Issue #506: bots restart cleanly with new newRegion() code; sage re-enters Downtown_5f and arrives normally
- [ ] Production deploy: \`//g sagebot\` from a C64 completes transit without infinite-region-transfer; PUT$/THROW$ broadcasts visible to neighbors; restart \`neohabitat-neohabitat-1\` container while bots are connected and confirm reconnect cycle works