### PR TITLE
feat(habisound): play the 3-part title and region-change tunes

### DIFF
--- a/habisound/README.md
+++ b/habisound/README.md
@@ -25,6 +25,8 @@ await hs.resume();          // call inside a click/keydown (browser autoplay pol
 hs.play('TELEPORT_ARRIVAL');        // by symbolic name (from habiworld behaviors)
 hs.play('CONTAINER_OPENING', { classHint: 'class_chest' }); // generic name + class
 hs.playFile('switch_click');        // by raw bank key (file stem)
+hs.playTune('title');               // 3-part tune ('title' | 'region_change')
+hs.playPiece(['a_v0','a_v1','a_v2']); // arbitrary multi-voice piece (max 3 parts)
 hs.stop();                          // silence everything (e.g. looping music)
 ```
 
@@ -102,6 +104,12 @@ startup and the effects rely on it; habisound defaults it to `0x0F`.
   averaged (the real chip AND's them) — a usable stand-in.
 - Music tracks (`titles_music_*`, `region_change_music_*`) play through the same engine;
   they loop forever by design (`stop` them when changing regions).
+- **3-part tunes.** The title theme and region-transition music are each three separate
+  one-voice parts (`*_v0/_v1/_v2`), played on oscillator voices 0/1/2 simultaneously —
+  exactly how `init.m` queued them. Each part's entry timing is baked into its own
+  bytecode as leading rests (e.g. the title theme builds up over ~5 s: voice 2 leads,
+  voice 1 enters at ~2.4 s, voice 0 at ~4.8 s). Use `playTune('title' | 'region_change')`,
+  or render offline with `node tools/render-wav.js tune:title out.wav 12`.
 
 ## Name table notes (`lib/names.js`)
 

--- a/habisound/demo/index.html
+++ b/habisound/demo/index.html
@@ -28,6 +28,8 @@
   <div id="bar">
     <button id="enable">▶ Enable audio</button>
     <button id="stop">■ Stop / silence</button>
+    <button id="title" title="3-part title theme — voices build in over ~5s">♪ Title theme</button>
+    <button id="region" title="3-part region-transition tune">♪ Region change</button>
     <input id="filter" type="search" placeholder="filter…" />
     <span id="status" class="muted"></span>
   </div>
@@ -70,6 +72,8 @@
 
     document.getElementById('enable').onclick = enable;
     document.getElementById('stop').onclick = () => hs.stop();
+    document.getElementById('title').onclick = () => hs.playTune('title');
+    document.getElementById('region').onclick = () => hs.playTune('region_change');
     document.getElementById('filter').oninput = (e) => render(e.target.value.trim());
   </script>
 </body>

--- a/habisound/lib/habisound.js
+++ b/habisound/lib/habisound.js
@@ -14,6 +14,13 @@
 
 import { resolve } from './names.js';
 
+// The two 3-part tunes, as the C64 client played them: each part is one SID
+// oscillator voice, all started together (entry staggering lives in the data).
+export const TUNES = {
+  title: ['titles_music_v0', 'titles_music_v1', 'titles_music_v2'],
+  region_change: ['region_change_music_v0', 'region_change_music_v1', 'region_change_music_v2'],
+};
+
 export class HabiSound {
   constructor(opts = {}) {
     // URLs resolve relative to this module by default, so the library works
@@ -74,6 +81,31 @@ export class HabiSound {
     this.resume();
     this.node.port.postMessage({ type: 'play', voices: s.voices, pw: s.pw || null });
     return true;
+  }
+
+  // Play a multi-voice piece: partKeys are bank keys, one per oscillator voice
+  // (max 3), started together. Use for the 3-part tunes. The piece takes over
+  // the chip, as it did in the client.
+  playPiece(partKeys) {
+    if (!this.ready) {
+      console.warn('habisound: call await init() before playing');
+      return false;
+    }
+    const parts = partKeys.slice(0, 3).map((k) => {
+      const s = this.bank[k];
+      if (!s || !s.voices) console.warn(`habisound: no sound named "${k}"`);
+      return { voices: s ? s.voices : null, pw: s ? s.pw || null : null };
+    });
+    this.resume();
+    this.node.port.postMessage({ type: 'playPiece', parts });
+    return true;
+  }
+
+  // Play one of the named TUNES ('title', 'region_change').
+  playTune(name) {
+    const keys = TUNES[name];
+    if (!keys) { console.warn(`habisound: unknown tune "${name}"`); return false; }
+    return this.playPiece(keys);
   }
 
   // Silence everything (useful for the looping music/continuous effects).

--- a/habisound/lib/interpreter.js
+++ b/habisound/lib/interpreter.js
@@ -92,6 +92,21 @@ export class SfxPlayer {
     return vi;
   }
 
+  // Play a multi-voice piece: parts[i] = { voices, pw } is assigned to
+  // oscillator voice i (and its paired pulse-width voice i+4), with all parts
+  // started on the same frame — exactly how the C64 queued the 3-part title and
+  // region-change tunes (init.m). Each part's entry timing is in its own
+  // bytecode (leading rests), so a simultaneous start reproduces the staggering.
+  // The piece takes over the chip (reset first), as it did in the client.
+  playPiece(parts) {
+    this.reset();
+    parts.forEach((part, i) => {
+      if (i >= FILTER_VOICE) return; // only the 3 oscillator voices
+      if (part.voices) this.queue[i] = part.voices;
+      if (part.pw) this.queue[i + 4] = part.pw;
+    });
+  }
+
   anyActive() {
     return this.active.some(Boolean);
   }

--- a/habisound/lib/synth-worklet.js
+++ b/habisound/lib/synth-worklet.js
@@ -16,6 +16,12 @@ class HabiSoundProcessor extends AudioWorkletProcessor {
         const voices = msg.voices ? Uint8Array.from(msg.voices) : null;
         const pw = msg.pw ? Uint8Array.from(msg.pw) : null;
         if (voices) this.synth.play(voices, pw);
+      } else if (msg.type === 'playPiece') {
+        const parts = msg.parts.map((p) => ({
+          voices: p.voices ? Uint8Array.from(p.voices) : null,
+          pw: p.pw ? Uint8Array.from(p.pw) : null,
+        }));
+        this.synth.playPiece(parts);
       } else if (msg.type === 'stop') {
         this.synth.stop();
       }

--- a/habisound/lib/synth.js
+++ b/habisound/lib/synth.js
@@ -45,6 +45,7 @@ export class SidSynth {
   }
 
   play(voices, pw = null) { this.player.play(voices, pw); }
+  playPiece(parts) { this.player.playPiece(parts); }
   stop() { this.player.reset(); for (const o of this.osc) Object.assign(o, new OscState()); }
   isBusy() { return this.player.isBusy(); }
 

--- a/habisound/tools/render-wav.js
+++ b/habisound/tools/render-wav.js
@@ -11,22 +11,32 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SidSynth } from '../lib/synth.js';
+import { TUNES } from '../lib/habisound.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const bank = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'sounds.json'), 'utf8'));
 
 const name = process.argv[2];
-const outFile = process.argv[3] || `${name}.wav`;
+const outFile = process.argv[3] || `${name.replace(/^tune:/, '')}.wav`;
 const maxSeconds = Number(process.argv[4] || 4);
 const FS = 44100;
 
-if (!name || !bank[name]) {
-  console.error(`usage: render-wav.js <sound> [out.wav] [seconds]\nunknown sound: ${name}`);
+const synth = new SidSynth(FS);
+
+if (name && name.startsWith('tune:')) {
+  // 3-part tune: tune:title  or  tune:region_change
+  const keys = TUNES[name.slice(5)];
+  if (!keys) { console.error(`unknown tune: ${name.slice(5)} (have: ${Object.keys(TUNES).join(', ')})`); process.exit(1); }
+  synth.playPiece(keys.map((k) => ({
+    voices: Uint8Array.from(bank[k].voices),
+    pw: bank[k].pw ? Uint8Array.from(bank[k].pw) : null,
+  })));
+} else if (name && bank[name]) {
+  synth.play(Uint8Array.from(bank[name].voices), bank[name].pw ? Uint8Array.from(bank[name].pw) : null);
+} else {
+  console.error(`usage: render-wav.js <sound|tune:NAME> [out.wav] [seconds]\nunknown sound: ${name}`);
   process.exit(1);
 }
-
-const synth = new SidSynth(FS);
-synth.play(Uint8Array.from(bank[name].voices), bank[name].pw ? Uint8Array.from(bank[name].pw) : null);
 
 // render in blocks until the sound finishes (or hits the cap, for loops)
 const block = 1024;


### PR DESCRIPTION
Adds proper playback of Habitat's two 3-part tunes — the **title theme** and the **region-transition** music — with a button for each in the soundboard.

### How the tunes work (from the C64 sources)
Each tune is three separate one-voice parts (`*_v0/_v1/_v2`). `init.m` queues all parts onto oscillator voices 0/1/2 **simultaneously**; the entry timing of each voice is baked into its own bytecode as leading rests. Verified by stepping the interpreter:

- **Title theme** builds up over ~5 s: voice 2 leads (frame 1), voice 1 enters at ~2.4 s, voice 0 at ~4.8 s — then each loops. (Confirmed audibly: per-second RMS steps up 0.26 → 0.34 → 0.38 as the voices enter.)
- **Region change**: all three layers enter immediately and loop as short phrases.

So both play correctly by starting the parts together and letting the faithful interpreter reproduce the rests — exactly what the client did.

### Changes
- `interpreter.js`: `SfxPlayer.playPiece(parts)` — assigns `parts[i]` to oscillator voice `i` (+ its pulse-width voice `i+4`), all started together after a reset (a piece takes over the chip, as in the client).
- `synth.js` + `synth-worklet.js`: `SidSynth.playPiece` + a `playPiece` message.
- `habisound.js`: `playPiece(keys)` and `playTune('title' | 'region_change')`, plus a `TUNES` registry.
- `demo/index.html`: **♪ Title theme** and **♪ Region change** buttons.
- `tools/render-wav.js`: `tune:NAME` mode to audition a tune offline (`node tools/render-wav.js tune:title out.wav 12`).

5/5 tests pass. Both tunes render non-silent with the expected build-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)