### PR TITLE
fix: harden TOUCH (null target) and FIDDLE_$ (multi-arg value) message handling

### DIFF
--- a/bridge_v2/bridge/fiddle_value_test.go
+++ b/bridge_v2/bridge/fiddle_value_test.go
@@ -1,0 +1,73 @@
+package bridge
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// Regression coverage: FIDDLE_$'s `value` field is polymorphic on the wire —
+// a bare integer for a single-arg fiddle and a JSON array for multi-arg
+// fiddles (HabitatMod.compose_fiddle_msg @ HabitatMod.java:2207-2211). The old
+// *uint8 schema parsed the scalar form but failed the whole-message unmarshal
+// on the array form ("json: cannot unmarshal array into Go struct field
+// ...value of type uint8"), silently dropping multi-byte FIDDLE_$ broadcasts
+// (avatar customize, token denominations, posted text).
+
+func TestUnmarshal_FiddleScalarValue(t *testing.T) {
+	raw := []byte(`{"type":"private","noid":5,"op":"FIDDLE_$","target":14,"offset":2,"argCount":1,"value":50}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(msg.Value) != 1 || msg.Value[0] != 50 {
+		t.Errorf("Value = %v, want [50]", msg.Value)
+	}
+	if msg.ArgCount == nil || *msg.ArgCount != 1 {
+		t.Errorf("ArgCount = %v, want 1", msg.ArgCount)
+	}
+}
+
+func TestUnmarshal_FiddleArrayValue(t *testing.T) {
+	// Exact payload from the reported bridge error (talking to SageBot).
+	raw := []byte(`{"type":"broadcast", "noid":0, "op":"FIDDLE_$", "target":14, "offset":15, "argCount":2, "value":[50, 4]}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal (the reported regression): %v", err)
+	}
+	if len(msg.Value) != 2 || msg.Value[0] != 50 || msg.Value[1] != 4 {
+		t.Errorf("Value = %v, want [50 4]", msg.Value)
+	}
+	if msg.Target == nil || *msg.Target != 14 {
+		t.Errorf("Target = %v, want 14", msg.Target)
+	}
+	if msg.Offset == nil || *msg.Offset != 15 {
+		t.Errorf("Offset = %v, want 15", msg.Offset)
+	}
+	if msg.ArgCount == nil || *msg.ArgCount != 2 {
+		t.Errorf("ArgCount = %v, want 2", msg.ArgCount)
+	}
+}
+
+// The C64 client (actions.m fiddle_with_object) reads
+// [target][offset][argCount][argCount value bytes] in a loop. The encoder must
+// emit every value byte, not just the first, or the binary stream desyncs on
+// multi-arg fiddles.
+func TestFiddle_EncodesAllValueBytes(t *testing.T) {
+	raw := []byte(`{"op":"FIDDLE_$","target":14,"offset":15,"argCount":2,"value":[50,4]}`)
+	var msg ElkoMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	op, ok := ServerOps["FIDDLE_$"]
+	if !ok || op.ToClient == nil {
+		t.Fatal("FIDDLE_$ ServerOp / ToClient missing")
+	}
+	buf := NewHabBufEmpty()
+	op.ToClient(&msg, buf, nil)
+	got := buf.Data()
+	want := []byte{14, 15, 2, 50, 4} // target, offset, argCount, value[0], value[1]
+	if !bytes.Equal(got, want) {
+		t.Errorf("encoded = %v, want %v", got, want)
+	}
+}

--- a/bridge_v2/bridge/schema.go
+++ b/bridge_v2/bridge/schema.go
@@ -104,7 +104,7 @@ type ElkoMessage struct {
 	Type                 string         `json:"type,omitempty"`
 	UpOrDown             *uint8         `json:"up_or_down,omitempty"`
 	User                 *string        `json:"user,omitempty"`
-	Value                *uint8         `json:"value,omitempty"`
+	Value                []uint8        `json:"value,omitempty"`
 	WishMessage          *string        `json:"WISH_MESSAGE,omitempty"`
 	Who                  *uint8         `json:"who,omitempty"`
 	Why                  *string        `json:"why,omitempty"`
@@ -170,6 +170,7 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 		ContainerNoid json.RawMessage `json:"container_noid,omitempty"`
 		Noid          json.RawMessage `json:"noid,omitempty"`
 		Target        json.RawMessage `json:"target,omitempty"`
+		Value         json.RawMessage `json:"value,omitempty"`
 		*elkoMessage
 	}
 	aux := envelope{
@@ -240,6 +241,30 @@ func (m *ElkoMessage) UnmarshalJSON(text []byte) error {
 		return err
 	} else if narrowed != nil {
 		m.Target = narrowed
+	}
+
+	// `value` is polymorphic on the FIDDLE_$ wire format: a bare integer
+	// for a single-arg fiddle and a JSON array for multi-arg fiddles
+	// (HabitatMod.compose_fiddle_msg @ HabitatMod.java:2207-2211 — gr_state
+	// vs. customize / token-denomination / posted-text). The scalar shape
+	// parsed fine into the old *uint8 field, but the array shape failed the
+	// whole-message unmarshal and the broadcast was silently dropped. Peel
+	// it and accept either shape as a flat []uint8 so the FIDDLE_$ encoder
+	// can emit all argCount value bytes.
+	if len(aux.Value) > 0 && string(aux.Value) != "null" {
+		if aux.Value[0] == '[' {
+			var arr []uint8
+			if err := json.Unmarshal(aux.Value, &arr); err != nil {
+				return fmt.Errorf("parsing elko message value array: %w", err)
+			}
+			m.Value = arr
+		} else {
+			var scalar uint8
+			if err := json.Unmarshal(aux.Value, &scalar); err != nil {
+				return fmt.Errorf("parsing elko message value: %w", err)
+			}
+			m.Value = []uint8{scalar}
+		}
 	}
 
 	return nil

--- a/bridge_v2/bridge/server_ops.go
+++ b/bridge_v2/bridge/server_ops.go
@@ -148,7 +148,7 @@ func init() {
 			buf.AddInt(*o.Target)
 			buf.AddInt(*o.Offset)
 			buf.AddInt(*o.ArgCount)
-			buf.AddInt(*o.Value)
+			buf.AddIntSlice(o.Value)
 			return false
 		},
 	}

--- a/src/main/java/org/made/neohabitat/mods/Avatar.java
+++ b/src/main/java/org/made/neohabitat/mods/Avatar.java
@@ -1013,9 +1013,13 @@ public class Avatar extends Container implements UserMod {
     public void TOUCH(User from,  OptInteger target) {
         Avatar curAvatar = avatar(from);
         HabitatMod targetMod = current_region().noids[target.value(0)];
+        if (targetMod == null || targetMod.HabitatClass() != CLASS_AVATAR) {
+            send_reply_error(from);
+            return;
+        }
         Avatar victim = (Avatar) targetMod;
-        
-        if (amAGhost) { 
+
+        if (amAGhost) {
             illegal_request(from, "Avatar commands not allowed when a ghost.");
             return;
         }


### PR DESCRIPTION
Two robustness fixes surfaced by the SageBot region-hang investigation. Both follow the same principle: a client-supplied / wire-polymorphic value must never throw an uncaught exception or get dropped — the message must always be handled.

## 1. `Avatar.TOUCH` null/non-Avatar guard (neohabitat, Java)

`TOUCH` resolved the target by noid and cast it to `Avatar` with no validation:

```java
HabitatMod targetMod = current_region().noids[target.value(0)];
Avatar     victim    = (Avatar) targetMod;
```

Two uncaught-exception paths, both before any reply is sent, so the client's TOUCH request is never acknowledged and its state machine hangs (same signature as the merged NEWREGION null-passage fix in #540):

- **Non-Avatar target → `ClassCastException`** at the cast (touching any non-avatar object, or target `0` = the region/context object).
- **Null target → `NullPointerException`** at `victim.elko_user()` (`adjacent()` is a no-op `return true;`, so it doesn't catch a null victim). Triggered by touching an avatar whose noid slot was just nulled — e.g. a neighbor that walked off.

**Fix:** validate the target is a live `Avatar` (non-null, `CLASS_AVATAR`) and `send_reply_error` otherwise.

## 2. `FIDDLE_$` polymorphic `value` parsing (bridge_v2, Go)

Elko sends FIDDLE_$ `value` as a bare integer for a single-arg fiddle but a JSON array for multi-arg ones (`HabitatMod.compose_fiddle_msg:2207-2211` — avatar customize, token denominations, posted text). The bridge typed `value` as `*uint8`, so the array shape failed the whole-message unmarshal (`cannot unmarshal array into Go struct field …value of type uint8`) and the broadcast was **silently dropped** — that object-state change never reached the client. Single-byte fiddles parsed fine, so it only surfaced intermittently.

**Fix:** peel `value` as `json.RawMessage` in `UnmarshalJSON` (matching the existing body/obj/noid/target polymorphic handling), decode either shape into `[]uint8`, and emit every value byte in the encoder (`AddIntSlice`) — the C64 reads `argCount` value bytes, so writing one would desync the stream on multi-arg fiddles.

## Test plan

- neohabitat: `mvn -DskipTests compile` → BUILD SUCCESS.
- bridge_v2: `go build/vet` (linux), and `go test ./bridge/ -run 'Fiddle|Unmarshal'` on Linux → all pass, including new regression tests (scalar value, the reported `[50,4]` array payload, encoder emits all bytes) and the pre-existing polymorphic-unmarshal suite.