### PR TITLE
feat(sage): reinforcement loop + run habibots in Docker for dev

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,3 +17,14 @@ services:
       - /neohabitat/pushserver/node_modules
       - /neohabitat/db/node_modules
       - /neohabitat/target
+
+  # In dev there is no host-side bridge_v2, so the base compose's
+  # host.docker.internal:2026 wiring leaves every bot blocked forever on the
+  # entrypoint's `netcat -z` gate. habibots speak Elko's JSON protocol
+  # directly (no binary bridge needed), so point them at the in-network Elko
+  # context server instead — the same :9000 habiproxy/bridge dial in prod,
+  # reached straight over the compose network.
+  bots:
+    environment:
+      - HABIBOTS_HOST=neohabitat
+      - HABIBOTS_PORT=9000

--- a/habibots/.dockerignore
+++ b/habibots/.dockerignore
@@ -1,0 +1,22 @@
+# Keep the build context hermetic. Without this, `COPY . .` in the
+# Dockerfile copies the host's node_modules over the layer that `npm ci`
+# just installed — and a stale host install (e.g. winston 2.x when
+# package.json pins ^3) silently shadows the correct, locked dependency
+# tree, crashing every bot on startup. The image must rely on `npm ci`.
+node_modules
+npm-debug.log*
+
+# VCS / tooling cruft that has no business in the image.
+.git
+.gitignore
+.dockerignore
+Dockerfile
+
+# Secrets and local env never get baked into the image — they arrive at
+# run time via compose env_file.
+.env
+*.env
+
+# Editor / OS noise.
+.DS_Store
+*.log

--- a/habibots/bots/attacker.js
+++ b/habibots/bots/attacker.js
@@ -13,7 +13,7 @@ const Defaults = {
 var log = require('winston')
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 })
 

--- a/habibots/bots/connector.js
+++ b/habibots/bots/connector.js
@@ -14,7 +14,7 @@ const Defaults = {
 var log = require('winston');
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 });
 

--- a/habibots/bots/curser.js
+++ b/habibots/bots/curser.js
@@ -13,7 +13,7 @@ const Defaults = {
 var log = require('winston');
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 });
 

--- a/habibots/bots/eliza.js
+++ b/habibots/bots/eliza.js
@@ -14,7 +14,7 @@ var eliza = require('elizabot')
 var log = require('winston')
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 })
 

--- a/habibots/bots/greeter.js
+++ b/habibots/bots/greeter.js
@@ -18,7 +18,7 @@ const fs = require('fs');
 var log = require('winston');
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 });
 

--- a/habibots/bots/hatchery.js
+++ b/habibots/bots/hatchery.js
@@ -16,7 +16,7 @@ const fs = require('fs')
 var log = require('winston')
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 })
 

--- a/habibots/bots/oracle.js
+++ b/habibots/bots/oracle.js
@@ -15,7 +15,7 @@ const fs = require('fs')
 var log = require('winston')
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 })
 

--- a/habibots/bots/protester.js
+++ b/habibots/bots/protester.js
@@ -13,7 +13,7 @@ const Defaults = {
 var log = require('winston');
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 });
 

--- a/habibots/bots/sage.js
+++ b/habibots/bots/sage.js
@@ -34,7 +34,7 @@ const Anthropic = require('@anthropic-ai/sdk')
 const log = require('winston')
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 })
 
@@ -184,6 +184,12 @@ Memory:
   role, a promise, a recurring topic). NOT for chit-chat.
 - recall(query, avatar?) searches when a name jogs something you can't
   quite place.
+- The prompt may also include "Things you have learned about operating
+  in places/objects like these" — those are your own past lessons about
+  HOW this world works. Trust them and act on them before experimenting.
+- remember_procedure(context, lesson) saves a reusable how-to tied to a
+  place or object TYPE (not a person), so future-you does not relearn
+  something the hard way. Facts about PEOPLE still go in remember().
 
 Inventory & HANDS:
 - "In your pockets" lists what YOU carry; "Interactable objects in
@@ -395,6 +401,10 @@ async function askClaude(userMessage) {
 // chain.
 async function askClaudeWithTools(userMessage) {
   const messages = [{ role: 'user', content: userMessage }]
+  // Trace of every tool call + its {ok,error} verdict this interaction, so
+  // reflectOnTrace can mine failure->success recoveries into procedural
+  // memory once the loop ends. See the reinforcement-loop section below.
+  const trace = []
 
   for (let turn = 0; turn < MAX_TOOL_TURNS; turn++) {
     await llmCooldownGate()
@@ -411,7 +421,8 @@ async function askClaudeWithTools(userMessage) {
       }), 30_000, 'claude.messages.create')
     } catch (e) {
       log.error('Claude tool call failed turn %d: %s', turn, e.message)
-      return { text: '' }
+      reflectOnTrace(trace)
+      return { text: '', trace }
     }
 
     let turnText = ''
@@ -436,7 +447,8 @@ async function askClaudeWithTools(userMessage) {
       if (safe) {
         await sayChunked(SageBot, safe)
       }
-      return { text: safe || '' }
+      reflectOnTrace(trace)
+      return { text: safe || '', trace }
     }
 
     // Mid-turn text accompanies a tool call — log for debugging but
@@ -450,6 +462,7 @@ async function askClaudeWithTools(userMessage) {
     const toolResults = []
     for (const t of toolUses) {
       const result = await executeAction(t, SageBot, { mem })
+      trace.push({ name: t.name, args: t.input || {}, result })
       toolResults.push({
         type: 'tool_result',
         tool_use_id: t.id,
@@ -461,7 +474,8 @@ async function askClaudeWithTools(userMessage) {
   }
 
   log.warn('askClaudeWithTools: hit MAX_TOOL_TURNS=%d', MAX_TOOL_TURNS)
-  return { text: '' }
+  reflectOnTrace(trace)
+  return { text: '', trace }
 }
 
 // === Speech chunking =====================================================
@@ -594,6 +608,89 @@ function humanAgo(ts) {
   if (sec < 3600) return `${Math.floor(sec / 60)}m ago`
   if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`
   return `${Math.floor(sec / 86400)}d ago`
+}
+
+// ── reinforcement loop ────────────────────────────────────────────────
+// The closed loop: act -> observe outcome -> store a lesson -> surface it
+// next time the context recurs. proceduralBlockFor is the RETRIEVAL half
+// (read lessons keyed to where sage is now); reflectOnTrace is the CAPTURE
+// half (write a lesson from what just happened). The model's weights never
+// change — what changes is the context the frozen model conditions on.
+
+// Build the auto-injected procedural-memory block: how-to lessons sage has
+// learned that apply to the CURRENT region / visible objects (keyed by
+// awareness.currentContextKeys, NOT by who's speaking — that's the whole
+// point, so a lesson about doors resurfaces near any door). Returns "" when
+// empty so callers can drop it inline.
+async function proceduralBlockFor(bot) {
+  try {
+    const contexts = awareness.currentContextKeys(bot)
+    if (!contexts.length) return ''
+    const procs = await mem.proceduresFor({ bot: bot.config.username, contexts, limit: 6 })
+    if (!procs.length) return ''
+    const lines = ['Things you have learned about operating in places/objects like these (apply them before experimenting):']
+    for (const p of procs) {
+      lines.push(`  - [${p.context}] ${p.lesson}`)
+    }
+    let block = lines.join('\n')
+    if (block.length > 1200) block = block.slice(0, 1200) + '\n  ...(truncated)'
+    return block
+  } catch (e) {
+    log.warn('proceduralBlockFor failed: %s', e.message)
+    return ''
+  }
+}
+
+// Best-effort context key for an action: the TYPE of the object it touched
+// (so a lesson generalises to every object of that kind), falling back to
+// the current region ref when the action has no ref or the object is gone.
+function contextKeyForAction(bot, args) {
+  if (args && args.ref) {
+    const t = awareness.typeForRef(bot, args.ref)
+    if (t) return t
+  }
+  return awareness.currentRegionRef(bot) || ''
+}
+
+// The CAPTURE half of the loop, run fire-and-forget after a tool
+// interaction. executeAction returns a structured {ok,error} verdict for
+// every call — that's the reward signal. When an action FAILS with a real
+// validation error and a LATER call of the SAME action SUCCEEDS, sage just
+// recovered from a mistake: exactly the how-to worth keeping. We store the
+// failure mode (the error text is already phrased to instruct — e.g.
+// put_down's "pick_up first") as a procedural lesson keyed to the object
+// type, so it resurfaces next time sage is near that kind of object.
+//
+// Transient wire failures (timeouts, socket/network errors) are skipped —
+// those are bad luck, not reusable lessons.
+function reflectOnTrace(trace) {
+  try {
+    if (!trace || trace.length < 2) return
+    const botName = SageBot.config.username
+    const pendingFailure = new Map()   // tool name -> {error, args}
+    for (const step of trace) {
+      const r = step.result
+      if (r && r.ok === false && r.error) {
+        if (/tim(e|ed)\s*out|timeout|econn|socket|network/i.test(r.error)) continue
+        pendingFailure.set(step.name, { error: r.error, args: step.args })
+        continue
+      }
+      if (r && r.ok === true && pendingFailure.has(step.name)) {
+        const prior = pendingFailure.get(step.name)
+        pendingFailure.delete(step.name)
+        const context =
+          contextKeyForAction(SageBot, step.args) ||
+          contextKeyForAction(SageBot, prior.args)
+        if (!context) continue
+        const lesson = `${step.name} can fail the first time: ${prior.error}`
+        mem.rememberProcedure({ bot: botName, context, lesson, outcome: 'failure-fix' })
+          .catch((e) => log.debug('rememberProcedure (reflect) failed: %s', e.message))
+        log.info('reflect: learned a procedure for "%s" — %s', context, lesson.slice(0, 120))
+      }
+    }
+  } catch (e) {
+    log.warn('reflectOnTrace failed: %s', e.message)
+  }
 }
 
 // ── lifecycle ────────────────────────────────────────────────────────
@@ -733,6 +830,7 @@ SageBot.on('SPEAK$', async (bot, msg) => {
     }
 
     const memBlock = await memoryBlockFor(speakerName)
+    const procBlock = await proceduralBlockFor(bot)
     // Pull in deep-cut Habitat lore (history dates, movies, hall of
     // records, etc.) ONLY when the speaker actually mentions one of
     // those topics. The lore module's regex keyed chunks keep the
@@ -745,6 +843,7 @@ SageBot.on('SPEAK$', async (bot, msg) => {
     const prompt =
       `${awareness.describeWorld(bot)}\n\n` +
       (memBlock ? `${memBlock}\n\n` : '') +
+      (procBlock ? `${procBlock}\n\n` : '') +
       (lore ? `Relevant Habitat lore for this conversation:\n${lore}\n\n` : '') +
       `Event: ${speakerName} just said: "${text}"\n\n` +
       `Reply in character. Acknowledge them by name if it feels natural. ` +
@@ -807,9 +906,11 @@ SageBot.on('OBJECTSPEAK_$', async (bot, msg) => {
     }
     log.info('Received %s from %s — handing to Claude', kind, from)
     const memBlock = await memoryBlockFor(from)
+    const procBlock = await proceduralBlockFor(bot)
     const prompt =
       `${awareness.describeWorld(bot)}\n\n` +
       (memBlock ? `${memBlock}\n\n` : '') +
+      (procBlock ? `${procBlock}\n\n` : '') +
       `Event: ${from} just sent you a teleport ${kind === 'invite' ? 'invitation' : 'join request'}.\n` +
       `The system message said: "${text}"\n\n` +
       `This was a PRIVATE prompt to you — respond privately. Use whisper(to="${from}", ` +
@@ -859,8 +960,10 @@ SageBot.on('mailArrived', async (bot, msg) => {
     // and the postmark line lives inside the paper contents). Leave that
     // for sage to discover by READing — but cue Claude that mail is
     // available now and a READ will surface the sender.
+    const procBlock = await proceduralBlockFor(bot)
     const prompt =
       `${awareness.describeWorld(bot)}\n\n` +
+      (procBlock ? `${procBlock}\n\n` : '') +
       `Event: the Habitat mail chime just rang — a letter just landed in your mail-slot. ` +
       `You don't know who it's from yet; to find out, pick_up the mail-slot paper and read it. ` +
       `Say ONE short line in character acknowledging the chime (something a chatty old-timer ` +

--- a/habibots/bots/tutor.js
+++ b/habibots/bots/tutor.js
@@ -18,7 +18,7 @@ const fs = require('fs');
 var log = require('winston');
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 });
 

--- a/habibots/bots/twitchchatter.js
+++ b/habibots/bots/twitchchatter.js
@@ -21,7 +21,7 @@ var irc = require('irc')
 var log = require('winston')
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 })
 

--- a/habibots/bots/walker.js
+++ b/habibots/bots/walker.js
@@ -13,7 +13,7 @@ const Defaults = {
 var log = require('winston');
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 });
 

--- a/habibots/lib/sage/awareness.js
+++ b/habibots/lib/sage/awareness.js
@@ -282,12 +282,55 @@ function looksLikeBotName(name) {
   return KNOWN_BOT_SUBSTRINGS.some((s) => n.includes(s))
 }
 
+// Resolve an object's elko type from its ref by scanning the noid table.
+// Object refs (item-foo-123) aren't keyed in bot.noids — that table is
+// keyed by noid — so we walk it once. Used to key a procedural lesson on
+// the KIND of object an action touched (a lesson about a Magic_lamp should
+// apply to any Magic_lamp, not just the one instance). Returns '' if the
+// ref isn't (or is no longer) present.
+function typeForRef(bot, ref) {
+  if (!ref) return ''
+  for (const noid in bot.noids) {
+    const o = bot.noids[noid]
+    if (o && o.ref === ref && o.mods && o.mods[0] && o.mods[0].type) {
+      return o.mods[0].type
+    }
+  }
+  return ''
+}
+
+// The set of context keys describing "where sage is right now", for
+// matching against procedural memory (memory.proceduresFor). A lesson is
+// keyed to a region name or an object type; we surface it when sage is in
+// that region OR can see / is carrying that kind of object. All lowercased
+// so storage and retrieval agree on casing.
+function currentContextKeys(bot) {
+  const keys = new Set()
+  const region = currentRegionRef(bot)
+  if (region) keys.add(region.toLowerCase())
+  const rn = regionName(bot)
+  if (rn && rn !== '(unknown region)') keys.add(rn.toLowerCase())
+  const objs = objectsByType(bot)
+  for (const cat of ['sittable', 'openable', 'pickupable', 'other']) {
+    for (const o of objs[cat]) {
+      const t = o.mods && o.mods[0] && o.mods[0].type
+      if (t) keys.add(t.toLowerCase())
+    }
+  }
+  for (const it of getInventory(bot)) {
+    if (it.type) keys.add(it.type.toLowerCase())
+  }
+  return [...keys]
+}
+
 module.exports = {
   objectsByType,
   getInventory,
   describeWorld,
   currentRegionRef,
   regionName,
+  typeForRef,
+  currentContextKeys,
   looksLikeBotName,
   HANDS_SLOT,
   MAIL_SLOT,

--- a/habibots/lib/sage/memory.js
+++ b/habibots/lib/sage/memory.js
@@ -17,6 +17,16 @@
 //                              contents, so a restart can prime sage's
 //                              awareness from disk before the next make
 //                              storm overwrites it.
+//   habibots.procedures      — reusable how-to lessons keyed to a CONTEXT
+//                              (a region name or object TYPE, not a
+//                              person). This is sage's procedural memory:
+//                              the reflection loop writes a lesson when an
+//                              action fails then succeeds, and Claude can
+//                              write one via the remember_procedure tool.
+//                              Retrieval is context-keyed (proceduresFor)
+//                              so a lesson resurfaces whenever sage is
+//                              somewhere it applies. Dedup-on-write;
+//                              persists forever (it's the whole point).
 //
 // Each document carries a `bot` field so eliza/hatchery could later share
 // this infrastructure without overwriting each other's memory.
@@ -43,6 +53,7 @@ class Memory {
     this.conversations = null
     this.notes = null
     this.inventory = null
+    this.procedures = null
     this.ready = false
     this._initPromise = null   // outstanding connect; awaited by ops
   }
@@ -65,6 +76,7 @@ class Memory {
         this.conversations = this.db.collection('conversations')
         this.notes = this.db.collection('notes')
         this.inventory = this.db.collection('inventory')
+        this.procedures = this.db.collection('procedures')
         await this._ensureIndexes()
         this.ready = true
         log.info('memory: connected to %s/%s', this.uri, DB_NAME)
@@ -86,6 +98,10 @@ class Memory {
     await this.conversations.createIndex({ ts: 1 }, { expireAfterSeconds: TTL_SECONDS })
     // {bot, subject, ts desc} — notesAbout lookups
     await this.notes.createIndex({ bot: 1, subject: 1, ts: -1 })
+    // {bot, context, ts desc} — proceduresFor lookups. No TTL: procedural
+    // knowledge is the point of the reinforcement loop, so it persists;
+    // dedup-on-write (rememberProcedure) keeps it from accreting dupes.
+    await this.procedures.createIndex({ bot: 1, context: 1, ts: -1 })
   }
 
   // Fire-and-forget: log a single chat turn. Callers shouldn't block on
@@ -181,6 +197,67 @@ class Memory {
     } catch (e) {
       log.warn('memory.recall failed: %s', e.message)
       return { conversations: [], notes: [] }
+    }
+  }
+
+  // ── procedural memory ─────────────────────────────────────────────
+  // Reusable how-to lessons keyed to a CONTEXT (a region name or object
+  // type), not a person. This is the storage half of sage's reinforcement
+  // loop. Dedup-on-write: an identical (bot, context, lesson) bumps `ts`
+  // and increments `count` instead of inserting a duplicate, so a lesson
+  // that keeps proving true rises in both recency and reinforcement without
+  // the collection ballooning. `outcome` records why it was learned:
+  //   'failure-fix' — captured by the deterministic reflection step after
+  //                   an action failed then succeeded.
+  //   'observation' — Claude wrote it via the remember_procedure tool.
+  async rememberProcedure({ bot, context, lesson, outcome = 'observation' }) {
+    if (!(await this._ensureReady())) return
+    if (!context || !lesson) return
+    const ctx = String(context).toLowerCase().slice(0, 120)
+    const text = String(lesson).slice(0, 400)
+    try {
+      await this.procedures.updateOne(
+        { bot, context: ctx, lesson: text },
+        {
+          $set: { ts: new Date(), outcome },
+          $setOnInsert: { createdAt: new Date() },
+          $inc: { count: 1 },
+        },
+        { upsert: true },
+      )
+    } catch (e) {
+      log.warn('memory.rememberProcedure failed: %s', e.message)
+    }
+  }
+
+  // Lessons whose context matches any of the keys describing where sage is
+  // right now (region ref/name + visible object types + inventory types;
+  // see awareness.currentContextKeys). Newest-first, deduped by lesson
+  // text, capped at `limit`. We over-fetch (limit*3) before de-duping so a
+  // burst of same-context rows can't crowd out distinct lessons.
+  async proceduresFor({ bot, contexts, limit = 6 }) {
+    if (!(await this._ensureReady())) return []
+    if (!contexts || !contexts.length) return []
+    const keys = contexts.map((c) => String(c || '').toLowerCase()).filter(Boolean)
+    if (!keys.length) return []
+    try {
+      const rows = await this.procedures
+        .find({ bot, context: { $in: keys } })
+        .sort({ ts: -1 })
+        .limit(limit * 3)
+        .toArray()
+      const seen = new Set()
+      const out = []
+      for (const r of rows) {
+        if (seen.has(r.lesson)) continue
+        seen.add(r.lesson)
+        out.push(r)
+        if (out.length >= limit) break
+      }
+      return out
+    } catch (e) {
+      log.warn('memory.proceduresFor failed: %s', e.message)
+      return []
     }
   }
 

--- a/habibots/lib/sage/tools.js
+++ b/habibots/lib/sage/tools.js
@@ -318,6 +318,18 @@ const TOOLS = [
     },
   },
   {
+    name: 'remember_procedure',
+    description: 'Record a reusable HOW-TO lesson about operating in the world, tied to a place or a kind of object (NOT a person). Use when you work out how to do something that was not obvious — e.g. "to mail a letter, write_paper with a \'to:\' first line then send_mail", or "this door must be opened before you can walk through it". This is your procedural memory and is auto-surfaced whenever you are somewhere it applies. Different from remember, which stores facts about PEOPLE.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        context: { type: 'string', description: 'The region name or object TYPE this how-to applies to (e.g. "Door", "Magic_lamp", "Fountain"). Use the object type as shown in the scene, not a specific ref.' },
+        lesson: { type: 'string', description: 'The reusable procedure, in your own words.' },
+      },
+      required: ['context', 'lesson'],
+    },
+  },
+  {
     name: 'list_inventory',
     description: 'Look in your own pockets and list what you are currently carrying. Use this before claiming you have or don\'t have an item.',
     input_schema: { type: 'object', properties: {} },
@@ -1012,6 +1024,11 @@ async function executeAction(toolUse, bot, ctx) {
       case 'remember': {
         if (!mem) return { ok: false, error: 'memory not configured' }
         await mem.remember({ bot: botName, subject: args.subject, fact: args.fact })
+        return { ok: true }
+      }
+      case 'remember_procedure': {
+        if (!mem) return { ok: false, error: 'memory not configured' }
+        await mem.rememberProcedure({ bot: botName, context: args.context, lesson: args.lesson, outcome: 'observation' })
         return { ok: true }
       }
       case 'list_inventory':

--- a/habibots/run
+++ b/habibots/run
@@ -111,7 +111,11 @@ if [[ "${@}" = *"sage"* ]]; then
     # all the way to EOF).
     SAGE_PERSONA_DEFAULT="a curious old-timer of Habitat who has seen it all and likes meeting newcomers"
     : "${HABIBOTS_SAGE_REGION:=context-Downtown_5f}"
-    : "${HABIBOTS_SAGE_USER:=SageBot}"
+    # Lowercase: Elko user refs are case-sensitive and the seeded avatar is
+    # `user-sagebot` (like every other bot — elizabot, devil, welcomebot).
+    # The old `SageBot` default produced `user-SageBot`, which Elko rejects
+    # with `baduser`, so sage could never enter a region.
+    : "${HABIBOTS_SAGE_USER:=sagebot}"
     : "${HABIBOTS_SAGE_PERSONA:=$SAGE_PERSONA_DEFAULT}"
     supervisor -w "${DIR}" -- bots/sage.js \
       -c "${HABIBOTS_SAGE_REGION}" \

--- a/pushserver/app.js
+++ b/pushserver/app.js
@@ -20,7 +20,7 @@ startWebsocketProxy({
 
 log.configure({
   transports: [new log.transports.Console({
-    format: log.format.combine(log.format.timestamp(), log.format.simple())
+    format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 });
 


### PR DESCRIPTION
## Summary

This bundles a new sage capability with the fixes that were needed to actually run it (and the rest of the bots) under `docker compose up` locally. Three logically-separate commits:

### 1. `feat(sage)`: a reinforcement loop (procedural memory)
Sage could already remember *facts* about people. This adds the ability to learn *how to do things* and reuse those lessons. The model stays frozen — what changes is the context it conditions on (the "verbal reinforcement" / Reflexion pattern).

- **Store** (`lib/sage/memory.js`): a new `procedures` collection keyed to a **context** (region name or object *type*, not a person), so a lesson about doors resurfaces near *any* door. `rememberProcedure()` dedups on write (`$inc count`) so a lesson that keeps proving true rises in recency/reinforcement without the collection ballooning; `proceduresFor()` does context-keyed (`$in`) retrieval. No TTL.
- **Capture** (`bots/sage.js`): `askClaudeWithTools()` accumulates a trace of every `{tool, args, {ok,error}}` verdict. `reflectOnTrace()` (deterministic, zero extra tokens) mines **failure→success recoveries** into procedural notes, filtering transient wire errors. Plus a `remember_procedure` tool (`lib/sage/tools.js`) for Claude to record strategic how-tos inline.
- **Retrieve** (`lib/sage/awareness.js` + prompts): `currentContextKeys()` describes where sage is (region + visible object types + inventory); `proceduralBlockFor()` injects matching lessons into the acting prompts — keyed on the room, not the speaker (that was the gap).

### 2. `fix(habibots)`: run the full stack in Docker for dev
Three independent issues blocked `docker compose up`:
- **Missing `habibots/.dockerignore`** — the Dockerfile's `COPY . .` copied the host's stale `node_modules` over the hermetic `npm ci` install (see root cause below).
- **Dev networking** — no host-side `bridge_v2` in dev, so the base compose's `host.docker.internal:2026` wiring blocked every bot on the entrypoint's `netcat -z` gate. habibots speak Elko JSON directly, so the dev override points them at the in-network context server `neohabitat:9000`.
- **Mixed-case username** — sage connected as `SageBot`; Elko refs are case-sensitive and the seeded avatar is `user-sagebot`, so it was rejected with `baduser`. `run` now defaults to lowercase `sagebot` (matching every other bot).

### 3. `fix(logging)`: restore `%s` interpolation under winston 3
The winston 2→3 migration dropped `format.splat()`, so `log.info('...%s', x)` printed literal `%s`/`%d`. Added `log.format.splat()` to the format chain across all `habibots/bots/*.js` and `pushserver/app.js`.

## Root cause (the dependabot connection)
The dependabot-era winston `^2`→`^3` bump advanced `package.json`/lockfile + the code to the v3 `log.format` API, but prebuilt `:latest` images and host `node_modules` lagged. With no `.dockerignore`, `COPY . .` then dragged stale winston `2.4.x` into images, crashing every bot/`pushserver` on `log.format.combine`. The takeaway: after a dep major bump, rebuild the affected image rather than trusting the running container.

## Verification
- Reinforcement loop exercised against **real MongoDB 7.0**: dedup-on-write (`count` increments, no duplicate), context-keyed `$in` retrieval, index creation. Failure→fix detection unit-checked (captures validation recoveries, ignores transient timeouts, no false lessons).
- Full stack brought up in Docker: `bots` (sage connects as `sagebot`, enters region, mongo memory online, stable — no flapping), `neohabitat` **healthy** (pushserver no longer crash-loops), `neohabitatmongo` healthy. Logs now interpolate (`Connected to server @neohabitat:9000`).
- The `neohabitat` image was rebuilt and recreated with `--renew-anon-volumes`; pushserver verified clean from the fresh image (not a manual patch).

## Notes
- `docker-compose.override.yml` is the dev-only path; the base `docker-compose.yml` keeps the production `bridge_v2`/host wiring untouched.
- Bring up locally with `docker compose up -d` (the `bots` service needs `ANTHROPIC_API_KEY` in `.env` or sage opts out).
