### PR TITLE
fix(habibots): populate config.username so memory bot field isn't null

### DIFF
--- a/habibots/habibot.js
+++ b/habibots/habibot.js
@@ -64,6 +64,11 @@ class HabiBot {
     this.actionQueue = new Queue(1, Infinity)
 
     this.config = util.clone(DefaultHabiBotConfig)
+    // Mirror username into config so callers can read bot.config.username.
+    // The memory subsystem keys its `bot` field on it; without this the
+    // field was undefined and stored as null in mongo (issue #537). The
+    // instance still carries this.username; the two stay in sync.
+    this.config.username = username
 
     this.callbacks = {
       connected: [],


### PR DESCRIPTION
Fixes #537.

## Problem
`HabiBot`'s constructor sets `this.username` but initializes `this.config` to just `{ shouldReconnect: true }` and never copies `username` into it. Every sage memory call passes `bot: bot.config.username` as the `bot` field, which resolved to `undefined` and was stored as `null` in MongoDB.

Confirmed in the live dev DB — **every** row is affected:

| collection | total | null `bot` |
|---|---|---|
| conversations | 34 | 34 |
| inventory | 1 | 1 |

## Fix
Mirror `username` into `config` at construction (`habibot.js`):
```js
this.config = util.clone(DefaultHabiBotConfig)
this.config.username = username
```
This is the robust option from the issue: it fixes **every** caller at once — including the procedural-memory writes added in #536, which also key on `bot.config.username` — with no churn in `sage.js`, and keeps `this.username` in sync. New rows will carry the real bot name (`sagebot`), so the `bot` namespacing works once a second bot adopts the memory collections.

## Verification
Unit-checked both construction paths:
- `newWithConfig(host, port, 'sagebot').config.username` → `'sagebot'` (was `undefined`)
- `this.username` still `'sagebot'`
- extra config preserved (`shouldReconnect` honored for `true`/`false`)

Scope: one-line source change; no behavior change beyond populating the field. Existing `null`-bot rows are harmless (queries key on `avatar`, not `bot`) and age out via the conversations TTL.
