### PR TITLE
fix(sagebot): reply-contract handling for Nexus gadgets (ROLL/SPRAY/Compass/ATTACK)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ volumes/bridge_v2_bin/
 
 # Ansible runtime cache (controller-side fact cache)
 ansible/.ansible_cache/
+
+# habiworld test-fixture wire captures (dev-local)
+habibots/capture/

--- a/habibots/habibot.js
+++ b/habibots/habibot.js
@@ -997,6 +997,18 @@ class HabiBot {
   fakeShoot(gunRef) {
     return this.sendWithDelay({ op: 'FAKESHOOT', to: gunRef }, 500)
   }
+  // ATTACK fires a REAL weapon (Gun/Sword/etc., anything extending
+  // Weapon) at a target noid — distinct from FAKESHOOT, which only the
+  // gag Fake_gun answers (a real Gun silently ignores FAKESHOOT). The
+  // server replies { ATTACK_target, ATTACK_result }: result 0 = no effect
+  // (missed, out of range, or a weapons-free zone), non-zero = a hit of
+  // that damage level, and the top value = a kill. Read it so the caller
+  // knows whether the shot actually landed instead of assuming it did.
+  async attack(weaponRef, targetNoid) {
+    const reply = await this.sendForReply({ op: 'ATTACK', to: weaponRef, pointed_noid: targetNoid })
+    const result = reply.ATTACK_result
+    return { ok: !!result, result, target: reply.ATTACK_target }
+  }
   resetFakeGun(gunRef) {
     return this.sendWithDelay({ op: 'RESET', to: gunRef }, 500)
   }

--- a/habibots/habibot.js
+++ b/habibots/habibot.js
@@ -915,8 +915,18 @@ class HabiBot {
   }
 
   // ── Misc world objects ─────────────────────────────────────────────
-  directCompass(compassRef) {
-    return this.sendWithDelay({ op: 'DIRECT', to: compassRef }, 500)
+  // DIRECT a Compass. Compass.java replies (no `err`) with
+  //   { text: "WEST: <arrow>" }
+  // where <arrow> is a PETSCII direction char pointing the way to the
+  // West Pole: 124 '|' = UP, 125 '}' = DOWN, 126 '~' = LEFT, 127 = RIGHT.
+  // Translate it to a screen direction so the caller can report it.
+  async directCompass(compassRef) {
+    const reply = await this.sendForReply({ op: 'DIRECT', to: compassRef })
+    const ARROWS = { 124: 'UP', 125: 'DOWN', 126: 'LEFT', 127: 'RIGHT' }
+    const text = reply.text || ''
+    const arrow = text.charCodeAt(text.length - 1)
+    const direction = ARROWS[arrow] || null
+    return { ok: true, text, direction }
   }
   // SPRAY paints a body part from a Spray_can held in HANDS. `limb` is
   // the body-part code (Spray_can.java enumerates HEAD/CHEST/etc.).

--- a/habibots/habibot.js
+++ b/habibots/habibot.js
@@ -881,8 +881,19 @@ class HabiBot {
   windToy(toyRef) {
     return this.sendWithDelay({ op: 'WIND', to: toyRef }, 500)
   }
-  rollDie(dieRef) {
-    return this.sendWithDelay({ op: 'ROLL', to: dieRef }, 500)
+  // ROLL a die. The server (Die.java) replies to the roller with
+  // ROLL_STATE = the new gr_state (the face value, 1..faces), and only
+  // broadcasts ROLL$ to NEIGHBORS — so our own roll result arrives in the
+  // reply, never as a delta. Read it, update the die's gr_state locally,
+  // and return the value so the caller can report it.
+  async rollDie(dieRef) {
+    const reply = await this.sendForReply({ op: 'ROLL', to: dieRef })
+    const value = reply.ROLL_STATE
+    if (value !== undefined) {
+      const die = this.world.getByRef(this.substituteName(dieRef))
+      if (die) die.mod.gr_state = value
+    }
+    return { ok: value !== undefined, value }
   }
   kingPiece(pieceRef) {
     return this.sendWithDelay({ op: 'KING', to: pieceRef }, 500)
@@ -908,10 +919,31 @@ class HabiBot {
     return this.sendWithDelay({ op: 'DIRECT', to: compassRef }, 500)
   }
   // SPRAY paints a body part from a Spray_can held in HANDS. `limb` is
-  // the body-part code (Spray_can.java enumerates HEAD/CHEST/etc.); a
-  // sensible default lets the can pick its current default target.
-  sprayCan(canRef, limb) {
-    return this.sendWithDelay({ op: 'SPRAY', to: canRef, limb: limb == null ? 0 : limb }, 500)
+  // the body-part code (Spray_can.java enumerates HEAD/CHEST/etc.).
+  //
+  // Spray_can.java replies in TWO shapes, neither using `err`:
+  //   guard failure (not holding the can / out of charges):
+  //     { success: 0|1, custom_1, custom_2 }
+  //   main path:
+  //     { SPRAY_SUCCESS: 0|1, SPRAY_CUSTOMIZE_0, SPRAY_CUSTOMIZE_1 }
+  // In both, success==1 means the spray landed and the two customize
+  // bytes are the avatar's new custom[0]/custom[1]. Apply them locally
+  // and report failure honestly (the common failure is spraying without
+  // the can in HANDS).
+  async sprayCan(canRef, limb) {
+    const reply = await this.sendForReply({
+      op: 'SPRAY', to: canRef, limb: limb == null ? 0 : limb,
+    })
+    const flag = reply.SPRAY_SUCCESS !== undefined ? reply.SPRAY_SUCCESS : reply.success
+    const ok = flag === 1 || flag === true
+    const c0 = reply.SPRAY_CUSTOMIZE_0 !== undefined ? reply.SPRAY_CUSTOMIZE_0 : reply.custom_1
+    const c1 = reply.SPRAY_CUSTOMIZE_1 !== undefined ? reply.SPRAY_CUSTOMIZE_1 : reply.custom_2
+    const me = this.world.me
+    if (me && Array.isArray(me.mod.custom)) {
+      if (c0 !== undefined) me.mod.custom[0] = c0
+      if (c1 !== undefined) me.mod.custom[1] = c1
+    }
+    return { ok, reason: ok ? undefined : 'spray-failed (need the can in HANDS, or it is empty)' }
   }
   fillBottle(bottleRef) {
     return this.sendWithDelay({ op: 'FILL', to: bottleRef }, 500)

--- a/habibots/habibot.js
+++ b/habibots/habibot.js
@@ -10,6 +10,7 @@ const Queue = require('promise-queue')
 
 const constants = require('./constants')
 const util = require('./util')
+const { Capture } = require('./lib/capture')
 const { HabitatWorld, actions: worldActions, dispatch: worldDispatch } = require('../habiworld')
 
 
@@ -92,6 +93,13 @@ class HabiBot {
     })
 
     this.clearState()
+
+    // Wire tap for test-fixture capture — null unless HABITAT_CAPTURE is set
+    // (see lib/capture.js). Tapped in sendWithDelay and processData below.
+    this._capture = Capture.fromEnv(username)
+    if (this._capture) {
+      log.info('wire capture enabled → %s', this._capture.path)
+    }
 
     log.debug('Constructed HabiBot @%s:%d: %j', this.host, this.port, this.config)
   }
@@ -675,6 +683,7 @@ class HabiBot {
         var msg = JSON.stringify(obj)
         setTimeout(() => {
           log.debug('->SEND@%s:%s [%s]: %s', self.host, self.port, self.username, msg.trim())
+          if (self._capture) self._capture.record('send', obj)
           self.server.write(msg + '\n\n', 'UTF8', () => {
             resolve()
           })
@@ -1325,6 +1334,7 @@ class HabiBot {
     var self = this;
     util.parseElko(buffer).forEach((message) => {
       log.debug('<-RCVD@%s:%s [%s]: %s', self.host, self.port, self.username, JSON.stringify(message));
+      if (self._capture) self._capture.record('recv', message)
       this.processElkoMessage(message);
     });
   }

--- a/habibots/lib/capture.js
+++ b/habibots/lib/capture.js
@@ -1,0 +1,74 @@
+/* jshint esversion: 8 */
+
+'use strict'
+
+// capture.js — an in-bot wire tap for building habiworld test fixtures.
+//
+// When HABITAT_CAPTURE is set to a file path, every message the bot sends
+// to the server and every message it receives is appended to that file as
+// one JSON object per line (JSONL). The result is a faithful, replayable
+// record of a live session — exactly the input habiworld's tests want:
+// the `make` storm becomes a region fixture, and each send/reply/delta
+// triple becomes a behavior test (see habiworld/test/*.test.js).
+//
+// Capture is OFF unless the env var is present, so production bots pay
+// nothing. To record a session:
+//
+//   HABITAT_CAPTURE=/tmp/test-region.jsonl node bots/sage.js ... --loglevel debug
+//
+// then drive the bot (e.g. Randy summons SageBot into the TEST region and
+// exercises each item class). Convert the JSONL into a fixture with
+// habiworld/lib/tools/capture_to_fixture.js.
+//
+// Each line is: { t, dir, user, msg }
+//   t    — ISO timestamp (orders the stream, ties replies to requests)
+//   dir  — 'send' (bot → server) or 'recv' (server → bot)
+//   user — the bot's username (a capture may interleave several bots)
+//   msg  — the exact wire object, post name/state substitution
+
+const fs = require('fs')
+const nodePath = require('path')
+
+class Capture {
+  constructor(path, user) {
+    this.path = path
+    this.user = user
+    // Ensure the parent dir exists — the capture path is usually a
+    // gitignored subdir (e.g. /habibots/capture/) that may not be created
+    // yet on a fresh checkout or container.
+    fs.mkdirSync(nodePath.dirname(path), { recursive: true })
+    // Append (not truncate): a single capture run may span several bot
+    // reconnects, and multiple bots may share one file. Each line is
+    // self-describing via `dir`/`user`, so interleaving is fine.
+    this.stream = fs.createWriteStream(path, { flags: 'a' })
+  }
+
+  // Build from the environment, or return null when capture is disabled.
+  // Called once per bot at construction; a null return means every later
+  // record() call is skipped at the callsite (`bot._capture && ...`).
+  static fromEnv(user) {
+    const path = process.env.HABITAT_CAPTURE
+    if (!path) return null
+    return new Capture(path, user)
+  }
+
+  record(dir, msg) {
+    if (!this.stream) return
+    const line = JSON.stringify({
+      t: new Date().toISOString(),
+      dir,
+      user: this.user,
+      msg,
+    })
+    this.stream.write(line + '\n')
+  }
+
+  close() {
+    if (this.stream) {
+      this.stream.end()
+      this.stream = null
+    }
+  }
+}
+
+module.exports = { Capture }

--- a/habibots/lib/sage/tools.js
+++ b/habibots/lib/sage/tools.js
@@ -739,12 +739,29 @@ const TOOLS = [
   },
   {
     name: 'fake_shoot',
-    description: 'FAKESHOOT — fire a Fake_gun. Makes a loud noise and flag; no real damage. Single ' +
-      'shot, then reset_fake_gun before firing again.',
+    description: 'FAKESHOOT — fire a Fake_gun (the gag gun) held in HANDS. Makes a loud noise and a ' +
+      'BANG flag; no real damage. Single shot, then reset_fake_gun before firing again. ' +
+      'ONLY works on a Fake_gun — a real Gun ignores this silently; use attack for a real Gun.',
     input_schema: {
       type: 'object',
       properties: { ref: { type: 'string' } },
       required: ['ref'],
+    },
+  },
+  {
+    name: 'attack',
+    description: 'ATTACK — fire a REAL weapon (a Gun, etc.) held in HANDS at a target avatar. This is ' +
+      'the actual Habitat combat verb and can damage or kill the target. Use strictly in character ' +
+      'and only when clearly invited (a demo, a duel) — most regions are weapons-free zones where the ' +
+      'weapon simply will not operate. Returns whether the shot landed and the damage result. ' +
+      'For the harmless gag gun use fake_shoot instead.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Ref of the real weapon in your HANDS.' },
+        target_noid: { type: 'integer', description: 'Noid of the avatar to attack.' },
+      },
+      required: ['ref', 'target_noid'],
     },
   },
   {
@@ -1365,6 +1382,12 @@ async function executeAction(toolUse, bot, ctx) {
       case 'fake_shoot':
         await withTimeout(bot.fakeShoot(args.ref), 10_000, 'fake_shoot')
         return { ok: true }
+      case 'attack': {
+        const hit = await withTimeout(bot.attack(args.ref, args.target_noid), 10_000, 'attack')
+        return hit.ok
+          ? { ok: true, result: hit.result }
+          : { ok: false, error: 'no effect — missed, out of range, or a weapons-free zone' }
+      }
       case 'reset_fake_gun':
         await withTimeout(bot.resetFakeGun(args.ref), 10_000, 'reset_fake_gun')
         return { ok: true }

--- a/habibots/lib/sage/tools.js
+++ b/habibots/lib/sage/tools.js
@@ -1321,9 +1321,11 @@ async function executeAction(toolUse, bot, ctx) {
         return { ok: true }
 
       // ── misc world objects ──────────────────────────────────────
-      case 'direct_compass':
-        await withTimeout(bot.directCompass(args.ref), 10_000, 'direct_compass')
-        return { ok: true }
+      case 'direct_compass': {
+        const c = await withTimeout(bot.directCompass(args.ref), 10_000, 'direct_compass')
+        // The West Pole lies in the `direction` screen-direction from here.
+        return { ok: true, west_pole_direction: c.direction, raw: c.text }
+      }
       case 'spray_can': {
         const sprayed = await withTimeout(bot.sprayCan(args.ref, args.limb), 10_000, 'spray_can')
         return sprayed.ok ? { ok: true } : { ok: false, error: sprayed.reason }

--- a/habibots/lib/sage/tools.js
+++ b/habibots/lib/sage/tools.js
@@ -1299,9 +1299,12 @@ async function executeAction(toolUse, bot, ctx) {
       case 'wind_toy':
         await withTimeout(bot.windToy(args.ref), 10_000, 'wind_toy')
         return { ok: true }
-      case 'roll_die':
-        await withTimeout(bot.rollDie(args.ref), 10_000, 'roll_die')
-        return { ok: true }
+      case 'roll_die': {
+        const rolled = await withTimeout(bot.rollDie(args.ref), 10_000, 'roll_die')
+        return rolled.ok
+          ? { ok: true, value: rolled.value }
+          : { ok: false, error: 'die did not report a value' }
+      }
       case 'king_piece':
         await withTimeout(bot.kingPiece(args.ref), 10_000, 'king_piece')
         return { ok: true }
@@ -1321,9 +1324,10 @@ async function executeAction(toolUse, bot, ctx) {
       case 'direct_compass':
         await withTimeout(bot.directCompass(args.ref), 10_000, 'direct_compass')
         return { ok: true }
-      case 'spray_can':
-        await withTimeout(bot.sprayCan(args.ref, args.limb), 10_000, 'spray_can')
-        return { ok: true }
+      case 'spray_can': {
+        const sprayed = await withTimeout(bot.sprayCan(args.ref, args.limb), 10_000, 'spray_can')
+        return sprayed.ok ? { ok: true } : { ok: false, error: sprayed.reason }
+      }
       case 'fill_bottle':
         await withTimeout(bot.fillBottle(args.ref), 10_000, 'fill_bottle')
         return { ok: true }

--- a/habiworld/lib/behaviors/gadgets.js
+++ b/habiworld/lib/behaviors/gadgets.js
@@ -69,23 +69,34 @@ async function spray_can_do(ctx) {
   const reply = await ctx.send({
     op: 'SPRAY', to: can.ref, limb: ctx.args.limb !== undefined ? ctx.args.limb : 0,
   })
-  if (!succeeded(reply)) return ctx.beep('server-denied')
+  // Spray_can.java does NOT use `err`. It replies success/SPRAY_SUCCESS
+  // (1 = landed) with the new customize bytes. Two reply shapes:
+  //   guard failure: { success, custom_1, custom_2 }
+  //   main path:     { SPRAY_SUCCESS, SPRAY_CUSTOMIZE_0, SPRAY_CUSTOMIZE_1 }
+  // custom_1/SPRAY_CUSTOMIZE_0 → custom[0]; custom_2/SPRAY_CUSTOMIZE_1 → custom[1].
+  const flag = reply.SPRAY_SUCCESS !== undefined ? reply.SPRAY_SUCCESS : reply.success
+  if (!(flag === 1 || flag === true)) return ctx.beep('spray-failed')
   if (ctx.actor && Array.isArray(ctx.actor.mod.custom)) {
-    if (reply.custom_0 !== undefined) ctx.actor.mod.custom[0] = reply.custom_0
-    if (reply.custom_1 !== undefined) ctx.actor.mod.custom[1] = reply.custom_1
+    const c0 = reply.SPRAY_CUSTOMIZE_0 !== undefined ? reply.SPRAY_CUSTOMIZE_0 : reply.custom_1
+    const c1 = reply.SPRAY_CUSTOMIZE_1 !== undefined ? reply.SPRAY_CUSTOMIZE_1 : reply.custom_2
+    if (c0 !== undefined) ctx.actor.mod.custom[0] = c0
+    if (c1 !== undefined) ctx.actor.mod.custom[1] = c1
   }
   return { ok: true }
 }
 
-// spray_can_SPRAY.m (host): someone got resprayed — apply their new
-// pattern bytes.
+// spray_can_SPRAY.m (host): a neighbor got resprayed — apply their new
+// pattern bytes. Spray_can.java broadcasts SPRAY$ with SPRAY_SPRAYEE and
+// SPRAY_CUSTOMIZE_0 / SPRAY_CUSTOMIZE_1 (→ custom[0] / custom[1]).
 async function spray_can_SPRAY(ctx) {
   ctx.sound('SPRAY', ctx.pointed.noid)
   const sprayee = ctx.world.get(ctx.args.SPRAY_SPRAYEE !== undefined
     ? ctx.args.SPRAY_SPRAYEE : ctx.args.sprayee)
   if (sprayee && Array.isArray(sprayee.mod.custom)) {
-    if (ctx.args.custom_0 !== undefined) sprayee.mod.custom[0] = ctx.args.custom_0
-    if (ctx.args.custom_1 !== undefined) sprayee.mod.custom[1] = ctx.args.custom_1
+    const c0 = ctx.args.SPRAY_CUSTOMIZE_0 !== undefined ? ctx.args.SPRAY_CUSTOMIZE_0 : ctx.args.custom_0
+    const c1 = ctx.args.SPRAY_CUSTOMIZE_1 !== undefined ? ctx.args.SPRAY_CUSTOMIZE_1 : ctx.args.custom_1
+    if (c0 !== undefined) sprayee.mod.custom[0] = c0
+    if (c1 !== undefined) sprayee.mod.custom[1] = c1
   }
   return { ok: true }
 }

--- a/habiworld/lib/tools/capture_to_fixture.js
+++ b/habiworld/lib/tools/capture_to_fixture.js
@@ -1,0 +1,118 @@
+/* jshint esversion: 8 */
+
+'use strict'
+
+// capture_to_fixture.js — turn a raw JSONL wire capture (from the bot's
+// HABITAT_CAPTURE tap, habibots/lib/capture.js) into a segmented fixture
+// that's easy to hand-write habiworld tests against.
+//
+//   node capture_to_fixture.js <capture.jsonl> [username] > fixture.json
+//
+// The output groups the stream into per-region "sessions". Each session:
+//
+//   {
+//     context: "context-...",          // region ref (from the context make)
+//     makeStorm: [ <make msg>, ... ],  // recv messages that build the region
+//     exchanges: [                     // one per bot request, in order
+//       { send: <req>, reply: <reply|null>, deltas: [ <ALLCAPS$ msg>, ... ] }
+//     ]
+//   }
+//
+// A makeStorm array feeds straight into world.apply() in a test's setup
+// (like the existing inline makeStorm() helpers, but real and complete).
+// Each exchange is the material for one behavior test: `send` is what the
+// behavior must emit (assert calls.sends), `reply` is what to script into
+// recorder([...]), and `deltas` are the broadcasts to apply and assert
+// against world state.
+//
+// This does NOT write assertions — we hand-write those per class so each
+// test documents the expected C64 semantics. It just slices the stream.
+
+const fs = require('fs')
+
+function readJsonl(path) {
+  return fs.readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l))
+}
+
+// A delta op is a server broadcast that mutates client world state — by
+// convention its op name ends in '$' (WALK$, OPENCONTAINER$, ROLL$, ...).
+function isDelta(msg) {
+  return typeof msg.op === 'string' && msg.op.endsWith('$')
+}
+
+function isMake(msg) {
+  return msg.op === 'make' || msg.op === 'ready' || msg.op === 'delete'
+}
+
+function startsRegion(msg) {
+  return msg.op === 'make' && msg.obj && msg.obj.type === 'context'
+}
+
+function segment(entries, user) {
+  const sessions = []
+  let cur = null
+
+  // A pending request awaiting its reply. Habitat is single-request-in-
+  // flight, so the next recv reply belongs to the most recent send.
+  let pendingExchange = null
+
+  const flushPending = () => {
+    if (pendingExchange && cur) cur.exchanges.push(pendingExchange)
+    pendingExchange = null
+  }
+
+  for (const e of entries) {
+    if (user && e.user !== user) continue
+    const m = e.msg
+
+    if (e.dir === 'recv') {
+      if (startsRegion(m)) {
+        flushPending()
+        cur = { context: m.obj.ref, makeStorm: [m], exchanges: [] }
+        sessions.push(cur)
+        continue
+      }
+      if (m.type === 'changeContext') {
+        flushPending()
+        cur = null
+        continue
+      }
+      if (!cur) continue
+
+      if (isMake(m) && !pendingExchange) {
+        cur.makeStorm.push(m)
+      } else if (m.type === 'reply') {
+        if (pendingExchange) pendingExchange.reply = m
+      } else if (isDelta(m)) {
+        // A delta during an exchange is that request's result; a delta
+        // with no pending request is an ambient world event — record it
+        // as a zero-send exchange so it isn't lost.
+        if (pendingExchange) pendingExchange.deltas.push(m)
+        else cur.exchanges.push({ send: null, reply: null, deltas: [m] })
+      }
+    } else if (e.dir === 'send') {
+      if (!cur) continue
+      flushPending()
+      pendingExchange = { send: m, reply: null, deltas: [] }
+    }
+  }
+  flushPending()
+  return sessions
+}
+
+function main() {
+  const [path, user] = process.argv.slice(2)
+  if (!path) {
+    process.stderr.write('usage: capture_to_fixture.js <capture.jsonl> [username]\n')
+    process.exit(2)
+  }
+  const sessions = segment(readJsonl(path), user)
+  process.stdout.write(JSON.stringify(sessions, null, 2) + '\n')
+}
+
+if (require.main === module) main()
+
+module.exports = { segment, isDelta, isMake, startsRegion }

--- a/habiworld/test/behaviors.test.js
+++ b/habiworld/test/behaviors.test.js
@@ -104,6 +104,51 @@ test('dispatch routes GET on an item through generic_goToAndGet', async () => {
   assert.equal(w.holding(17).noid, 30)
 })
 
+// ── reply-contract regressions (ground truth from a live capture in the
+//    Testing Grounds: Spray_can.java replies with success/SPRAY_SUCCESS
+//    and the customize bytes, never `err`) ────────────────────────────
+
+// Hold a fresh spray can in the avatar's HANDS and give the avatar a
+// two-byte custom pattern so respray effects are observable.
+function withHeldSprayCan(w) {
+  w.me.mod.custom = [0, 0]
+  w.apply({
+    to: ME_REF, op: 'make',
+    obj: {
+      type: 'item', ref: 'item-spray-1', name: 'Spray_can',
+      mods: [{ type: 'Spray_can', noid: 95, x: 0, y: HANDS, orientation: 0, gr_state: 0 }],
+    },
+  })
+}
+
+test('spray_can DO success path: SPRAY_SUCCESS + SPRAY_CUSTOMIZE_* repaint the avatar', async () => {
+  const w = new HabitatWorld()
+  makeStorm(w)
+  withHeldSprayCan(w)
+  // Spray_can.java main-path reply shape.
+  const { calls, cb } = recorder([
+    { type: 'reply', noid: 95, SPRAY_SUCCESS: 1, SPRAY_CUSTOMIZE_0: 7, SPRAY_CUSTOMIZE_1: 8 },
+  ])
+  const result = await dispatch(w, ACTION_DO, 95, { limb: 2 }, cb)
+  assert.ok(result.ok)
+  assert.deepEqual(calls.sends, [{ op: 'SPRAY', to: 'item-spray-1', limb: 2 }])
+  assert.deepEqual(w.me.mod.custom, [7, 8]) // new pattern applied
+})
+
+test('spray_can DO guard-failure: {success:0, custom_1, custom_2} beeps and leaves the pattern', async () => {
+  const w = new HabitatWorld()
+  makeStorm(w)
+  withHeldSprayCan(w)
+  w.me.mod.custom = [34, 129]
+  // Exact guard-failure reply captured live (not holding the can / empty).
+  const { cb } = recorder([
+    { type: 'reply', noid: 95, success: 0, custom_1: 34, custom_2: 129 },
+  ])
+  const result = await dispatch(w, ACTION_DO, 95, { limb: 0 }, cb)
+  assert.equal(result.ok, false) // beeped, not a false success
+  assert.deepEqual(w.me.mod.custom, [34, 129]) // unchanged
+})
+
 test('dispatch on an unported behavior fails loudly with the .m name', async (t) => {
   // Find any class slot whose behavior hasn't been ported yet, so this
   // test keeps working as the port advances (and retires itself once

--- a/habiworld/test/capture_to_fixture.test.js
+++ b/habiworld/test/capture_to_fixture.test.js
@@ -1,0 +1,100 @@
+/* jshint esversion: 8 */
+
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { segment } = require('../lib/tools/capture_to_fixture')
+
+// Helpers to build capture entries the way habibots/lib/capture.js writes
+// them: { t, dir, user, msg }.
+let clock = 0
+const recv = (msg, user = 'sagebot') => ({ t: String(clock++), dir: 'recv', user, msg })
+const send = (msg, user = 'sagebot') => ({ t: String(clock++), dir: 'send', user, msg })
+
+const ctxMake = (ref) => ({
+  to: 'session', op: 'make',
+  obj: { type: 'context', ref, name: ref, mods: [{ type: 'Region', neighbors: ['', '', '', ''] }] },
+})
+const itemMake = (ref, noid, type) => ({
+  to: 'context-TEST', op: 'make',
+  obj: { type: 'item', ref, name: type, mods: [{ type, noid, x: 40, y: 140 }] },
+})
+
+test('segment: one region with a make storm and a request/reply/delta exchange', () => {
+  const entries = [
+    recv(ctxMake('context-TEST')),
+    recv(itemMake('item-die-1', 5, 'Die')),
+    recv({ to: 'context-TEST', op: 'ready' }),
+    send({ op: 'ROLL', to: 'item-die-1' }),
+    recv({ type: 'reply', noid: 5, err: 1 }),
+    recv({ op: 'ROLL$', noid: 5, new_value: 4 }),
+  ]
+  const sessions = segment(entries)
+  assert.equal(sessions.length, 1)
+  const s = sessions[0]
+  assert.equal(s.context, 'context-TEST')
+  assert.equal(s.makeStorm.length, 3) // context + item + ready
+  assert.equal(s.exchanges.length, 1)
+  assert.deepEqual(s.exchanges[0].send, { op: 'ROLL', to: 'item-die-1' })
+  assert.equal(s.exchanges[0].reply.err, 1)
+  assert.equal(s.exchanges[0].deltas.length, 1)
+  assert.equal(s.exchanges[0].deltas[0].op, 'ROLL$')
+})
+
+test('segment: changeContext closes a session and a new make storm opens another', () => {
+  const entries = [
+    recv(ctxMake('context-TEST')),
+    recv({ to: 'context-TEST', op: 'ready' }),
+    recv({ type: 'changeContext', context: 'context-elsewhere', immediate: true }),
+    recv(ctxMake('context-TEST2')),
+    recv({ to: 'context-TEST2', op: 'ready' }),
+  ]
+  const sessions = segment(entries)
+  assert.equal(sessions.length, 2)
+  assert.equal(sessions[0].context, 'context-TEST')
+  assert.equal(sessions[1].context, 'context-TEST2')
+})
+
+test('segment: a delta with no pending request becomes a zero-send exchange', () => {
+  const entries = [
+    recv(ctxMake('context-TEST')),
+    recv({ to: 'context-TEST', op: 'ready' }),
+    recv({ op: 'WALK$', noid: 21, x: 40, y: 170 }), // ambient neighbor walk
+  ]
+  const sessions = segment(entries)
+  assert.equal(sessions[0].exchanges.length, 1)
+  assert.equal(sessions[0].exchanges[0].send, null)
+  assert.equal(sessions[0].exchanges[0].deltas[0].op, 'WALK$')
+})
+
+test('segment: filters to a single user when several bots interleave', () => {
+  const entries = [
+    recv(ctxMake('context-TEST'), 'sagebot'),
+    recv(itemMake('item-die-1', 5, 'Die'), 'sagebot'),
+    send({ op: 'SPEAK', to: 'ME', text: 'hi' }, 'elizabot'), // noise from another bot
+    recv({ to: 'context-TEST', op: 'ready' }, 'sagebot'),
+    send({ op: 'ROLL', to: 'item-die-1' }, 'sagebot'),
+    recv({ type: 'reply', err: 1 }, 'sagebot'),
+  ]
+  const sessions = segment(entries, 'sagebot')
+  assert.equal(sessions.length, 1)
+  assert.equal(sessions[0].exchanges.length, 1)
+  assert.equal(sessions[0].exchanges[0].send.op, 'ROLL')
+})
+
+test('segment: make messages after the first send are not folded into the storm', () => {
+  // OPENCONTAINER$ streams contents as `make` AFTER the request — those
+  // belong to the exchange's world effects, not the region make storm.
+  const entries = [
+    recv(ctxMake('context-TEST')),
+    recv(itemMake('item-bag-1', 6, 'Bag')),
+    recv({ to: 'context-TEST', op: 'ready' }),
+    send({ op: 'OPEN', to: 'item-bag-1' }),
+    recv({ type: 'reply', err: 1 }),
+    recv({ op: 'OPENCONTAINER$', noid: 6, cont: 6 }),
+  ]
+  const sessions = segment(entries)
+  assert.equal(sessions[0].makeStorm.length, 3) // context + bag + ready only
+  assert.equal(sessions[0].exchanges.length, 1)
+})

--- a/habiworld/test/fixtures/nexus.json
+++ b/habiworld/test/fixtures/nexus.json
@@ -1,0 +1,3206 @@
+[
+  {
+    "context": "context-table",
+    "makeStorm": [
+      {
+        "to": "session",
+        "op": "make",
+        "obj": {
+          "type": "context",
+          "ref": "context-table",
+          "name": "The Nexus",
+          "mods": [
+            {
+              "type": "Region",
+              "orientation": 0,
+              "nitty_bits": 2,
+              "depth": 32,
+              "neighbors": [
+                "",
+                "context-frontyard",
+                "",
+                ""
+              ],
+              "is_turf": false,
+              "realm": "Backroom",
+              "lighting": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "user",
+          "ref": "user-randy-7134105755364870786",
+          "name": "Randy",
+          "mods": [
+            {
+              "type": "Avatar",
+              "noid": 23,
+              "style": 0,
+              "x": 144,
+              "y": 149,
+              "orientation": 0,
+              "gr_state": 0,
+              "nitty_bits": 8,
+              "bodyType": "male",
+              "stun_count": 0,
+              "curse_type": 0,
+              "curse_count": 0,
+              "bankBalance": 50400,
+              "activity": 255,
+              "action": 129,
+              "health": 255,
+              "restrainer": 0,
+              "custom": [
+                17,
+                17
+              ],
+              "amAGhost": false,
+              "turf": "context-Randy_Rd_13_interior"
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-randy.changomatic-7134105755364870786",
+          "name": "Paintin' yer turf",
+          "mods": [
+            {
+              "type": "Changomatic",
+              "noid": 18,
+              "style": 0,
+              "x": 128,
+              "y": 1,
+              "orientation": 0,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-randygodtool-7134105755364870786",
+          "name": "Tool to rule the universe.",
+          "mods": [
+            {
+              "type": "Knick_knack",
+              "noid": 19,
+              "style": 2,
+              "x": 0,
+              "y": 2,
+              "orientation": 8,
+              "gr_state": 0,
+              "magic_type": 17
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-randyPaper-7134105755364870786",
+          "name": "Pad and mailbox",
+          "mods": [
+            {
+              "type": "Paper",
+              "noid": 20,
+              "style": 0,
+              "x": 0,
+              "y": 4,
+              "orientation": 16,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-randyhead-7134105755364870786",
+          "name": "Randy's Head",
+          "mods": [
+            {
+              "type": "Head",
+              "noid": 21,
+              "style": 151,
+              "x": 0,
+              "y": 6,
+              "orientation": 0,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "i-7298720110234221969-7134105755364870786",
+          "name": "money",
+          "mods": [
+            {
+              "type": "Tokens",
+              "noid": 22,
+              "style": 0,
+              "x": 0,
+              "y": 0,
+              "orientation": 0,
+              "gr_state": 0,
+              "denom_lo": 196,
+              "denom_hi": 3
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "ready"
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.door.heads",
+          "name": "Door to Heads",
+          "mods": [
+            {
+              "type": "Door",
+              "noid": 1,
+              "style": 0,
+              "x": 20,
+              "y": 32,
+              "orientation": 192,
+              "gr_state": 1,
+              "open_flags": 3
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.door.library",
+          "name": "Door to Library",
+          "mods": [
+            {
+              "type": "Door",
+              "noid": 2,
+              "style": 0,
+              "x": 112,
+              "y": 32,
+              "orientation": 144,
+              "gr_state": 1,
+              "open_flags": 3
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.down.sign",
+          "name": "Indicate Down Exit",
+          "mods": [
+            {
+              "type": "Short_sign",
+              "noid": 3,
+              "style": 0,
+              "x": 64,
+              "y": 5,
+              "orientation": 0,
+              "gr_state": 1,
+              "ascii": [
+                32,
+                228,
+                228,
+                228,
+                228,
+                228,
+                228,
+                228,
+                228,
+                32
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.ground",
+          "name": "Ground for Contents Testing",
+          "mods": [
+            {
+              "type": "Ground",
+              "noid": 4,
+              "style": 1,
+              "x": 0,
+              "y": 4,
+              "orientation": 104,
+              "gr_state": 0,
+              "flat_type": 2
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.key",
+          "name": "Key",
+          "mods": [
+            {
+              "type": "Key",
+              "noid": 5,
+              "style": 0,
+              "x": 20,
+              "y": 132,
+              "orientation": 0,
+              "gr_state": 0,
+              "key_number_lo": 5,
+              "key_number_hi": 5
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_canblack",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 7,
+              "style": 0,
+              "x": 40,
+              "y": 130,
+              "orientation": 8,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_canskin",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 8,
+              "style": 0,
+              "x": 70,
+              "y": 130,
+              "orientation": 16,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_can24",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 9,
+              "style": 0,
+              "x": 100,
+              "y": 130,
+              "orientation": 24,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_can32",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 10,
+              "style": 0,
+              "x": 130,
+              "y": 130,
+              "orientation": 32,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.table",
+          "name": "Test Table",
+          "mods": [
+            {
+              "type": "Table",
+              "noid": 16,
+              "style": 0,
+              "x": 60,
+              "y": 140,
+              "orientation": 0,
+              "gr_state": 0,
+              "open_flags": 3,
+              "key_lo": 5,
+              "key_hi": 5
+            }
+          ]
+        }
+      },
+      {
+        "to": "item-table.table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.compass",
+          "name": "Compass",
+          "mods": [
+            {
+              "type": "Compass",
+              "noid": 11,
+              "style": 0,
+              "x": 0,
+              "y": 0,
+              "orientation": 16,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "item-table.table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.die",
+          "name": "Die",
+          "mods": [
+            {
+              "type": "Die",
+              "noid": 12,
+              "style": 0,
+              "x": 0,
+              "y": 1,
+              "orientation": 16,
+              "gr_state": 3,
+              "state": 6
+            }
+          ]
+        }
+      },
+      {
+        "to": "item-table.table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.flashlight",
+          "name": "Blue Flashlight",
+          "mods": [
+            {
+              "type": "Flashlight",
+              "noid": 13,
+              "style": 0,
+              "x": 0,
+              "y": 2,
+              "orientation": 0,
+              "gr_state": 0,
+              "on": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "item-table.table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.gun",
+          "name": "Gun",
+          "mods": [
+            {
+              "type": "Gun",
+              "noid": 14,
+              "style": 0,
+              "x": 0,
+              "y": 3,
+              "orientation": 8,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "item-table.table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_can",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 15,
+              "style": 0,
+              "x": 0,
+              "y": 4,
+              "orientation": 64,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.wall",
+          "name": "Wall for Contents Testing",
+          "mods": [
+            {
+              "type": "Wall",
+              "noid": 17,
+              "style": 4,
+              "x": 0,
+              "y": 0,
+              "orientation": 152,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_canblue",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 6,
+              "style": 0,
+              "x": 80,
+              "y": 144,
+              "orientation": 0,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "ready"
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "user",
+          "ref": "user-sagebot-2446138527393909576",
+          "name": "sagebot",
+          "mods": [
+            {
+              "type": "Avatar",
+              "noid": 29,
+              "style": 0,
+              "x": 8,
+              "y": 130,
+              "orientation": 0,
+              "gr_state": 0,
+              "bodyType": "male",
+              "stun_count": 0,
+              "curse_type": 0,
+              "curse_count": 0,
+              "bankBalance": 50200,
+              "activity": 254,
+              "action": 129,
+              "health": 255,
+              "restrainer": 0,
+              "custom": [
+                34,
+                129
+              ],
+              "amAGhost": false,
+              "turf": "context-Aric_Ave_14_interior"
+            }
+          ]
+        },
+        "you": true
+      },
+      {
+        "to": "user-sagebot-2446138527393909576",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-head.7727387109675963439-2446138527393909576",
+          "name": "Default head for sagebot",
+          "mods": [
+            {
+              "type": "Head",
+              "noid": 27,
+              "style": 117,
+              "x": 0,
+              "y": 6,
+              "orientation": 0,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-sagebot-2446138527393909576",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-paper.6344961387510953271-2446138527393909576",
+          "name": "Paper for sagebot",
+          "mods": [
+            {
+              "type": "Paper",
+              "noid": 28,
+              "style": 0,
+              "x": 0,
+              "y": 4,
+              "orientation": 16,
+              "gr_state": 0
+            }
+          ]
+        }
+      }
+    ],
+    "exchanges": [
+      {
+        "send": null,
+        "reply": null,
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "CAUGHT_UP_$",
+            "err": 1
+          }
+        ]
+      },
+      {
+        "send": null,
+        "reply": null,
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 0,
+            "op": "APPEARING_$",
+            "appearing": 29
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 20,
+          "y": 31,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 20,
+          "y": 159,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.heads"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 1,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 1
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Huh, looks like Randy's been busy with his collection again."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Huh, looks like Randy's been busy with his collection again."
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Roll the die please and tell me the result you see."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "ROLL",
+          "to": "item-library.die"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 12,
+          "filler": 0,
+          "ROLL_STATE": 3
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Rolled a three, Randy!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Rolled a three, Randy!"
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Right!"
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "No way out to the right from here, Randy."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "No way out to the right from here, Randy."
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Pick up the compass please?"
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "GET",
+          "to": "item-table.compass"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 11,
+          "filler": 1,
+          "err": 1
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 0,
+            "op": "FIDDLE_$",
+            "target": 11,
+            "offset": 10,
+            "argCount": 1,
+            "value": 0
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Got it, Randy."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Got it, Randy."
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Then try to read it."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "READ",
+          "to": "item-table.compass",
+          "page": 1
+        },
+        "reply": null,
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "The compass says north, south, east and west are all accessible from here!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "The compass says north, south, east and west are all accessible from here!"
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "It should indicate which way is west? did you activate it?"
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 112,
+          "y": 31,
+          "how": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 112,
+          "y": 159,
+          "how": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "DIRECT",
+          "to": "item-table.compass"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 11,
+          "filler": 0,
+          "text": "WEST: |"
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.library"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 2,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 2
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Ah, good point - let me activate it properly, Randy!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Ah, good point - let me activate it properly, Randy!"
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Let's see what Randy's hidin' today."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Let's see what Randy's hidin' today."
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Can you put it on the table?"
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "PUT",
+          "to": "item-table.compass",
+          "containerNoid": 16,
+          "x": 0,
+          "y": 0,
+          "orientation": 16
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 11,
+          "filler": 0,
+          "err": 1,
+          "pos": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Done, Randy - compass is on the table now."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Done, Randy - compass is on the table now."
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Nice. Do you see the gun? Pick it up and shoot me, only once."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "GET",
+          "to": "item-library.gun"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 14,
+          "filler": 1,
+          "err": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "FAKESHOOT",
+          "to": "item-library.gun"
+        },
+        "reply": null,
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Bang, Randy - hope that's what you wanted!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Bang, Randy - hope that's what you wanted!"
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Hmm. Did you point at me and shoot?"
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Yep, straight at you, Randy - gun's still warm."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Yep, straight at you, Randy - gun's still warm."
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Put it back on the table. I'm sure that didn'T work. Then pick up the blue paint can."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 120,
+          "y": 140,
+          "how": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 120,
+          "y": 140,
+          "how": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "PUT",
+          "to": "item-library.gun",
+          "containerNoid": 0,
+          "x": 120,
+          "y": 140,
+          "orientation": 8
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 14,
+          "filler": 0,
+          "err": 1,
+          "pos": 140
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 80,
+          "y": 144,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 80,
+          "y": 144,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "GET",
+          "to": "item-library.spray_canblue"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 6,
+          "filler": 1,
+          "err": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Got the blue paint can, Randy - ready to go."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Got the blue paint can, Randy - ready to go."
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Nice. Paint your legs, torso,and arms."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPRAY",
+          "to": "item-library.spray_canblue",
+          "limb": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 6,
+          "filler": 0,
+          "SPRAY_SUCCESS": 1,
+          "SPRAY_CUSTOMIZE_0": 2,
+          "SPRAY_CUSTOMIZE_1": 129
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPRAY",
+          "to": "item-library.spray_canblue",
+          "limb": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 6,
+          "filler": 0,
+          "SPRAY_SUCCESS": 1,
+          "SPRAY_CUSTOMIZE_0": 0,
+          "SPRAY_CUSTOMIZE_1": 129
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPRAY",
+          "to": "item-library.spray_canblue",
+          "limb": 2
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 6,
+          "filler": 0,
+          "SPRAY_SUCCESS": 1,
+          "SPRAY_CUSTOMIZE_0": 0,
+          "SPRAY_CUSTOMIZE_1": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "There we go, Randy - all painted blue from head to toe!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "There we go, Randy - all painted blue from head to toe!"
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Great! Walk to me."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 124,
+          "y": 149,
+          "how": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 124,
+          "y": 149,
+          "how": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Coming right over, Randy!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Coming right over, Randy!"
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 52,
+          "y": 31,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 52,
+          "y": 159,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.heads"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 1,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 1
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "You'd think a door like that would jam by now."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "You'd think a door like that would jam by now."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 112,
+          "y": 31,
+          "how": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 112,
+          "y": 159,
+          "how": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.library"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 2,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 2
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Curious what's on the other side these days."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Curious what's on the other side these days."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 52,
+          "y": 31,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 52,
+          "y": 159,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.heads"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 1,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 1
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "This room's a museum."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "This room's a museum."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 112,
+          "y": 31,
+          "how": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 112,
+          "y": 159,
+          "how": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.library"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 2,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 2
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Seems like Randy's got a door for everything."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Seems like Randy's got a door for everything."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 52,
+          "y": 31,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 52,
+          "y": 159,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.heads"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 1,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 1
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Well, here we go."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Well, here we go."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 112,
+          "y": 31,
+          "how": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 112,
+          "y": 159,
+          "how": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.library"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 2,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 2
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "That's the ticket."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "That's the ticket."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 52,
+          "y": 31,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 52,
+          "y": 159,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.heads"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 1,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 1
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Alright, what're we looking at?"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Alright, what're we looking at?"
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-2446138527393909576",
+          "x": 112,
+          "y": 31,
+          "how": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "x": 112,
+          "y": 159,
+          "how": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.library"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 2,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 2
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-2446138527393909576",
+          "esp": 0,
+          "text": "Wonder what fresh stash Randy's crammed in here."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 29,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 29,
+            "op": "SPEAK$",
+            "text": "Wonder what fresh stash Randy's crammed in here."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "entercontext",
+          "to": "session",
+          "context": "context-Downtown_5f",
+          "user": "user-sagebot"
+        },
+        "reply": null,
+        "deltas": []
+      }
+    ]
+  },
+  {
+    "context": "context-table",
+    "makeStorm": [
+      {
+        "to": "session",
+        "op": "make",
+        "obj": {
+          "type": "context",
+          "ref": "context-table",
+          "name": "The Nexus",
+          "mods": [
+            {
+              "type": "Region",
+              "orientation": 0,
+              "nitty_bits": 2,
+              "depth": 32,
+              "neighbors": [
+                "",
+                "context-frontyard",
+                "",
+                ""
+              ],
+              "is_turf": false,
+              "realm": "Backroom",
+              "lighting": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "user",
+          "ref": "user-randy-7134105755364870786",
+          "name": "Randy",
+          "mods": [
+            {
+              "type": "Avatar",
+              "noid": 23,
+              "style": 0,
+              "x": 144,
+              "y": 149,
+              "orientation": 0,
+              "gr_state": 0,
+              "nitty_bits": 8,
+              "bodyType": "male",
+              "stun_count": 0,
+              "curse_type": 0,
+              "curse_count": 0,
+              "bankBalance": 50400,
+              "activity": 255,
+              "action": 129,
+              "health": 255,
+              "restrainer": 0,
+              "custom": [
+                17,
+                17
+              ],
+              "amAGhost": false,
+              "turf": "context-Randy_Rd_13_interior"
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-randy.changomatic-7134105755364870786",
+          "name": "Paintin' yer turf",
+          "mods": [
+            {
+              "type": "Changomatic",
+              "noid": 18,
+              "style": 0,
+              "x": 128,
+              "y": 1,
+              "orientation": 0,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-randygodtool-7134105755364870786",
+          "name": "Tool to rule the universe.",
+          "mods": [
+            {
+              "type": "Knick_knack",
+              "noid": 19,
+              "style": 2,
+              "x": 0,
+              "y": 2,
+              "orientation": 8,
+              "gr_state": 0,
+              "magic_type": 17
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-randyPaper-7134105755364870786",
+          "name": "Pad and mailbox",
+          "mods": [
+            {
+              "type": "Paper",
+              "noid": 20,
+              "style": 0,
+              "x": 0,
+              "y": 4,
+              "orientation": 16,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-randyhead-7134105755364870786",
+          "name": "Randy's Head",
+          "mods": [
+            {
+              "type": "Head",
+              "noid": 21,
+              "style": 151,
+              "x": 0,
+              "y": 6,
+              "orientation": 0,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "i-7298720110234221969-7134105755364870786",
+          "name": "money",
+          "mods": [
+            {
+              "type": "Tokens",
+              "noid": 22,
+              "style": 0,
+              "x": 0,
+              "y": 0,
+              "orientation": 0,
+              "gr_state": 0,
+              "denom_lo": 196,
+              "denom_hi": 3
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-randy-7134105755364870786",
+        "op": "ready"
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.door.heads",
+          "name": "Door to Heads",
+          "mods": [
+            {
+              "type": "Door",
+              "noid": 1,
+              "style": 0,
+              "x": 20,
+              "y": 32,
+              "orientation": 192,
+              "gr_state": 1,
+              "open_flags": 3
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.door.library",
+          "name": "Door to Library",
+          "mods": [
+            {
+              "type": "Door",
+              "noid": 2,
+              "style": 0,
+              "x": 112,
+              "y": 32,
+              "orientation": 144,
+              "gr_state": 1,
+              "open_flags": 3
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.down.sign",
+          "name": "Indicate Down Exit",
+          "mods": [
+            {
+              "type": "Short_sign",
+              "noid": 3,
+              "style": 0,
+              "x": 64,
+              "y": 5,
+              "orientation": 0,
+              "gr_state": 1,
+              "ascii": [
+                32,
+                228,
+                228,
+                228,
+                228,
+                228,
+                228,
+                228,
+                228,
+                32
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.ground",
+          "name": "Ground for Contents Testing",
+          "mods": [
+            {
+              "type": "Ground",
+              "noid": 4,
+              "style": 1,
+              "x": 0,
+              "y": 4,
+              "orientation": 104,
+              "gr_state": 0,
+              "flat_type": 2
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.key",
+          "name": "Key",
+          "mods": [
+            {
+              "type": "Key",
+              "noid": 5,
+              "style": 0,
+              "x": 20,
+              "y": 132,
+              "orientation": 0,
+              "gr_state": 0,
+              "key_number_lo": 5,
+              "key_number_hi": 5
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_canblack",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 7,
+              "style": 0,
+              "x": 40,
+              "y": 130,
+              "orientation": 8,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_canskin",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 8,
+              "style": 0,
+              "x": 70,
+              "y": 130,
+              "orientation": 16,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_can24",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 9,
+              "style": 0,
+              "x": 100,
+              "y": 130,
+              "orientation": 24,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_can32",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 10,
+              "style": 0,
+              "x": 130,
+              "y": 130,
+              "orientation": 32,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.table",
+          "name": "Test Table",
+          "mods": [
+            {
+              "type": "Table",
+              "noid": 16,
+              "style": 0,
+              "x": 60,
+              "y": 140,
+              "orientation": 0,
+              "gr_state": 0,
+              "open_flags": 3,
+              "key_lo": 5,
+              "key_hi": 5
+            }
+          ]
+        }
+      },
+      {
+        "to": "item-table.table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.die",
+          "name": "Die",
+          "mods": [
+            {
+              "type": "Die",
+              "noid": 12,
+              "style": 0,
+              "x": 0,
+              "y": 1,
+              "orientation": 16,
+              "gr_state": 3,
+              "state": 6
+            }
+          ]
+        }
+      },
+      {
+        "to": "item-table.table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.flashlight",
+          "name": "Blue Flashlight",
+          "mods": [
+            {
+              "type": "Flashlight",
+              "noid": 13,
+              "style": 0,
+              "x": 0,
+              "y": 2,
+              "orientation": 0,
+              "gr_state": 0,
+              "on": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "item-table.table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_can",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 15,
+              "style": 0,
+              "x": 0,
+              "y": 4,
+              "orientation": 64,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "item-table.table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.compass",
+          "name": "Compass",
+          "mods": [
+            {
+              "type": "Compass",
+              "noid": 11,
+              "style": 0,
+              "x": 0,
+              "y": 0,
+              "orientation": 16,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-table.wall",
+          "name": "Wall for Contents Testing",
+          "mods": [
+            {
+              "type": "Wall",
+              "noid": 17,
+              "style": 4,
+              "x": 0,
+              "y": 0,
+              "orientation": 152,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.gun",
+          "name": "Gun",
+          "mods": [
+            {
+              "type": "Gun",
+              "noid": 14,
+              "style": 0,
+              "x": 120,
+              "y": 140,
+              "orientation": 8,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "context-table",
+        "op": "ready"
+      },
+      {
+        "to": "context-table",
+        "op": "make",
+        "obj": {
+          "type": "user",
+          "ref": "user-sagebot-109664656397888704",
+          "name": "sagebot",
+          "mods": [
+            {
+              "type": "Avatar",
+              "noid": 33,
+              "style": 0,
+              "x": 8,
+              "y": 130,
+              "orientation": 0,
+              "gr_state": 0,
+              "bodyType": "male",
+              "stun_count": 0,
+              "curse_type": 0,
+              "curse_count": 0,
+              "bankBalance": 50200,
+              "activity": 255,
+              "action": 129,
+              "health": 255,
+              "restrainer": 0,
+              "custom": [
+                0,
+                1
+              ],
+              "amAGhost": false,
+              "turf": "context-Aric_Ave_14_interior"
+            }
+          ]
+        },
+        "you": true
+      },
+      {
+        "to": "user-sagebot-109664656397888704",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-library.spray_canblue-109664656397888704",
+          "name": "Spray Can",
+          "mods": [
+            {
+              "type": "Spray_can",
+              "noid": 30,
+              "style": 0,
+              "x": 80,
+              "y": 5,
+              "orientation": 0,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-sagebot-109664656397888704",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-head.7727387109675963439-109664656397888704",
+          "name": "Default head for sagebot",
+          "mods": [
+            {
+              "type": "Head",
+              "noid": 31,
+              "style": 117,
+              "x": 0,
+              "y": 6,
+              "orientation": 0,
+              "gr_state": 0
+            }
+          ]
+        }
+      },
+      {
+        "to": "user-sagebot-109664656397888704",
+        "op": "make",
+        "obj": {
+          "type": "item",
+          "ref": "item-paper.6344961387510953271-109664656397888704",
+          "name": "Paper for sagebot",
+          "mods": [
+            {
+              "type": "Paper",
+              "noid": 32,
+              "style": 0,
+              "x": 0,
+              "y": 4,
+              "orientation": 16,
+              "gr_state": 0
+            }
+          ]
+        }
+      }
+    ],
+    "exchanges": [
+      {
+        "send": null,
+        "reply": null,
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "CAUGHT_UP_$",
+            "err": 1
+          }
+        ]
+      },
+      {
+        "send": null,
+        "reply": null,
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 0,
+            "op": "APPEARING_$",
+            "appearing": 33
+          }
+        ]
+      },
+      {
+        "send": null,
+        "reply": null,
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Drop that please."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-109664656397888704",
+          "x": 128,
+          "y": 144,
+          "how": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "x": 128,
+          "y": 144,
+          "how": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "PUT",
+          "to": "item-library.spray_canblue-109664656397888704",
+          "containerNoid": 0,
+          "x": 128,
+          "y": 144,
+          "orientation": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 30,
+          "filler": 0,
+          "err": 1,
+          "pos": 144
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Done, Randy."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Done, Randy."
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Pick up the gun and fire it at me one time."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-109664656397888704",
+          "x": 120,
+          "y": 140,
+          "how": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "x": 120,
+          "y": 140,
+          "how": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "GET",
+          "to": "item-library.gun"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 14,
+          "filler": 1,
+          "err": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "ATTACK",
+          "to": "item-library.gun",
+          "pointed_noid": 23
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 14,
+          "filler": 0,
+          "ATTACK_target": 23,
+          "ATTACK_result": 2
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Bang! Got you good, Randy!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Bang! Got you good, Randy!"
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Ow! That worked!"
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Yep, that'll do the trick - thing's got a real punch to it!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Yep, that'll do the trick - thing's got a real punch to it!"
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Put that thing down, it'S dangerous"
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-109664656397888704",
+          "x": 128,
+          "y": 144,
+          "how": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "x": 128,
+          "y": 144,
+          "how": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "PUT",
+          "to": "item-library.gun",
+          "containerNoid": 0,
+          "x": 128,
+          "y": 144,
+          "orientation": 8
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 14,
+          "filler": 0,
+          "err": 1,
+          "pos": 144
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Fair point, Randy - thing's got quite the kick to it!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Fair point, Randy - thing's got quite the kick to it!"
+          },
+          {
+            "type": "neighbor",
+            "noid": 23,
+            "op": "POSTURE$",
+            "new_posture": 254
+          },
+          {
+            "type": "neighbor",
+            "noid": 23,
+            "op": "WALK$",
+            "x": 12,
+            "y": 141,
+            "how": 0
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-109664656397888704",
+          "x": 144,
+          "y": 31,
+          "how": 1
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "x": 144,
+          "y": 159,
+          "how": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.library"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 2,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 2
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Wonder what Randy's been stashing in here."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Wonder what Randy's been stashing in here."
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Is that a flashlight I see on the table?"
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Yep, blue one right there - want to give it a try?"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Yep, blue one right there - want to give it a try?"
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "yes. Pick it up and throw the switch."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-109664656397888704",
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "GET",
+          "to": "item-table.flashlight"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 13,
+          "filler": 1,
+          "err": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "ON",
+          "to": "item-table.flashlight"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 13,
+          "filler": 1,
+          "err": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Here we go, Randy - lighting things up!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Here we go, Randy - lighting things up!"
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "That sounded right. Switch it again."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "OFF",
+          "to": "item-table.flashlight"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 13,
+          "filler": 1,
+          "err": 1
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Lights off again - nice and simple!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Lights off again - nice and simple!"
+          },
+          {
+            "type": "neighbor",
+            "noid": 23,
+            "op": "POSTURE$",
+            "new_posture": 255
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Put it back on the table."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-109664656397888704",
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "PUT",
+          "to": "item-table.flashlight",
+          "containerNoid": 16,
+          "x": 0,
+          "y": 0,
+          "orientation": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 13,
+          "filler": 0,
+          "err": 1,
+          "pos": 2
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Done, Randy - back on the table where it belongs."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Done, Randy - back on the table where it belongs."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-109664656397888704",
+          "x": 52,
+          "y": 31,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "x": 52,
+          "y": 159,
+          "how": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Then, grab the compass and give it a read."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "OPEN",
+          "to": "item-table.door.heads"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 1,
+          "filler": 0,
+          "err": 0
+        },
+        "deltas": [
+          {
+            "type": "private",
+            "noid": 0,
+            "op": "OBJECTSPEAK_$",
+            "text": "It is locked.",
+            "speaker": 1
+          },
+          {
+            "type": "neighbor",
+            "noid": 23,
+            "op": "POSTURE$",
+            "new_posture": 255
+          },
+          {
+            "type": "neighbor",
+            "noid": 23,
+            "op": "WALK$",
+            "x": 120,
+            "y": 143,
+            "how": 1
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "WALK",
+          "to": "user-sagebot-109664656397888704",
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "x": 60,
+          "y": 140,
+          "how": 0
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "GET",
+          "to": "item-table.compass"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 11,
+          "filler": 1,
+          "err": 1
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 0,
+            "op": "FIDDLE_$",
+            "target": 11,
+            "offset": 10,
+            "argCount": 1,
+            "value": 0
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "DIRECT",
+          "to": "item-table.compass"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 11,
+          "filler": 0,
+          "text": "WEST: |"
+        },
+        "deltas": []
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Got it, Randy - compass says West is up from here."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Got it, Randy - compass says West is up from here."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Ah, Randy's workshop - where all the magic happens."
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Ah, Randy's workshop - where all the magic happens."
+          },
+          {
+            "type": "broadcast",
+            "noid": 23,
+            "op": "SPEAK$",
+            "text": "Nice. Everything's working! We'll check this all in."
+          }
+        ]
+      },
+      {
+        "send": {
+          "op": "SPEAK",
+          "to": "user-sagebot-109664656397888704",
+          "esp": 0,
+          "text": "Sounds good, Randy - glad it all checks out!"
+        },
+        "reply": {
+          "type": "reply",
+          "noid": 33,
+          "filler": 0,
+          "esp": 0
+        },
+        "deltas": [
+          {
+            "type": "broadcast",
+            "noid": 33,
+            "op": "SPEAK$",
+            "text": "Sounds good, Randy - glad it all checks out!"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Fixes a family of **reply-contract** bugs in SageBot's gadget tools, surfaced by a live capture in the Testing Grounds (The Nexus). Each was the same shape: a fire-and-forget tool that returned `{ok:true}` without reading a reply whose result lives in an **op-specific field** — the server never uses `err` for these.

All four verified working on the wire after the fix (see committed fixture `habiworld/test/fixtures/nexus.json`):

| Verb | Reply field | Was | Now |
|------|-------------|-----|-----|
| `ROLL` (Die) | `ROLL_STATE` (= gr_state face) | fabricated the value | reads true face; `ROLL$` only broadcasts to neighbors |
| `SPRAY` (Spray_can) | `success`/`SPRAY_SUCCESS` + customize bytes | checked `err` (always beeped); custom off-by-one | reads success flag; `custom_1`/`SPRAY_CUSTOMIZE_0`→custom[0], `custom_2`/`_1`→custom[1] |
| `DIRECT` (Compass) | `text:"WEST: <arrow>"` | heading discarded | decodes PETSCII arrow (124'\|'=UP …) to a screen direction |
| `ATTACK` (real Gun) | `{ATTACK_target, ATTACK_result}` | used `FAKESHOOT` — real Gun ignores it silently | new `attack` tool; real fire verb `ATTACK(pointed_noid)` |

**New capability note:** `attack` exposes the real Habitat combat verb (can damage/kill). It's gated in the tool prompt to in-character use only, and the server enforces weapons-free zones (most regions). `fake_shoot` is now documented as Fake_gun-only.

## Also in this PR (inert in production)
- **Wire-capture tooling** (`habibots/lib/capture.js`, `habiworld/lib/tools/capture_to_fixture.js`): an opt-in JSONL tap, **off unless `HABITAT_CAPTURE` is set** — that toggle lives only in the gitignored dev `.env`, so production is unaffected.
- **Tests**: spray contract tests + converter tests (57 total, 1 pre-existing SIT$ stub fail).
- **Fixture**: the verified Nexus session as ground truth for the upcoming per-class suite.

## Test plan
- [x] `npm test` in `habiworld/` (56/57; the one fail is the pre-existing `unhandledDelta`/SIT$ stub)
- [x] Live confirmation in The Nexus: ROLL→3, DIRECT→"WEST: |", SPRAY→3× SPRAY_SUCCESS, ATTACK→result 2
- [ ] CI build of all three images green before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)