### PR TITLE
fix(bridge): make Elko forced-exit terminal; seal two dangling region exits

### DIFF
--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -147,6 +147,17 @@ type ClientSession struct {
 	// closeMutex held for cheap reuse of an existing mutex.
 	elkoRecovering bool
 
+	// elkoForcedExit is set when Elko sends a session `exit` (e.g.
+	// whycode:"badcontext" when a bot wanders through a dangling region
+	// exit whose target context isn't in the object DB). It makes the
+	// elko-side EOF that follows the exit TERMINAL: recoverElkoConnection
+	// must NOT silently redial and re-enter the context, or the bridge
+	// hot-loops entercontext → badcontext → EOF → reconnect → entercontext
+	// forever (~10/sec), hammering Elko. Mirrors the binary path, which
+	// already Close()s on a forced exit (handleElkoMessage). Accessed with
+	// closeMutex held, like doneClosed / elkoRecovering.
+	elkoForcedExit bool
+
 	// restoredSession is true after RestoreSession has rebuilt this
 	// ClientSession from a snapshot — i.e. we are about to re-enter the
 	// region's elko context on a FRESH elko TCP, and the client already
@@ -258,10 +269,18 @@ func (c *ClientSession) elkoReader(ready chan<- struct{}) {
 		// buffered Elko data draining after the client has gone away.
 		c.closeMutex.Lock()
 		closing := c.doneClosed
+		forcedExit := c.elkoForcedExit
 		c.closeMutex.Unlock()
 		if err != nil {
 			if closing {
 				c.log.Debug().Err(err).Msg("Elko reader exiting (teardown)")
+				return
+			}
+			// Elko forced this session out (handleElkoMessageJson saw an
+			// `exit` op and is tearing us down). The EOF here is expected;
+			// do NOT silent-reconnect or we'd re-enter the bad context.
+			if forcedExit {
+				c.log.Debug().Err(err).Msg("Elko reader exiting (forced exit)")
 				return
 			}
 			// Unplanned elko-side disconnect. The common cause is NOT
@@ -1307,7 +1326,7 @@ func (c *ClientSession) reconnectToElko(immediate bool, context string) {
 // with two live writer goroutines pulling from one elkoSendChan.
 func (c *ClientSession) recoverElkoConnection() {
 	c.closeMutex.Lock()
-	if c.doneClosed || c.elkoRecovering {
+	if c.doneClosed || c.elkoRecovering || c.elkoForcedExit {
 		c.closeMutex.Unlock()
 		return
 	}
@@ -1770,6 +1789,34 @@ func (c *ClientSession) handleElkoMessageJson(raw []byte, msg *ElkoMessage) {
 
 	// "you:true" on an avatar make → track so we can synthesize the
 	// arrival handshake on the next "ready".
+	// Server-forced session exit (kicked, full, or — the common case
+	// for wandering bots — whycode:"badcontext" when the target region
+	// isn't in the object DB). The binary path Close()s on this (see
+	// handleElkoMessage); the JSON path must too, otherwise the EOF that
+	// Elko sends right after the exit trips recoverElkoConnection, which
+	// re-enters the same dead context and hot-loops. Set elkoForcedExit
+	// synchronously (this runs in the elkoReader goroutine, before that
+	// same goroutine reads the following EOF) so the reconnect path is
+	// suppressed deterministically, relay the exit so the bot learns why,
+	// then tear the session down for HabiBot's reconnect loop.
+	if msg.Op != nil && *msg.Op == "exit" && msg.To != nil && *msg.To == "session" {
+		whyCode, why := "", ""
+		if msg.WhyCode != nil {
+			whyCode = *msg.WhyCode
+		}
+		if msg.Why != nil {
+			why = *msg.Why
+		}
+		c.log.Warn().Str("whycode", whyCode).Str("why", why).
+			Msg("Elko forced session exit; tearing down (no silent reconnect)")
+		c.writeJsonToClient(raw)
+		c.closeMutex.Lock()
+		c.elkoForcedExit = true
+		c.closeMutex.Unlock()
+		go c.Close()
+		return
+	}
+
 	if msg.Op != nil && *msg.Op == "make" && msg.You != nil && *msg.You {
 		c.waitingForAvatarContents = true
 		c.regionRef = ""

--- a/bridge_v2/bridge/elko_recover_test.go
+++ b/bridge_v2/bridge/elko_recover_test.go
@@ -251,6 +251,63 @@ func TestRecover_PrefersBridgeAutoEnteredContextOverRegionRef(t *testing.T) {
 	sess.Close()
 }
 
+func TestRecover_ForcedExitIsTerminal(t *testing.T) {
+	// Regression for the Sage infinite-reconnect loop: a wandering bot
+	// walked through a dangling region exit (context-region_10382, which
+	// isn't in the object DB). Elko replied
+	//   {to:session, op:exit, whycode:badcontext}
+	// then closed the socket. Pre-fix, the JSON path relayed the exit but
+	// did nothing else, so the EOF that followed tripped silent reconnect,
+	// which faithfully re-entered the same dead context — entercontext →
+	// badcontext → EOF → reconnect, ~10/sec forever, hammering Elko. A
+	// server-forced exit must be terminal (matching the binary path).
+	elko := newFakeElkoListener(t)
+	sess, clientRC := recoverTestSession(t, elko.addr(), "context-rent_front1")
+	// The in-flight transit target is the dead region — exactly what
+	// bridgeAutoEnteredContext holds after the walkToExit, and what
+	// recovery would otherwise re-enter.
+	sess.stateMu.Lock()
+	sess.bridgeAutoEnteredContext = "context-region_10382"
+	sess.stateMu.Unlock()
+	waitForRecoveryCondition(t, 2*time.Second, "initial dial", func() bool {
+		return elko.acceptedCount() >= 1
+	})
+
+	// Deliver Elko's forced exit on the JSON-passthrough path.
+	op, to := "exit", "session"
+	why, whycode := "invalid context context-region_10382", "badcontext"
+	raw := []byte(`{"to":"session","op":"exit","why":"invalid context context-region_10382","whycode":"badcontext"}`)
+	sess.handleElkoMessageJson(raw, &ElkoMessage{Op: &op, To: &to, Why: &why, WhyCode: &whycode})
+
+	// The forced-exit flag must latch, and the session must be torn down
+	// (go c.Close) so HabiBot reconnects cleanly into its home region.
+	waitForRecoveryCondition(t, 2*time.Second, "elkoForcedExit latched", func() bool {
+		sess.closeMutex.Lock()
+		defer sess.closeMutex.Unlock()
+		return sess.elkoForcedExit
+	})
+	waitForRecoveryCondition(t, 2*time.Second, "session removed after forced exit", func() bool {
+		sess.bridge.sessionsMutex.Lock()
+		defer sess.bridge.sessionsMutex.Unlock()
+		_, present := sess.bridge.Sessions[sess.TableKey()]
+		return !present
+	})
+	waitForRecoveryCondition(t, 2*time.Second, "client closed after forced exit", func() bool {
+		clientRC.mu.Lock()
+		defer clientRC.mu.Unlock()
+		return clientRC.closed
+	})
+
+	// Smoking gun: recovery must be a no-op now — no fresh dial, no
+	// re-enter of the dead context. (No loop.)
+	elko.closeAllAccepted()
+	sess.recoverElkoConnection()
+	time.Sleep(300 * time.Millisecond)
+	if got := elko.acceptedCount(); got != 0 {
+		t.Errorf("recovery re-dialed after forced exit (accepts: %d) — must be terminal", got)
+	}
+}
+
 func TestRecover_PlannedCloseDoesNotTriggerRecovery(t *testing.T) {
 	// When Close() is what flipped doneClosed, the elkoReader EOF
 	// must NOT spin up a doomed recovery goroutine that races the

--- a/db/new_Downtown/rent_front1.json
+++ b/db/new_Downtown/rent_front1.json
@@ -11,7 +11,7 @@
         "type": "Region",
         "orientation": 1,
         "neighbors": [
-          "context-region_10382",
+          "",
           "context-court_front",
           "",
           "context-rent_front2"

--- a/db/new_Downtown/rent_front2.json
+++ b/db/new_Downtown/rent_front2.json
@@ -11,7 +11,7 @@
         "type": "Region",
         "orientation": 1,
         "neighbors": [
-          "context-region_10378",
+          "",
           "context-rent_front1",
           "",
           "context-rent_front3"


### PR DESCRIPTION
## What

Fixes a production incident where **sagebot appeared "crashed"** — actually its bridge session was stuck in a **tight infinite reconnect loop** hammering Elko (~10×/sec, 15k+ attempts).

## Root cause

A wandering bot walked NORTH out of `rent_front1`/`rent_front2` into `context-region_10382` / `context-region_10378` — regions referenced as exits but **never seeded into the object DB**. Elko replied `{op:exit,whycode:badcontext}` and dropped the backend socket. The **JSON-passthrough path** (used by bots) relayed the exit but took no further action, so the EOF that followed tripped `recoverElkoConnection`, which faithfully re-entered the same dead context — `entercontext → badcontext → EOF → reconnect`, forever. The retry/backoff only guards *dial* failures; here the dial always succeeded and Elko rejected at the app layer, so nothing rate-limited it.

This is the inverse of the prior silent-reconnect bug (empty region → never re-enters); here a *bad* region → re-enters forever.

## Fix

- The binary path already `Close()`s on a server-forced exit (`handleElkoMessage`); the JSON path now does too.
- New `elkoForcedExit` flag latches **synchronously** in the `elkoReader` goroutine (before it reads the following EOF); both reconnect triggers (the recover guard + the elkoReader EOF branch) honor it, so the session tears down for HabiBot to reconnect cleanly instead of looping.
- Seals the two dangling exits in the seed map data (`neighbors[0] → ""`), matching siblings `court_front`/`rent_front3`. Live mongo was corrected out of band; a full `elko.odb` integrity scan confirms **no other dangling exits remain**.

## Test

Adds `TestRecover_ForcedExitIsTerminal` (forced exit → flag latched → session torn down → **0 re-dials**). `go vet` clean; full `bridge_v2` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)