### PR TITLE
fix(textclient): silence harmless winston padLevels startup warning

### DIFF
--- a/textclient/index.js
+++ b/textclient/index.js
@@ -23,6 +23,20 @@
 
 const readline = require('readline')
 
+// Silence one specific, harmless startup warning before anything pulls in
+// winston: HabiBot requires winston, whose internals trip Node's
+// "Accessing non-existent property 'padLevels' ... inside circular
+// dependency" warning. It's a known winston quirk, not our bug, and
+// clutters the very first line a user sees. Filter only that message;
+// every other warning still passes through. Must run before the HabiBot
+// require below (which loads winston).
+const _emitWarning = process.emitWarning.bind(process)
+process.emitWarning = (warning, ...rest) => {
+  const msg = typeof warning === 'string' ? warning : (warning && warning.message) || ''
+  if (msg.includes("padLevels")) return
+  return _emitWarning(warning, ...rest)
+}
+
 const HabiBot = require('../habibots/habibot')
 const { makeRenderer } = require('./lib/render')
 const commands = require('./lib/commands')


### PR DESCRIPTION
Follow-up to #571.

`HabiBot` requires `winston`, whose internals trip Node's `Accessing non-existent property 'padLevels' ... inside circular dependency` warning on load. It's a known winston quirk (not our code), but it's the **first line a user sees** when launching the text client:

```
Connecting...
> (node:33052) Warning: Accessing non-existent property 'padLevels' of module exports inside circular dependency
```

This adds a tiny `process.emitWarning` override at the top of `textclient/index.js` — installed **before** the `HabiBot` require (which loads winston) — that drops **only** that specific message; every other warning still passes through.

Client-only change: no edits to `habibots/` or `habiworld/`.

Verified: startup is now clean (no warning line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)