### PR TITLE
feat(textclient): text-only terminal client built on HabiBot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 lib/
 !habibots/lib/
 !habiworld/lib/
+!textclient/lib/
 log/
 node_modules/
 pushserver/node_modules/

--- a/textclient/README.md
+++ b/textclient/README.md
@@ -1,0 +1,84 @@
+# textclient — a text-only terminal client for NeoHabitat
+
+A human-driven, text-only client for the Habitat world. It is a
+[`HabiBot`](../habibots/habibot.js) wired to a terminal instead of a bot
+loop: it **narrates** everything happening around you (speech, emotes,
+arrivals/departures, sounds, object changes, room contents) and accepts
+**verb-first commands** (`GO`, `GET`, `SAY`, …) that operate on objects by
+**name or noid**.
+
+It is built entirely on top of the existing libraries and changes none of
+them:
+
+- **`habibots/habibot.js`** — connection, reconnect, region transit, the
+  `habiworld` world model, and the verb helpers (`performVerb`,
+  `getIntoHands`, `walkToExit`, `openDoor`, `readObject`, …).
+- **`habiworld`** — the canonical client-side world model and behavior
+  dispatcher.
+
+> **Project rule:** the text client is purely additive. We do **not** modify
+> `habibots/` or `habiworld/` from here without explicit permission and a
+> compatibility check against `habibots`/`sagebot`. The client only consumes
+> the public `HabiBot` API.
+
+## Running
+
+No dependencies to install — the only third-party modules used belong to
+`HabiBot` and resolve from `habibots/node_modules` automatically.
+
+```sh
+node textclient/index.js -c context-Downtown_5f -u myname
+```
+
+Connects to the dev bridge at `127.0.0.1:2026` by default (the
+`bridge_v2` port from `docker-compose.dev.yml`; bots always dial the
+bridge, never elko directly). Override with flags:
+
+```
+-c, --context    region context to enter (required), e.g. context-Downtown_5f
+-u, --username   avatar username (required)
+-h, --host       server/bridge host (default 127.0.0.1)
+-p, --port       server/bridge port (default 2026)
+    --loglevel   HabiBot log level: error|warn|info|debug (default warn)
+```
+
+Make sure elko + `bridge_v2` are up first (e.g.
+`docker compose -f docker-compose.yml -f docker-compose.dev.yml up`).
+
+## Commands
+
+Targets accept a **name or a noid** — `LOOK` lists both. A line whose first
+word is not a known command is spoken aloud.
+
+| Command | Effect |
+|---|---|
+| `LOOK` / `L` | describe the room: exits, people, objects, your inventory |
+| `GO <dir\|name\|noid>` | walk to an exit (`UP/DOWN/LEFT/RIGHT` or `N/E/S/W`) or to an object |
+| `GET <name\|noid>` | pick an item up into your hands |
+| `DROP` / `PUT [tgt] [x y]` | drop what you hold — on the floor, or into a named container |
+| `SAY <text>` | speak aloud (bare lines are spoken too) |
+| `ESP` / `WHISPER <who> <text>` | private telepathic message |
+| `OPEN` / `CLOSE <tgt>` | open/close a door or container |
+| `READ <tgt> [page]` | read a book / paper / sign / plaque |
+| `DO <tgt> [text]` | the universal Habitat DO verb |
+| `TALK <tgt> <text>` | talk to an object (oracle, teleport, elevator, …) |
+| `SIT <tgt>` / `STAND` | sit on furniture / stand up |
+| `GIVE <avatar>` | hand what you hold to an avatar |
+| `GRAB <avatar>` | take what an avatar is holding |
+| `TOUCH <avatar>` | a friendly touch |
+| `FACE <dir>` | turn `LEFT/RIGHT/FORWARD/BEHIND` |
+| `WAVE` `JUMP` `FROWN` `POINT` `PUNCH` `BEND_OVER` `STAND_UP` `EXTEND_HAND` | postures / emotes |
+| `INV` / `I` | list what you are carrying |
+| `WHO` | who is online |
+| `GHOST` / `CORPORATE` | toggle ghost form |
+| `HELP` / `?` | in-world command list |
+| `QUIT` / `EXIT` | leave |
+
+## Layout
+
+```
+index.js        entrypoint: args, HabiBot wiring, readline loop
+lib/render.js   inbound elko op  → narration line (verbose)
+lib/commands.js command parser + dispatch; LOOK scene renderer
+lib/resolve.js  "name or noid" → habiworld record
+```

--- a/textclient/index.js
+++ b/textclient/index.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/* jshint esversion: 8 */
+
+'use strict'
+
+// textclient — a human, text-only client for NeoHabitat.
+//
+// It is a HabiBot (habibots/habibot.js) driven by a person at a terminal
+// instead of by a bot loop or an LLM. HabiBot already owns the socket
+// connection, reconnect/region-transit logic, the habiworld world model
+// (bot.world), and the full verb-helper set; this client only CONSUMES
+// that public API:
+//   - inbound world events  → narrated to stdout (lib/render.js)
+//   - typed command lines    → dispatched to HabiBot (lib/commands.js)
+//
+// We never modify the habibots or habiworld libraries from here (see the
+// "textclient: no habibots changes" rule) — if something is missing, we
+// surface it rather than patch shared code that habibots/sagebot depend on.
+//
+// Launch:
+//   node index.js -c <context> -u <username> [-h host] [-p port] [--loglevel lvl]
+// Defaults: host 127.0.0.1, port 2026 (the dev bridge_v2), loglevel warn.
+
+const readline = require('readline')
+
+const HabiBot = require('../habibots/habibot')
+const { makeRenderer } = require('./lib/render')
+const commands = require('./lib/commands')
+
+// ── arg parsing (zero-dep; mirrors the -h/-p/-c/-u flags the bots use) ──
+function parseArgs(argv) {
+  const out = { host: '127.0.0.1', port: 2026, loglevel: 'warn' }
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i]
+    const next = () => argv[++i]
+    switch (a) {
+      case '-h': case '--host': out.host = next(); break
+      case '-p': case '--port': out.port = Number(next()); break
+      case '-c': case '--context': out.context = next(); break
+      case '-u': case '--username': out.username = next(); break
+      case '--loglevel': out.loglevel = next(); break
+      case '--help': case '-?': out.help = true; break
+      default: console.error(`unknown argument: ${a}`); out.help = true
+    }
+  }
+  return out
+}
+
+function usage() {
+  console.log([
+    'NeoHabitat text client',
+    '',
+    'Usage: node index.js -c <context> -u <username> [options]',
+    '  -c, --context   region context to enter (required), e.g. context-Downtown_5f',
+    '  -u, --username  avatar username (required)',
+    '  -h, --host      server/bridge host (default 127.0.0.1)',
+    '  -p, --port      server/bridge port (default 2026)',
+    '      --loglevel  HabiBot log level: error|warn|info|debug (default warn)',
+    '',
+    'Once connected, type HELP for the in-world command list.',
+  ].join('\n'))
+}
+
+const argv = parseArgs(process.argv)
+if (argv.help || !argv.context || !argv.username) {
+  usage()
+  process.exit(argv.help ? 0 : 1)
+}
+
+// Quiet (or tune) HabiBot's own winston output so it doesn't drown the
+// narration. We configure the SAME winston instance habibot.js requires
+// (resolved from the habibots tree); this also silences winston's
+// "no transports" warning. Best-effort — if the path ever changes the
+// client still runs, just noisier.
+try {
+  const habiLog = require('../habibots/node_modules/winston')
+  habiLog.configure({
+    level: argv.loglevel,
+    transports: [new habiLog.transports.Console({
+      format: habiLog.format.combine(habiLog.format.timestamp(), habiLog.format.splat(), habiLog.format.simple()),
+    })],
+  })
+} catch (e) {
+  // ignore — habibot will use its default winston config
+}
+
+// ── readline UI ────────────────────────────────────────────────────────
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout, prompt: '> ' })
+
+// Print a narration / system line without clobbering whatever the user is
+// mid-typing: clear the current input line, print, then redraw the prompt
+// with the buffered input intact (rl.prompt(true) preserves the line).
+function print(line) {
+  if (line === undefined || line === null) return
+  readline.cursorTo(process.stdout, 0)
+  readline.clearLine(process.stdout, 0)
+  process.stdout.write(String(line) + '\n')
+  rl.prompt(true)
+}
+
+// ── the bot ──────────────────────────────────────────────────────────
+const bot = HabiBot.newWithConfig(argv.host, argv.port, argv.username)
+const renderer = makeRenderer(print)
+
+bot.on('connected', (b) => {
+  print(`Connected to ${argv.host}:${argv.port}. Entering ${argv.context}...`)
+  b.gotoContext(argv.context)
+})
+
+bot.on('disconnected', () => {
+  print('* Disconnected from server. (will retry)')
+})
+
+// Narrate every inbound message (verbose). Fires after world.apply, so
+// noids resolve to current names/positions.
+bot.on('msg', (b, o) => {
+  try { renderer.op(b, o) } catch (e) { print(`  [render error: ${e.message}]`) }
+})
+
+// Departures: the habiworld 'removed' event hands us the record before it
+// is gone (the raw delete op can't be resolved to a name after the fact).
+bot.world.on('removed', (record) => {
+  try { renderer.departed(bot, record) } catch (e) { /* non-fatal */ }
+})
+
+// On region entry, become corporeal then show the room. ensureCorporated
+// waits ~10s for imagery on a fresh corporate; that's fine for a human.
+let arrivedOnce = false
+bot.on('enteredRegion', (b) => {
+  b.ensureCorporated()
+    .then(() => {
+      print(commands.describeScene(b))
+      if (!arrivedOnce) {
+        arrivedOnce = true
+        print("Type HELP for commands. Just type a line to say it out loud.")
+      }
+    })
+    .catch((e) => print(`  (could not embody: ${e}); type LOOK to inspect the room`))
+})
+
+// ── input loop ─────────────────────────────────────────────────────────
+rl.on('line', async (line) => {
+  await commands.run(bot, line, { print })
+  rl.prompt()
+})
+
+rl.on('close', () => {
+  print('\nBye.')
+  process.exit(0)
+})
+
+print('Connecting...')
+bot.connect()
+rl.prompt()

--- a/textclient/lib/commands.js
+++ b/textclient/lib/commands.js
@@ -1,0 +1,388 @@
+/* jslint bitwise: true */
+/* jshint esversion: 8 */
+
+'use strict'
+
+// commands.js — parse a typed command line and dispatch it to the
+// EXISTING HabiBot API. This layer is a pure consumer: it only calls
+// public HabiBot methods and performVerb (the habiworld behavior
+// dispatcher). It never reaches into habibots/habiworld internals to
+// change state — see the "textclient: no habibots changes" rule.
+//
+// Command grammar is verb-first with a name-or-noid argument:
+//   GO <dir | name | noid>     GET <name | noid>      DROP [name|noid] [x y]
+//   SAY <text>                 ESP <name> <text>      OPEN/CLOSE <name|noid>
+//   READ <name|noid> [page]    DO <name|noid> [text]  TALK <name|noid> <text>
+//   SIT <name|noid> / STAND    GIVE <name|noid>       GRAB <name|noid>
+//   INV  WHO  LOOK  FACE <dir>  WAVE/JUMP/...  GHOST/CORPORATE  HELP  QUIT
+// A line whose first word is not a known command is spoken (SAY).
+
+const { resolve, label } = require('./resolve')
+const {
+  ACTION_DO, ACTION_GO, ACTION_GET, ACTION_PUT, ACTION_TALK,
+  HANDS,
+} = require('../../habiworld').constants
+
+const SCREEN_DIRS = ['UP', 'RIGHT', 'DOWN', 'LEFT']
+const CARDINALS = ['NORTH', 'EAST', 'SOUTH', 'WEST']
+const DIR_ALIASES = {
+  U: 'UP', D: 'DOWN', L: 'LEFT', R: 'RIGHT',
+  N: 'NORTH', E: 'EAST', S: 'SOUTH', W: 'WEST',
+}
+const POSTURES = ['WAVE', 'POINT', 'EXTEND_HAND', 'JUMP', 'BEND_OVER', 'STAND_UP', 'PUNCH', 'FROWN']
+
+// ── scene description (LOOK) ──────────────────────────────────────────
+// Built straight from the habiworld model (bot.world). Human-facing,
+// distinct from awareness.describeWorld (which is tuned for the LLM).
+function describeScene(bot) {
+  const w = bot.world
+  const lines = []
+  const region = w.region
+  lines.push('')
+  lines.push(`== ${region.name || region.ref || 'Unknown region'} ==`)
+
+  // Exits: neighbors[i] is a geographic slot; map to the screen side it
+  // appears on given the region orientation (same math as awareness.js).
+  const orientation = region.orientation || 0
+  const exits = []
+  for (let i = 0; i < 4; i++) {
+    const target = region.neighbors && region.neighbors[i]
+    if (target) {
+      const screen = SCREEN_DIRS[(i + 5 - orientation) % 4]
+      exits.push(`${screen}/${CARDINALS[i]}`)
+    }
+  }
+  lines.push(`Exits: ${exits.length ? exits.join(', ') : 'none'}`)
+
+  const meNoid = w.me ? w.me.noid : -1
+  const all = [...w.objects.values()]
+
+  // Avatars (other than us) present in the region.
+  const avatars = all.filter((o) => o.type === 'Avatar' && o.noid !== meNoid &&
+    o.containerRef === region.ref)
+  lines.push('')
+  lines.push('People here:')
+  if (avatars.length) {
+    for (const a of avatars) lines.push(`  - ${a.name || 'someone'} (noid ${a.noid}) at (${a.mod.x}, ${a.mod.y})`)
+  } else {
+    lines.push('  (nobody else)')
+  }
+
+  // Objects lying in the region (not held by anyone, not the region itself).
+  const objs = all.filter((o) =>
+    o.containerRef === region.ref &&
+    o.type !== 'Avatar' && o.type !== 'Ghost' && o.type !== 'Region')
+  lines.push('')
+  lines.push('Objects here:')
+  if (objs.length) {
+    for (const o of objs) {
+      const nm = o.name && o.name !== o.type ? `${o.name} ` : ''
+      lines.push(`  - ${nm}${o.type} (noid ${o.noid})`)
+    }
+  } else {
+    lines.push('  (nothing)')
+  }
+
+  lines.push('')
+  lines.push(inventoryText(bot))
+  lines.push('')
+  return lines.join('\n')
+}
+
+function inventoryText(bot) {
+  const w = bot.world
+  if (!w.me) return 'You are not embodied yet.'
+  const items = w.inventory(w.me.noid).filter((o) => o.type !== 'Avatar' && o.type !== 'Ghost')
+  const lines = ['You are carrying:']
+  if (!items.length) { lines.push('  (nothing)'); return lines.join('\n') }
+  for (const it of items) {
+    const where = it.mod.y === HANDS ? ' [in hands]' : ` [pocket slot ${it.mod.y}]`
+    const nm = it.name && it.name !== it.type ? `${it.name} ` : ''
+    lines.push(`  - ${nm}${it.type} (noid ${it.noid})${where}`)
+  }
+  return lines.join('\n')
+}
+
+// Find a walkable ground surface to drop onto (mirrors sage tools.js put_down).
+function groundSurface(w) {
+  for (const o of w.objects.values()) {
+    if (o.containerRef !== w.region.ref) continue
+    if (o.type === 'Street' || o.type === 'Ground') return o.noid
+    if ((o.type === 'Flat' || o.type === 'Trapezoid' || o.type === 'Super_trapezoid') &&
+        o.mod.flat_type === 2) return o.noid
+  }
+  return null
+}
+
+// ── dispatch plumbing ─────────────────────────────────────────────────
+
+// Resolve a name-or-noid token, printing a helpful message on miss /
+// ambiguity and returning null so the caller can bail.
+function target(bot, token, print) {
+  const r = resolve(bot.world, token)
+  if (!r) { print(`  ? no object matching "${token}" — try LOOK, or use its noid`); return null }
+  if (r.ambiguous) {
+    print(`  ? "${token}" is ambiguous:`)
+    for (const c of r.ambiguous.slice(0, 8)) print(`      ${label(c)}`)
+    print('    repeat the command with the noid.')
+    return null
+  }
+  return r
+}
+
+// Normalize a result from a HabiBot helper to a printable outcome line.
+function report(print, verb, result) {
+  if (result && result.ok === false) {
+    print(`  ✗ ${verb}: ${result.reason || result.error || 'failed'}`)
+  } else {
+    print(`  ✓ ${verb}`)
+  }
+  return result
+}
+
+const COMMANDS = {
+  async LOOK(bot, rest, toks, ctx) { ctx.print(describeScene(bot)) },
+
+  async GO(bot, rest, toks, ctx) {
+    if (!toks.length) { ctx.print('  GO where? a direction, name, or noid'); return }
+    const word = toks[0].toUpperCase()
+    const dir = DIR_ALIASES[word] || word
+    if (SCREEN_DIRS.includes(dir) || CARDINALS.includes(dir)) {
+      ctx.print(`  walking ${dir}...`)
+      try { await bot.walkToExit(dir); ctx.print(`  ✓ moved ${dir}`) }
+      catch (e) { ctx.print(`  ✗ GO ${dir}: ${e.message || e}`) }
+      return
+    }
+    const obj = target(bot, toks.join(' '), ctx.print)
+    if (!obj) return
+    report(ctx.print, `go to ${label(obj)}`, await bot.performVerb(ACTION_GO, obj.noid))
+  },
+
+  async GET(bot, rest, toks, ctx) {
+    const obj = target(bot, rest, ctx.print)
+    if (!obj) return
+    report(ctx.print, `get ${label(obj)}`, await bot.getIntoHands(obj.noid))
+  },
+
+  async DROP(bot, rest, toks, ctx) {
+    const w = bot.world
+    const held = w.me && w.holding(w.me.noid)
+    if (!held) { ctx.print('  ✗ drop: your hands are empty'); return }
+    // Optional [name|noid] container, then optional [x y].
+    let surfaceNoid = null
+    let x = 80, y = 144
+    const nums = toks.filter((t) => /^\d+$/.test(t))
+    const named = toks.filter((t) => !/^\d+$/.test(t))
+    if (named.length) {
+      const cont = target(bot, named.join(' '), ctx.print)
+      if (!cont) return
+      surfaceNoid = cont.noid
+    } else if (nums.length >= 2) {
+      x = Number(nums[0]); y = Number(nums[1])
+    }
+    if (surfaceNoid === null) surfaceNoid = groundSurface(w)
+    if (surfaceNoid === null) { ctx.print('  ✗ drop: no surface to drop onto here'); return }
+    report(ctx.print, `drop ${label(held)}`, await bot.performVerb(ACTION_PUT, surfaceNoid, { x, y }))
+  },
+
+  async SAY(bot, rest, toks, ctx) {
+    if (!rest) return
+    await bot.say(rest)
+    ctx.print(`You say: ${rest}`)
+  },
+
+  async ESP(bot, rest, toks, ctx) {
+    if (toks.length < 2) { ctx.print('  ESP <name> <message>'); return }
+    const to = toks[0]
+    const msg = toks.slice(1).join(' ')
+    await bot.say(`to:${to}`)
+    await bot.ESPsay(msg)
+    ctx.print(`You whisper to ${to}: ${msg}`)
+  },
+
+  async OPEN(bot, rest, toks, ctx) {
+    const obj = target(bot, rest, ctx.print)
+    if (!obj) return
+    report(ctx.print, `open ${label(obj)}`, await bot.openDoor(obj.ref))
+  },
+
+  async CLOSE(bot, rest, toks, ctx) {
+    const obj = target(bot, rest, ctx.print)
+    if (!obj) return
+    report(ctx.print, `close ${label(obj)}`, await bot.closeDoor(obj.ref))
+  },
+
+  async READ(bot, rest, toks, ctx) {
+    const nums = toks.filter((t) => /^\d+$/.test(t))
+    const named = toks.filter((t) => !/^\d+$/.test(t))
+    // If a name was given, the last bare number (if any) is the page.
+    let page = 0
+    let token = rest
+    if (named.length) { token = named.join(' '); if (nums.length) page = Number(nums[nums.length - 1]) }
+    const obj = target(bot, token, ctx.print)
+    if (!obj) return
+    const r = await bot.readObject(obj.ref, page)
+    if (!r || r.ok === false) { ctx.print(`  ✗ read: ${(r && r.reason) || 'failed'}`); return }
+    ctx.print(`  ── ${label(obj)} (page ${r.page}) ──`)
+    ctx.print(r.text ? `  ${r.text}` : '  (blank)')
+  },
+
+  async DO(bot, rest, toks, ctx) {
+    const named = toks.filter((t) => !/^\d+$/.test(t))
+    const obj = target(bot, named.length ? named[0] : rest, ctx.print)
+    if (!obj) return
+    const text = toks.slice(1).join(' ')
+    report(ctx.print, `do ${label(obj)}`, await bot.performVerb(ACTION_DO, obj.noid, { text }))
+  },
+
+  async TALK(bot, rest, toks, ctx) {
+    if (toks.length < 2) { ctx.print('  TALK <name|noid> <text>'); return }
+    const obj = target(bot, toks[0], ctx.print)
+    if (!obj) return
+    const text = toks.slice(1).join(' ')
+    const go = await bot.performVerb(ACTION_GO, obj.noid)
+    if (go && go.ok === false) { ctx.print(`  ✗ talk: could not reach it (${go.reason})`); return }
+    report(ctx.print, `talk to ${label(obj)}`, await bot.performVerb(ACTION_TALK, obj.noid, { text }))
+  },
+
+  async SIT(bot, rest, toks, ctx) {
+    const obj = target(bot, rest, ctx.print)
+    if (!obj) return
+    report(ctx.print, `sit on ${label(obj)}`, await bot.sitOrstand(1, obj.noid))
+  },
+
+  async STAND(bot, rest, toks, ctx) {
+    const w = bot.world
+    const me = w.me
+    const seat = me && me.containerRef && me.containerRef !== w.region.ref
+      ? w.getByRef(me.containerRef) : null
+    if (!seat) { ctx.print('  ✗ stand: you are not seated'); return }
+    report(ctx.print, 'stand up', await bot.sitOrstand(0, seat.noid))
+  },
+
+  async GIVE(bot, rest, toks, ctx) {
+    const obj = target(bot, rest, ctx.print)
+    if (!obj) return
+    if (obj.type !== 'Avatar') { ctx.print('  ✗ give: target must be an avatar'); return }
+    report(ctx.print, `give to ${label(obj)}`, await bot.giveObject(null, obj.noid))
+  },
+
+  async GRAB(bot, rest, toks, ctx) {
+    const obj = target(bot, rest, ctx.print)
+    if (!obj) return
+    if (obj.type !== 'Avatar') { ctx.print('  ✗ grab: target must be an avatar'); return }
+    report(ctx.print, `grab from ${label(obj)}`, await bot.grabFromAvatar(obj.noid))
+  },
+
+  async TOUCH(bot, rest, toks, ctx) {
+    const obj = target(bot, rest, ctx.print)
+    if (!obj) return
+    await bot.touchAvatar(obj.noid)
+    ctx.print(`  ✓ touch ${label(obj)}`)
+  },
+
+  async FACE(bot, rest, toks, ctx) {
+    const d = (toks[0] || '').toUpperCase()
+    if (!['LEFT', 'RIGHT', 'FORWARD', 'BEHIND'].includes(d)) {
+      ctx.print('  FACE LEFT|RIGHT|FORWARD|BEHIND'); return
+    }
+    try { await bot.faceDirection(d); ctx.print(`  ✓ facing ${d}`) }
+    catch (e) { ctx.print(`  ✗ face: ${e.message || e}`) }
+  },
+
+  async INV(bot, rest, toks, ctx) { ctx.print(inventoryText(bot)) },
+
+  async WHO(bot, rest, toks, ctx) {
+    await bot.userList()
+    ctx.print('  (asked elko for the online-user list — see the reply above)')
+  },
+
+  async GHOST(bot, rest, toks, ctx) {
+    await bot.discorporate()
+    ctx.print('  ✓ you turn into a ghost')
+  },
+
+  async CORPORATE(bot, rest, toks, ctx) {
+    await bot.corporate()
+    ctx.print('  ✓ you take corporeal form')
+  },
+
+  async HELP(bot, rest, toks, ctx) { ctx.print(helpText()) },
+
+  async QUIT(bot, rest, toks, ctx) {
+    ctx.print('Goodbye.')
+    try { await bot.discorporate() } catch (e) { /* best effort */ }
+    process.exit(0)
+  },
+}
+
+// Aliases.
+COMMANDS.L = COMMANDS.LOOK
+COMMANDS.I = COMMANDS.INV
+COMMANDS.PUT = COMMANDS.DROP
+COMMANDS.WHISPER = COMMANDS.ESP
+COMMANDS['?'] = COMMANDS.HELP
+COMMANDS.EXIT = COMMANDS.QUIT
+COMMANDS.STANDUP = COMMANDS.STAND
+// Postures as bare verbs (WAVE, JUMP, ...).
+for (const p of POSTURES) {
+  COMMANDS[p] = async (bot, rest, toks, ctx) => {
+    try { await bot.doPosture(p); ctx.print(`  ✓ ${p.toLowerCase()}`) }
+    catch (e) { ctx.print(`  ✗ ${p}: ${e.message || e}`) }
+  }
+}
+
+function helpText() {
+  return [
+    '',
+    'Commands (targets accept a name OR a noid; LOOK shows both):',
+    '  LOOK / L              describe the room, who and what is here',
+    '  GO <dir|name|noid>    walk to an exit (UP/DOWN/LEFT/RIGHT or N/E/S/W) or an object',
+    '  GET <name|noid>       pick an item up into your hands',
+    '  DROP/PUT [tgt] [x y]  drop what you hold (on the floor, or into a named container)',
+    '  SAY <text>            speak aloud (a bare line with no command is also spoken)',
+    '  ESP/WHISPER <who> <t> private telepathic message',
+    '  OPEN / CLOSE <tgt>    open or close a door/container',
+    '  READ <tgt> [page]     read a book/paper/sign/plaque',
+    '  DO <tgt> [text]       the universal Habitat DO verb',
+    '  TALK <tgt> <text>     talk to an object (oracle, teleport, elevator...)',
+    '  SIT <tgt> / STAND     sit on furniture / stand up',
+    '  GIVE <avatar>         hand what you hold to an avatar',
+    '  GRAB <avatar>         take what an avatar is holding',
+    '  TOUCH <avatar>        a friendly touch',
+    '  FACE <dir>            turn LEFT/RIGHT/FORWARD/BEHIND',
+    '  WAVE JUMP FROWN ...    postures/emotes',
+    '  INV / I               list what you are carrying',
+    '  WHO                   who is online',
+    '  GHOST / CORPORATE     toggle ghost form',
+    '  HELP / ?              this help',
+    '  QUIT / EXIT           leave',
+    '',
+  ].join('\n')
+}
+
+// Entry point: parse one line and run it. Unknown first word → speak the
+// whole line (Habitat is a chatty place).
+async function run(bot, line, ctx) {
+  const trimmed = (line || '').trim()
+  if (!trimmed) return
+  const sp = trimmed.indexOf(' ')
+  const verb = (sp === -1 ? trimmed : trimmed.slice(0, sp)).toUpperCase()
+  const rest = sp === -1 ? '' : trimmed.slice(sp + 1).trim()
+  const toks = rest.length ? rest.split(/\s+/) : []
+
+  const handler = COMMANDS[verb]
+  try {
+    if (handler) {
+      await handler(bot, rest, toks, ctx)
+    } else {
+      // Not a command → say it.
+      await bot.say(trimmed)
+      ctx.print(`You say: ${trimmed}`)
+    }
+  } catch (e) {
+    ctx.print(`  ✗ error: ${e && e.message ? e.message : e}`)
+  }
+}
+
+module.exports = { run, describeScene, inventoryText, helpText, COMMANDS }

--- a/textclient/lib/render.js
+++ b/textclient/lib/render.js
@@ -1,0 +1,305 @@
+/* jslint bitwise: true */
+/* jshint esversion: 8 */
+
+'use strict'
+
+// render.js — turn the inbound elko message stream into human narration.
+//
+// VERBOSE by design: every op the world recognises gets a line, and
+// anything unrecognised prints a dim `[op NAME]` marker so nothing is
+// silently dropped. Narration reads the habiworld model AFTER world.apply
+// has run (habibot calls world.apply before firing the 'msg' callback),
+// so noids already resolve to up-to-date names and positions.
+//
+// Two entry points, both wired in index.js:
+//   op(bot, o)         ← bot.on('msg')          — every inbound message
+//   departed(bot, rec) ← bot.world.on('removed')— object left / despawned
+//
+// Departures come through the habiworld 'removed' event rather than the
+// raw delete/GOAWAY_$ op because by the time 'msg' fires the record is
+// already gone from the model (can't resolve its name); the 'removed'
+// event hands us the record itself.
+
+// Avatar posture / direction pose ids → narration verb. Sources:
+// habibots/habibot.js AvatarPostures + DirectionToPoseId, and
+// Constants.java STAND_* / GET_SHOT_POSTURE.
+const POSTURE_VERB = {
+  141: 'waves',
+  136: 'points',
+  148: 'extends a hand',
+  139: 'jumps',
+  134: 'bends over',
+  135: 'stands up',
+  140: 'throws a punch',
+  142: 'frowns',
+  138: 'reels (shot!)',
+  254: 'faces left',
+  255: 'faces right',
+  146: 'faces forward',
+  143: 'turns away',
+  129: 'stands',
+  251: 'stands (left)',
+  252: 'stands (right)',
+}
+
+function makeRenderer(print) {
+  // ESP arrives as two OBJECTSPEAK_$ lines: "ESP from NAME: " then body.
+  let pendingEspFrom = null
+  let pendingEspAt = 0
+  const ESP_TTL_MS = 5000
+
+  function meNoid(bot) {
+    return bot.world && bot.world.me ? bot.world.me.noid : -1
+  }
+
+  // Name for a noid, falling back to the class type or a #noid marker.
+  function who(bot, noid) {
+    const r = bot.world.get(noid)
+    if (!r) return `#${noid}`
+    return r.name && r.name !== r.type ? r.name : r.type
+  }
+
+  function emit(line) {
+    if (line) print(line)
+  }
+
+  // ── speech ──────────────────────────────────────────────────────────
+  function speak(bot, o) {
+    if (o.noid === meNoid(bot)) return // our own line, already echoed locally
+    const text = o.text || ''
+    if (!text) return
+    emit(`${who(bot, o.noid)} says: ${text}`)
+  }
+
+  function objectSpeak(bot, o) {
+    const text = (o.text || '').trim()
+    if (!text) return
+
+    const header = text.match(/^ESP from (.+): $/)
+    if (header) {
+      pendingEspFrom = header[1]
+      pendingEspAt = Date.now()
+      return
+    }
+    if (pendingEspFrom && Date.now() - pendingEspAt < ESP_TTL_MS) {
+      const from = pendingEspFrom
+      pendingEspFrom = null
+      emit(`${from} whispers (ESP): ${text}`)
+      return
+    }
+    pendingEspFrom = null
+
+    // Other object speech: oracle replies, plaque text, system pings.
+    // Prefix with the speaking object's name when we can resolve it.
+    const speaker = o.speaker !== undefined ? bot.world.get(o.speaker) : null
+    const tag = speaker ? `${speaker.name || speaker.type}: ` : ''
+    emit(`  ${tag}${text}`)
+  }
+
+  // ── the op table ────────────────────────────────────────────────────
+  function op(bot, o) {
+    if (!o || typeof o !== 'object') return
+    if (!bot.world) return
+
+    // Session-level / replies are handled elsewhere (index prints command
+    // outcomes; region entry prints a LOOK). Skip them here.
+    if (o.type === 'reply' || o.type === 'changeContext') return
+
+    switch (o.op) {
+      case 'SPEAK$': return speak(bot, o)
+      case 'OBJECTSPEAK_$': return objectSpeak(bot, o)
+
+      case 'make': {
+        // Arrival of an avatar or appearance of an object. Skip our own
+        // entry (index prints the room on enteredRegion) and the Region.
+        if (o.you) return
+        const obj = o.obj
+        const mod = obj && obj.mods && obj.mods[0]
+        if (!mod || mod.type === 'Region') return
+        if (mod.type === 'Avatar') {
+          emit(`* ${obj.name || 'Someone'} has arrived.`)
+        } else if (mod.type === 'Ghost') {
+          // ghosts are invisible presence; keep it quiet but truthful
+          emit(`  (a ghostly presence drifts in)`)
+        } else {
+          const nm = obj.name && obj.name !== mod.type ? `${obj.name} ` : ''
+          emit(`  There is a ${nm}${mod.type} here. (noid ${mod.noid})`)
+        }
+        return
+      }
+
+      case 'WALK$': {
+        if (o.noid === meNoid(bot)) return
+        emit(`${who(bot, o.noid)} walks to (${o.x}, ${o.y}).`)
+        return
+      }
+
+      case 'POSTURE$': {
+        if (o.noid === meNoid(bot)) return
+        const verb = POSTURE_VERB[o.new_posture] || 'shifts posture'
+        emit(`${who(bot, o.noid)} ${verb}.`)
+        return
+      }
+
+      case 'APPEARING_$':
+        emit(`${who(bot, o.appearing)} appears.`)
+        return
+
+      // ── object manipulation by others ─────────────────────────────
+      case 'GET$':
+        emit(`${who(bot, o.noid)} picks up ${who(bot, o.target)}.`)
+        return
+      case 'GRABFROM$':
+        emit(`${who(bot, o.noid)} grabs something from ${who(bot, o.avatar_noid)}.`)
+        return
+      case 'PUT$':
+        emit(`${who(bot, o.noid)} puts down ${who(bot, o.obj)}.`)
+        return
+      case 'THROW$':
+        emit(`${who(bot, o.noid)} throws ${who(bot, o.obj)} to (${o.x}, ${o.y}).`)
+        return
+      case 'WEAR$':
+        emit(`${who(bot, o.noid)} puts something on.`)
+        return
+      case 'REMOVE$':
+        emit(`${who(bot, o.noid)} takes off ${who(bot, o.target)}.`)
+        return
+
+      // ── doors / containers ────────────────────────────────────────
+      case 'OPEN$':
+        emit(`${who(bot, o.target)} opens.`)
+        return
+      case 'CLOSE$':
+        emit(`${who(bot, o.target)} closes.`)
+        return
+      case 'OPENCONTAINER$':
+        emit(`${who(bot, o.cont)} opens.`)
+        return
+      case 'CLOSECONTAINER$':
+        emit(`${who(bot, o.cont)} closes.`)
+        return
+
+      // ── state / appearance ────────────────────────────────────────
+      case 'SIT$':
+        emit(`${who(bot, o.noid)} sits or stands.`)
+        return
+      case 'CHANGE$':
+        emit(`${who(bot, o.CHANGE_TARGET)} is reoriented.`)
+        return
+      case 'SEXCHANGE$':
+        emit(`${who(bot, o.AVATAR_NOID)} is transformed.`)
+        return
+      case 'SPRAY$':
+        emit(`${who(bot, o.noid)} sprays paint.`)
+        return
+      case 'ROLL$':
+        emit(`${who(bot, o.noid)} shows ${o.state}.`)
+        return
+      case 'WIND$':
+        emit(`${who(bot, o.noid)} is wound up.`)
+        return
+      case 'FILL$':
+        emit(`${who(bot, o.noid)} fills up.`)
+        return
+      case 'POUR$':
+        emit(`${who(bot, o.noid)} is poured out.`)
+        return
+      case 'SCAN$':
+        emit(`${who(bot, o.noid)} sweeps the area (scan).`)
+        return
+      case 'RESET$':
+        emit(`${who(bot, o.noid)} resets.`)
+        return
+
+      // ── lighting / power ──────────────────────────────────────────
+      case 'ON$':
+        emit(`${who(bot, o.noid)} switches on.`)
+        return
+      case 'OFF$':
+        emit(`${who(bot, o.noid)} switches off.`)
+        return
+      case 'CHANGELIGHT_$':
+        emit((o.adjustment || 0) >= 0 ? '  The room brightens.' : '  The room dims.')
+        return
+
+      // ── sounds / weapons / one-shots (choreography) ───────────────
+      case 'PLAY_$':
+        emit('  (a sound plays)')
+        return
+      case 'ATTACK$':
+        emit(`${who(bot, o.noid)} attacks!`)
+        return
+      case 'BASH$':
+        emit(`${who(bot, o.noid)} strikes!`)
+        return
+      case 'FAKESHOOT$':
+        emit(`${who(bot, o.noid)} fires — BANG! (a fake gun)`)
+        return
+      case 'RUB$':
+        emit(`${who(bot, o.noid)} rubs the lamp.`)
+        return
+      case 'WISH$':
+        emit(`${who(bot, o.noid)} makes a wish.`)
+        return
+      case 'DIG$':
+        emit(`${who(bot, o.noid)} digs.`)
+        return
+      case 'BUGOUT$':
+        emit(`${who(bot, o.noid)} vanishes in a hurry!`)
+        return
+      case 'MUNCH$':
+        emit('  *MUNCH* — the machine eats it.')
+        return
+      case 'FLUSH$':
+        emit('  *FLUSH*')
+        return
+      case 'ZAPTO$':
+        emit(`${who(bot, o.noid)} teleports away.`)
+        return
+      case 'TAKE$':
+        emit(`${who(bot, o.noid)} takes a dose.`)
+        return
+
+      // ── commerce (token movement) ─────────────────────────────────
+      case 'PAY$':
+      case 'PAYTO$':
+      case 'PAID$':
+      case 'SELL$':
+        emit('  (money changes hands)')
+        return
+
+      // ── deliberately quiet field pokes ────────────────────────────
+      case 'FIDDLE_$':
+      case 'CHANGE_CONTAINERS_$':
+      case 'VSELECT$':
+      case 'WAITFOR_$':
+      case 'delete':       // departures handled by departed() below
+      case 'GOAWAY_$':     // ditto
+        return
+
+      default:
+        if (o.op) emit(`  [· ${o.op}]`) // verbose: never drop an op
+        return
+    }
+  }
+
+  // Departures, via the habiworld 'removed' event (carries the record).
+  // Only narrate avatars and region-level objects — cascade-removed
+  // pocket contents of a departing avatar would otherwise spam lines.
+  function departed(bot, record) {
+    if (!record) return
+    const region = bot.world && bot.world.region
+    const wasInRegion = region && record.containerRef === region.ref
+    if (record.type === 'Avatar') {
+      emit(`* ${record.name || 'Someone'} leaves.`)
+    } else if (record.type === 'Ghost') {
+      // quiet
+    } else if (wasInRegion) {
+      emit(`  The ${record.name && record.name !== record.type ? record.name + ' ' : ''}${record.type} is gone.`)
+    }
+  }
+
+  return { op, departed }
+}
+
+module.exports = { makeRenderer, POSTURE_VERB }

--- a/textclient/lib/resolve.js
+++ b/textclient/lib/resolve.js
@@ -1,0 +1,73 @@
+/* jshint esversion: 8 */
+
+'use strict'
+
+// resolve.js — turn a user-typed "name or noid" token into a habiworld
+// record. Reads ONLY the habiworld world model (bot.world); it never
+// touches habibots internals, so the text client stays a pure consumer
+// of the public world state.
+//
+// Resolution order:
+//   1. all-digits           → that exact noid
+//   2. exact name (ci)      → the one record whose name matches
+//   3. exact type (ci)      → the one record whose class type matches
+//   4. substring of name    → unique substring hit
+//   5. substring of type    → unique substring hit
+// Ambiguous matches return { ambiguous: [...] } so the caller can ask the
+// user to disambiguate by noid; a miss returns null.
+
+// Everything visible in the region plus our own pockets — anything the
+// user could plausibly name. We don't filter by container: a held torch
+// and a ground rock are both legal targets for different verbs.
+function candidates(world) {
+  return [...world.objects.values()]
+}
+
+function lc(s) {
+  return (s || '').toLowerCase()
+}
+
+// Resolve a token to a single record, or signal ambiguity / miss.
+//   record         → resolved
+//   {ambiguous}    → more than one equally-good match
+//   null           → nothing matched
+function resolve(world, token) {
+  if (!world || !token) return null
+  const t = token.trim()
+  if (t === '') return null
+
+  if (/^\d+$/.test(t)) {
+    return world.get(Number(t))
+  }
+
+  const all = candidates(world)
+  const needle = lc(t)
+
+  const exactName = all.filter((o) => lc(o.name) === needle)
+  if (exactName.length === 1) return exactName[0]
+  if (exactName.length > 1) return { ambiguous: exactName }
+
+  const exactType = all.filter((o) => lc(o.type) === needle)
+  if (exactType.length === 1) return exactType[0]
+  if (exactType.length > 1) return { ambiguous: exactType }
+
+  const subName = all.filter((o) => lc(o.name).includes(needle))
+  if (subName.length === 1) return subName[0]
+  if (subName.length > 1) return { ambiguous: subName }
+
+  const subType = all.filter((o) => lc(o.type).includes(needle))
+  if (subType.length === 1) return subType[0]
+  if (subType.length > 1) return { ambiguous: subType }
+
+  return null
+}
+
+// Short label for prompts / ambiguity lists: `Name (Type, noid N)`.
+function label(record) {
+  if (!record) return '(nothing)'
+  const name = record.name && record.name !== record.type
+    ? `${record.name} ` : ''
+  return `${name}[${record.type} noid ${record.noid}]`
+}
+
+module.exports = { resolve, label, candidates }

--- a/textclient/package.json
+++ b/textclient/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "neohabitat-textclient",
+  "version": "0.1.0",
+  "description": "Human, text-only terminal client for NeoHabitat. A HabiBot driven by a person at a TTY: narrates the world and takes verb-first commands (GO/GET/SAY/...). Consumes the habibots/habiworld libraries read-only.",
+  "main": "index.js",
+  "bin": {
+    "neohabitat-textclient": "index.js"
+  },
+  "scripts": {
+    "start": "node index.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "habitat",
+    "neohabitat",
+    "client",
+    "terminal"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
## What this is

A **human-driven, text-only client** for NeoHabitat. You play the world from a plain terminal: it **narrates** everything happening around you (speech, emotes, walks, arrivals/departures, object changes, sounds, room contents) and accepts **verb-first commands** that operate on objects by **name or noid**:

```
GO <dir|name|noid>   GET <name|noid>   DROP/PUT [tgt] [x y]   SAY <text>
ESP/WHISPER <who> <t> OPEN/CLOSE <tgt>  READ <tgt> [page]      DO <tgt> [text]
TALK <tgt> <text>    SIT <tgt>/STAND   GIVE/GRAB/TOUCH <av>    FACE <dir>
WAVE JUMP FROWN ...  INV/I  WHO  LOOK/L  GHOST/CORPORATE  HELP/?  QUIT/EXIT
```

A bare line with no recognized command is simply spoken aloud.

## Relationship to `habibots` and `habiworld`

This client is **purely additive** and sits *on top of* the existing stack — it changes neither library:

- **`habibots/habibot.js` (`HabiBot`)** — imported read-only (`require('../habibots/habibot')`). It already owns the socket connection, reconnect/region-transit logic, the `habiworld` world model (`bot.world`), and the full verb-helper set (`performVerb`, `getIntoHands`, `walkToExit`, `openDoor`, `readObject`, …). The text client is essentially **a `HabiBot` whose driver is a person at a TTY** instead of a bot loop or an LLM (like `sagebot`).
- **`habiworld`** — the canonical client-side world model and behavior dispatcher. The client reads `bot.world` for scene/inventory rendering and resolves targets against it; verbs route through `performVerb` (the same path `sagebot` exercises).

> **Project rule honored here:** the text client does **not** modify `habibots/` or `habiworld/`. If something were missing from the public `HabiBot` API, we'd surface it rather than patch shared code that `habibots`/`sagebot` depend on. This PR touches no library files — only the new `textclient/` tree (plus one `.gitignore` exception).

The verb→helper mapping was lifted from the already-working table in `habibots/lib/sage/tools.js`, so client behavior matches what `sagebot` does today.

## Layout

```
textclient/
  index.js        entrypoint: zero-dep arg parsing, HabiBot wiring, readline loop
  lib/render.js   inbound elko op  -> verbose narration line
  lib/commands.js command parser + dispatch; LOOK scene renderer
  lib/resolve.js  "name or noid"   -> habiworld record
  package.json    zero deps (HabiBot's deps resolve from habibots/node_modules)
  README.md       launch + full command reference
```

Design notes:
- **Verbose narration** via a single `bot.on('msg')` sink — every op gets a line; unrecognized ops fall through to a dim `[· OP$]` marker so nothing is silently dropped. Your own speech/walks are suppressed (the command path already echoes them).
- **Departures** come via the habiworld `removed` event (the record is gone from the model by the time the raw `delete` op fires, so its name can't be resolved after the fact).
- **ESP** is reassembled from its two-part delivery.

## Running

No install needed — the only third-party modules belong to `HabiBot` and resolve from `habibots/node_modules`.

```sh
node textclient/index.js -c context-Downtown_5f -u <username>
```

Defaults to the dev bridge at `127.0.0.1:2026` (the `bridge_v2` port from `docker-compose.dev.yml`; bots always dial the bridge, never elko directly). Bring up elko + `bridge_v2` first, e.g. `./dev.sh --no-vice`.

## Verification

- All modules pass `node -c`; cross-dir requires resolve and `HabiBot` constructs with a live `world`.
- Offline harness against a seeded world: scene render, name/noid resolution, and narration (own-speech suppression, arrival, get, open, unknown-op fallback, departure).
- **Live in `context-Downtown_5f`** (as `randy`, through `bridge_v2:2026`): connected, embodied, auto-`LOOK`, then `LOOK`/`INV`/`SAY`/`WAVE`/`WHO`/`QUIT`. Live narration of `sagebot`/`ElizaBot` speech and movement worked — `sagebot` even reacted in character to the client ("Text client, huh?").

## `.gitignore`

Adds `!textclient/lib/`, matching the existing `!habibots/lib/` / `!habiworld/lib/` exceptions to the repo's broad `lib/` ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)