### PR TITLE
docs(textclient): document me/self targeting; add in-repo clients to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ If you'd like to contribute to NeoHabitat, there are plenty of great opportuniti
   - [Getting Started for Developers](https://github.com/frandallfarmer/neohabitat-doc/blob/master/docs/getting_started.md)
   - [Developer Wiki](https://github.com/frandallfarmer/neohabitat/wiki/Developers-Documentation)
 
+In-repo clients and libraries (besides the elko server in `src/` and the Go `bridge_v2/`):
+
+  - [`textclient/`](textclient/README.md) — a human, text-only terminal client: narrates the world and takes verb-first commands (`GO`/`GET`/`SAY`/…).
+  - [`habibots/`](habibots/README.md) — in-world bots (including the LLM-driven `sagebot`), built on the `HabiBot` connection + world-model layer.
+  - [`habiworld/`](habiworld/README.md) — the canonical client-side world model and 1986-faithful behavior dispatcher that the bots and `textclient` share.
+
+Clients and bots connect through `bridge_v2` (port 2026), never to the elko server directly.
+
 Have Fun!
 ---------
 

--- a/textclient/README.md
+++ b/textclient/README.md
@@ -47,8 +47,20 @@ Make sure elko + `bridge_v2` are up first (e.g.
 
 ## Commands
 
-Targets accept a **name or a noid** — `LOOK` lists both. A line whose first
-word is not a known command is spoken aloud.
+Targets accept a **name, a noid, or a self-word** (`me` / `self` / `i` /
+`myself`, which resolve to your own avatar — e.g. `DO me`). `LOOK` lists
+the names and noids around you. A line whose first word is not a known
+command is spoken aloud.
+
+When your avatar appears (on entry, after corporating, or after a
+reconnect) the client latches and announces your own noid:
+
+```
+You are Randy (noid 11).
+```
+
+That self-noid (`world.me.noid`) is what every avatar-targeting verb and
+the `me`/`self` words resolve through.
 
 | Command | Effect |
 |---|---|


### PR DESCRIPTION
Documentation refresh after the textclient work (#571, #573), so the repo is current for the next sub-project.

- **`textclient/README.md`** — document the `me`/`self`/`i`/`myself` self-target words and the `You are <name> (noid N)` self-noid announcement that shipped in #573.
- **`README.md`** — under *Developer Documentation*, list the in-repo clients/libraries ([`textclient/`](textclient/README.md), [`habibots/`](habibots/README.md), [`habiworld/`](habiworld/README.md)) and note that clients/bots connect through `bridge_v2` (port 2026), never elko directly.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)