### PR TITLE
feat(textclient): learn our avatar noid on appearance; resolve me/self

### DIFF
--- a/textclient/index.js
+++ b/textclient/index.js
@@ -137,6 +137,22 @@ bot.world.on('removed', (record) => {
   try { renderer.departed(bot, record) } catch (e) { /* non-fatal */ }
 })
 
+// Learn our own noid the moment our avatar make arrives. habiworld sets
+// world.me inside _makeObject (on the `make … you:true`) BEFORE emitting
+// 'added', so `record === bot.world.me` here identifies our own avatar.
+// world.me.noid is the canonical self-noid every avatar-targeting verb
+// resolves through (pocket_item, give, the `me`/`self` command target,
+// etc.); surfacing it confirms we latched it and tells the player who/what
+// they are. We re-announce on a noid change because corporating (ghost →
+// avatar) and silent reconnects hand us a fresh avatar noid.
+let myNoid = null
+bot.world.on('added', (record) => {
+  if (record !== bot.world.me || record.type !== 'Avatar') return
+  if (record.noid === myNoid) return
+  myNoid = record.noid
+  print(`You are ${record.name || argv.username} (noid ${record.noid}).`)
+})
+
 // On region entry, become corporeal then show the room. ensureCorporated
 // waits ~10s for imagery on a fresh corporate; that's fine for a human.
 let arrivedOnce = false

--- a/textclient/lib/resolve.js
+++ b/textclient/lib/resolve.js
@@ -31,10 +31,17 @@ function lc(s) {
 //   record         → resolved
 //   {ambiguous}    → more than one equally-good match
 //   null           → nothing matched
+// Words that mean "my own avatar" — resolved from world.me, the self-noid
+// habiworld latches on the `make … you:true`. Lets the player target
+// themselves (e.g. DO me) without looking up their own noid.
+const SELF_WORDS = new Set(['ME', 'SELF', 'I', 'MYSELF'])
+
 function resolve(world, token) {
   if (!world || !token) return null
   const t = token.trim()
   if (t === '') return null
+
+  if (SELF_WORDS.has(t.toUpperCase())) return world.me || null
 
   if (/^\d+$/.test(t)) {
     return world.get(Number(t))


### PR DESCRIPTION
Follow-up to #571.

Avatar-targeting verbs need our own noid. This makes the text client latch it explicitly when our avatar make arrives, and lets the player refer to themselves by name.

## Changes

- **`index.js`** — a `bot.world.on('added')` listener captures our self-noid the moment the `make … you:true` arrives and announces it:
  ```
  You are Randy (noid 11).
  ```
  habiworld sets `world.me` inside `_makeObject` *before* emitting `added`, so `record === bot.world.me` identifies our own avatar. It filters to the corporeal `Avatar` (skips the Ghost placeholder) and re-announces on a noid change (ghost→corporate transition, silent reconnect). `world.me.noid` is the canonical self-noid every avatar-targeting verb already routes through (`pocket_item`, `give`, `stand`, …).

- **`lib/resolve.js`** — `me` / `self` / `i` / `myself` now resolve to `world.me`, so you can target yourself by name (e.g. `DO me`) without looking up your noid.

Client-only: no edits to `habibots/` or `habiworld/`.

## Verification

- Offline: `me`/`self`/`i`/`myself` and the numeric/name forms all resolve to the avatar record.
- Live as `randy` in Plaza Fountain: `You are Randy (noid 11).` announced once on arrival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)