### PR TITLE
fix(bridge_v2): inherit admin HTTP port through tableflip (#534)

### DIFF
--- a/bridge_v2/main.go
+++ b/bridge_v2/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -88,15 +89,13 @@ func main() {
 		log.Logger = log.Output(zerolog.MultiLevelWriter(os.Stderr, ringLog))
 	}
 
+	// Build the admin mux here (it needs the ring log), but defer actually
+	// serving it to the run* paths: the graceful path inherits its listener
+	// through tableflip, the simple path binds directly.
+	var adminMux *http.ServeMux
 	if *adminListen != "" {
-		mux := http.NewServeMux()
-		mux.Handle("/logs", ringLog)
-		go func() {
-			if err := http.ListenAndServe(*adminListen, mux); err != nil {
-				log.Error().Err(err).Str("addr", *adminListen).Msg("Admin HTTP server failed")
-			}
-		}()
-		log.Info().Str("addr", *adminListen).Msg("Admin HTTP server listening")
+		adminMux = http.NewServeMux()
+		adminMux.Handle("/logs", ringLog)
 	}
 
 	var otelShutdown func(context.Context) error
@@ -111,9 +110,9 @@ func main() {
 	}
 
 	if *graceful {
-		runWithTableflip(otelShutdown)
+		runWithTableflip(otelShutdown, adminMux)
 	} else {
-		runSimple(otelShutdown)
+		runSimple(otelShutdown, adminMux)
 	}
 }
 
@@ -124,7 +123,18 @@ func newBridge() *bridge.Bridge {
 	)
 }
 
-func runSimple(otelShutdown func(context.Context) error) {
+func runSimple(otelShutdown func(context.Context) error, adminMux *http.ServeMux) {
+	// No tableflip handoff in the simple path, so a plain bind never races
+	// a departing process. Serve the admin mux directly.
+	if adminMux != nil {
+		go func() {
+			if err := http.ListenAndServe(*adminListen, adminMux); err != nil {
+				log.Error().Err(err).Str("addr", *adminListen).Msg("Admin HTTP server failed")
+			}
+		}()
+		log.Info().Str("addr", *adminListen).Msg("Admin HTTP server listening")
+	}
+
 	habitatBridge := newBridge()
 	habitatBridge.Start()
 
@@ -136,12 +146,33 @@ func runSimple(otelShutdown func(context.Context) error) {
 	shutdownOtel(otelShutdown)
 }
 
-func runWithTableflip(otelShutdown func(context.Context) error) {
+func runWithTableflip(otelShutdown func(context.Context) error, adminMux *http.ServeMux) {
 	upg, err := tableflip.New(tableflip.Options{})
 	if err != nil {
 		log.Fatal().Err(err).Msg("Could not initialize tableflip upgrader")
 	}
 	defer upg.Stop()
+
+	// Admin HTTP server: obtain its listener through tableflip so the socket
+	// is inherited across SIGHUP upgrades rather than freshly bound on each
+	// child. A fresh bind raced the departing parent releasing the port and
+	// intermittently failed with EADDRINUSE, leaving the admin server dead
+	// for that process's lifetime (issue #534). An inherited fd is shared
+	// parent→child during the brief handoff window and never re-bound, so
+	// there is no race. Must run before upg.Ready(): tableflip only hands a
+	// listener to the next child if it was registered before readiness.
+	if adminMux != nil {
+		if adminLn, aerr := upg.Fds.Listen("tcp", *adminListen); aerr != nil {
+			log.Error().Err(aerr).Str("addr", *adminListen).Msg("Could not obtain admin listener via tableflip")
+		} else {
+			go func() {
+				if serr := http.Serve(adminLn, adminMux); serr != nil && !errors.Is(serr, net.ErrClosed) {
+					log.Error().Err(serr).Str("addr", *adminListen).Msg("Admin HTTP server failed")
+				}
+			}()
+			log.Info().Str("addr", adminLn.Addr().String()).Msg("Admin HTTP server listening (tableflip)")
+		}
+	}
 
 	habitatBridge := newBridge()
 	listeners := make([]net.Listener, len(listenAddrs))


### PR DESCRIPTION
Fixes #534.

## Problem

The admin HTTP server (default `:2027`) was started with a plain `http.ListenAndServe` — a fresh bind on every process. During a tableflip upgrade that fresh bind races the departing parent releasing the port and intermittently fails with `EADDRINUSE`:

```
{"level":"error","error":"listen tcp 0.0.0.0:2027: bind: address already in use","addr":"0.0.0.0:2027","message":"Admin HTTP server failed"}
```

The goroutine then exits silently and the admin server is dead for the rest of that process's lifetime, so the pushserver `/status` page (which fetches `/logs` from the admin server) reports the bridge as unreachable until the next reload.

## Fix

The game listeners already survive upgrades because they're inherited via tableflip's fd passing — the admin port was the only socket doing a fresh bind. This obtains it through `upg.Fds.Listen` instead, so the fd is shared parent→child during the handoff and never re-bound, **eliminating the race rather than papering over it with retries** (which is what the issue originally proposed).

- `main()`: build the admin mux here (it needs the ring log) but defer actually serving it to the run paths, which bind differently.
- `runWithTableflip()` (production/graceful path): obtain the listener via `upg.Fds.Listen("tcp", *adminListen)` **before** `upg.Ready()` — tableflip only hands a listener to the next child if it was registered before readiness — and serve with `http.Serve`. tableflip auto-passes it on `Upgrade()`; since the admin listener isn't registered with the bridge, it's untouched by the TCP_REPAIR snapshot/close path.
- `runSimple()` (dev/non-graceful path): keep the plain `http.ListenAndServe` — there's no handoff there, so nothing to race.

## Notes

During the brief handoff window both parent and child accept on the shared admin socket, so a `/logs` request could land on either process's ring log. That's harmless and self-resolves the instant the parent exits — a strict improvement over the current "admin server dead until next reload."

## Verification

- `GOOS=linux go build ./...` — clean
- `GOOS=linux go vet ./...` — clean