### PR TITLE
perf(webclient): Phase 7b — FG/BG render split + across-region leak fix

### DIFF
--- a/webclient/DESIGN.md
+++ b/webclient/DESIGN.md
@@ -371,7 +371,8 @@ Each phase is independently demoable in the page shell.
     **synthesized from `location`** (same origin as the page, ws/wss to match; `?ws=` overrides
     for dev where the proxy is a separate port). `live.html` is a clean shell.
     *Open:* the title and client each spin up their own habisound engine — share one (a 7b
-    concern); and the title-music opening ~1s is still swallowed (task: title music warm-up).
+    concern). (The title-music opening ~1s swallow is **resolved** — it has played correctly
+    since at least the Alpha release, locally; no warm-up workaround needed.)
 
   - **7b. Performance — load time, render cadence, and steady-state memory.** This is a
     no-build, native-ESM client that fetches habiworld's ~27 CommonJS modules over http and

--- a/webclient/DESIGN.md
+++ b/webclient/DESIGN.md
@@ -374,34 +374,43 @@ Each phase is independently demoable in the page shell.
     concern). (The title-music opening ~1s swallow is **resolved** — it has played correctly
     since at least the Alpha release, locally; no warm-up workaround needed.)
 
-  - **7b. Performance — load time, render cadence, and steady-state memory.** This is a
-    no-build, native-ESM client that fetches habiworld's ~27 CommonJS modules over http and
-    decodes original C64 art in the browser; measure and tighten the cost.
-    - **Load time.** Bundle/concatenate or precompute the habiworld module graph so first
-      paint isn't gated on a waterfall of `fetch`es (`lib/habiworld.js` currently crawls +
-      fetches each module); cache/memoize decoded cels and charset glyphs; confirm the audio
-      worklet and image decode aren't blocking first frame.
-    - **Background/foreground render split (C64 hack).** The C64 client did **not** recompose
-      the whole scene each frame: the region backdrop + static/background objects were rendered
-      **once** (`background_render`; `forced_render_region` on mode exit), and only the
-      **foreground** objects — the avatars and other moving/animating items — were redrawn per
-      frame over that fixed background. Port the same split: composite the static background
-      to a cached layer once per region (and on background-object change), and per delta/tick
-      only recompose the FG objects. Today `worldToObjects` + a full region recompose runs on
-      **every** delta, which is both the frame-cost and a likely source of churn — replace it
-      with FG-only recomposition against the cached BG.
-    - **Steady-state memory / degradation over time.** We see **rendering performance
-      degrading the longer you stay in a region**, possibly tied to **modal display** use
-      (inventory grid / text mode entering and exiting). Investigate as a leak/accumulation
-      bug: decoded-cel or offscreen-canvas caches that grow without bound, balloon/animation
-      timers or world event listeners not torn down on mode switch or region change (e.g.
-      `trackAvatarsForBalloons`, `avatarMotion` intervals, the per-event `refresh`
-      subscriptions), and modal views (`text-view.js` / `inventory-view.js`) not releasing
-      their canvases/handlers on exit. Profile heap + listener counts across repeated
-      mode-enter/exit and a long region dwell; fix whatever grows unbounded.
-    - Drive all of the above with **real numbers** — time-to-first-region, per-frame cost in a
-      crowded region, and a heap/listener trend over a multi-minute session with repeated
-      modal entry/exit — rather than guesses.
+  - **7b. Performance — render cadence + steady-state memory. DONE (load-time deferred).**
+    A no-build, native-ESM client that decodes original C64 art in the browser. The render
+    cadence and the across-region memory creep are fixed; first-paint load time is deferred
+    (see below). Verified in-browser with real numbers: INP warms from ~72ms to ~144ms over
+    the first few regions (decoded-art cache filling — `imageFileMapSignal`, bounded/intended)
+    then stays **flat** walking across town, instead of doubling region-over-region.
+    - **Background/foreground render split (C64 `Main/render.m`). DONE.** On the C64, the
+      foreground objects — avatars, always flagged `0x80` (`walkto.m: ora #0x80`) — are the
+      only ones redrawn every frame; background objects are re-rendered only when
+      `background_render` is set (region load, `forced_render_region` on mode exit, a BG-object
+      change). The webclient renders one Preact component per object, each with a `layout`
+      signal computed in an effect that read `avatarMotion.tick` **unconditionally** — so every
+      static prop re-decoded on every frame. Fixed by reading tick only in the avatar (body)
+      branch: avatars recompose per frame, BG props recompute only on their own obj/prop/
+      container change, held items ride their carrier's tick-reactive layout. `computeLayoutMap`
+      no longer re-runs per frame either.
+    - **Steady-state memory / across-region INP creep. DONE (this was the real degradation).**
+      `computeLayoutMap` created two root `effect()`s per object and never disposed them. A bare
+      effect lives until its disposer is called, holding its signal subscriptions (notably
+      `avatarMotion.tick`) and closure — so every region walked through permanently left its
+      objects' effects alive and **still firing every animation frame**, making per-frame work
+      and INP climb monotonically and never recover on leaving a heavy region. Fixed by
+      capturing each effect's disposer and tearing them down when an object leaves the map
+      (departed / region hop) and on `regionView` unmount. (Ruled out as non-leaks first:
+      modal keydown listeners are paired; balloon scrollback is capped; the avatar override
+      maps are 256-noid-bounded; `trapCache` is cleared on region hop.) Also: the avatar
+      sprite-mover `setInterval` now stops when nothing is animating.
+    - **Load time — DEFERRED (not blocking).** `lib/habiworld.js` still crawls + fetches
+      habiworld's ~27 modules in a waterfall; bundling/precomputing the module graph and
+      memoizing decoded cels/charset glyphs would cut time-to-first-region. Not done — the
+      interactive/steady-state cost (above) was the priority and is resolved.
+    - **Pick-path readback — DEFERRED (not blocking).** Picks read composite-layer canvases
+      via `getImageData` (`pick.mjs:85/97/116`) whose contexts were created during compositing
+      **without** `willReadFrequently` (so the pick-time flag is ignored — context attributes
+      are fixed at first `getContext`); this is the `pointerup took NNNms` jank. Fix is to
+      create the read-back canvases with the flag in `render.js`; a measurable interaction-
+      latency win when picked up.
 
   - **7c. Cleanup — repo hygiene and ground-truth debts.**
     - **`classes.js` → beta.mud ground truth.** The committed `habiworld/lib/classes.js` was

--- a/webclient/habirender/region.js
+++ b/webclient/habirender/region.js
@@ -4,7 +4,7 @@ import { choreographyNameFromMod, headFacingFromAction, displayOrientForActivity
 import { shouldPaintFacePlate } from "./face-plate.js"
 import { html, catcher } from "./view.js"
 import { createContext } from "preact"
-import { useContext, useMemo } from "preact/hooks"
+import { useContext, useMemo, useEffect } from "preact/hooks"
 import { signal, computed, effect, useSignal, useSignalEffect } from "@preact/signals"
 import { contextMap, betaMud, logError, promiseToSignal, until, useBinary, useHabitatJson, charset } from './data.js'
 import { translateSpace, topLeftCanvasOffset, Scale, framesFromPropAnimation, framesFromAction, frameFromCels, celsFromMask,
@@ -619,17 +619,25 @@ export const computeLayoutMap = (objects, sig = signal({}), avatarMotion = null)
         layoutMap[ref] = layoutItem
         layoutItem.obj.value = obj
         if (!layoutItem.layout) {
+            // Capture each root effect's disposer. A bare effect() is a ROOT effect: it lives
+            // forever unless its returned disposer is called, holding its signal subscriptions
+            // (notably avatarMotion.tick, for avatars) and closure alive. Without disposal, every
+            // region you pass through permanently leaves dead-object effects that keep firing on
+            // every animation frame — INP climbs monotonically across town and never recovers when
+            // you leave a heavy region. Disposed when the object leaves the map (departed / region
+            // hop, below) or the layout unmounts (regionLayout cleanup).
+            layoutItem.disposers = []
             layoutItem.prop = signal(null)
-            effect(() => {
+            layoutItem.disposers.push(effect(() => {
                 try {
                     layoutItem.prop.value = propFromMod(layoutItem.obj.value.mods[0], ref)
                 } catch(e) {
                     console.error(e)
                 }
-            })
+            }))
             layoutItem.container = computed(() => sig.value[layoutItem.obj.value.in])
             layoutItem.layout = signal(null)
-            effect(() => {
+            layoutItem.disposers.push(effect(() => {
                 const { obj, prop, container, layout } = layoutItem
                 var newLayout = null
                 if (prop.value) {
@@ -713,7 +721,18 @@ export const computeLayoutMap = (objects, sig = signal({}), avatarMotion = null)
                     }
                 }
                 layout.value = newLayout
-            })
+            }))
+        }
+    }
+    // Dispose effects for objects that were in the previous map but are gone now (departed
+    // avatars, or the empty-objects step that precedes a region's make-storm). Frees their
+    // tick/signal subscriptions and closures so they stop running every frame and become
+    // GC-able — the across-region INP-creep fix.
+    const prev = sig.peek()
+    for (const oldRef in prev) {
+        if (!layoutMap[oldRef] && prev[oldRef]?.disposers) {
+            for (const dispose of prev[oldRef].disposers) dispose()
+            prev[oldRef].disposers = null
         }
     }
     sig.value = layoutMap
@@ -741,6 +760,20 @@ export const regionLayout = ({ objects, avatarMotion, children, pickState = null
             pickState.objects = sigObjects.value
         }
     })
+    // regionView fully unmounts on a region hop (objects → empty between contexts). The
+    // per-rebuild disposal in computeLayoutMap only runs while this component is mounted, so
+    // dispose every remaining layout item's effects on unmount — otherwise the just-departed
+    // region's per-object root effects outlive the component, orphaned but still subscribed to
+    // tick, and pile up region after region (the INP creep). Empty deps: runs only on unmount.
+    useEffect(() => () => {
+        const map = layoutMap.peek()
+        for (const ref in map) {
+            if (map[ref]?.disposers) {
+                for (const dispose of map[ref].disposers) dispose()
+                map[ref].disposers = null
+            }
+        }
+    }, [])
     return html`<${LayoutMap.Provider} value=${({ objects, map: layoutMap, avatarMotion })}>${children}<//>`
 }
 

--- a/webclient/habirender/region.js
+++ b/webclient/habirender/region.js
@@ -631,7 +631,6 @@ export const computeLayoutMap = (objects, sig = signal({}), avatarMotion = null)
             layoutItem.layout = signal(null)
             effect(() => {
                 const { obj, prop, container, layout } = layoutItem
-                avatarMotion?.tick?.value
                 var newLayout = null
                 if (prop.value) {
                     if (container.value?.layout?.value) {
@@ -644,6 +643,16 @@ export const computeLayoutMap = (objects, sig = signal({}), avatarMotion = null)
                         )
                     } else if (!container.value) {
                         if (prop.value.isBody) {
+                            // FG/BG split (C64 Main/render.m): foreground objects — avatars,
+                            // always flagged 0x80 (walkto.m: `ora #0x80`) — are the only ones
+                            // recomposited every animation frame. Read avatarMotion.tick HERE,
+                            // inside the body branch, instead of at the top of the effect: a
+                            // static background prop's layout effect then has NO tick dependency,
+                            // so it re-runs only when its own obj/prop/container signals change
+                            // (the C64 `background_render` "only on change" rule), not 30×/sec.
+                            // Held items read their container's (avatar's) tick-reactive layout
+                            // below, so they stay in sync with their carrier without a direct dep.
+                            avatarMotion?.tick?.value
                             const serverMod = obj.value.mods[0]
                             const motion = avatarMotion?.get?.(serverMod.noid) ?? null
                             const findSlot = (slot) => Object.values(sig.value).find((li) =>
@@ -721,7 +730,11 @@ export const regionLayout = ({ objects, avatarMotion, children, pickState = null
     const sigObjects = useSignal(objects)
     sigObjects.value = objects
     useSignalEffect(() => {
-        avatarMotion?.tick?.value
+        // No tick read here (FG/BG split): computeLayoutMap rebuilds the whole layoutMap signal,
+        // so running it every animation frame churned every item's container/layout subscribers.
+        // It only needs to run when the OBJECT SET changes (added/removed refs, new server mods).
+        // The per-item layout effects it creates self-subscribe to avatarMotion.tick for the
+        // avatars that animate per-frame, so foreground motion still updates without this re-loop.
         computeLayoutMap(sigObjects.value, layoutMap, avatarMotion)
         if (pickState) {
             pickState.layoutMap = layoutMap.value

--- a/webclient/lib/avatar-chore.js
+++ b/webclient/lib/avatar-chore.js
@@ -203,6 +203,10 @@ export function createAvatarMotion({ frameMs = FRAME_MS } = {}) {
                 }
             }
             if (changed) bump()
+            // animate.m: the C64 sprite mover only ran while something was in motion.
+            // Stop the interval once no avatar is animating, so an idle region doesn't
+            // wake the tab every frame forever. beginWalk/beginGesture restart it.
+            if (states.size === 0) { clearInterval(timer); timer = null }
         }, frameMs)
     }
 
@@ -324,6 +328,7 @@ export function createAvatarMotion({ frameMs = FRAME_MS } = {}) {
         gestureQueues.clear()
         orientOverrides.clear()
         activityOverrides.clear()
+        if (timer) { clearInterval(timer); timer = null }   // stop the sprite mover on region hop / disconnect
         bump()
     }
 

--- a/webclient/lib/live.js
+++ b/webclient/lib/live.js
@@ -322,8 +322,8 @@ async function main() {
       url: ws,
       onMessage: (m) => {
         gotMsg = true
-        const traceChore = m.op === "PLAY_$"
-          || (m.op?.endsWith?.("$") && m.op !== "WALK$" && m.op !== "FIDDLE_$")
+        const traceChore = SOUND_TRACE && (m.op === "PLAY_$"
+          || (m.op?.endsWith?.("$") && m.op !== "WALK$" && m.op !== "FIDDLE_$"))
         if (traceChore) {
           const fromRec = m.from_noid != null ? world.get(m.from_noid) : null
           console.log("[sound-trace] ws inbound:", m.op, {


### PR DESCRIPTION
## What

Phase 7b performance work for the Alpha web client. Render cadence and the across-region memory creep are fixed and verified in-browser; first-paint load time is deferred (not blocking).

## Changes

- **FG/BG render split** (C64 `Main/render.m`): avatars (foreground, always `0x80`) are the only objects recomposed per animation frame; static background props recompute only when their own obj/prop/container signals change. Each item's `layout` effect read `avatarMotion.tick` unconditionally before — so every static prop re-decoded every frame.
- **Dispose per-object layout effects** (the real degradation fix): `computeLayoutMap` created two root `effect()`s per object and never disposed them. The layout effect subscribes to `avatarMotion.tick`, so every region walked through permanently left dead-object effects **still firing every frame** → INP climbed monotonically across town and never recovered. Now disposed when an object leaves the map (departed / region hop) and on `regionView` unmount.
- **Idle sprite-mover interval**: the avatar animation `setInterval` now stops when nothing is animating (and on region hop / disconnect).
- **Sound-trace** chore log gated behind `SOUND_TRACE` (was always-on).

## Verification

In-browser (local stack): INP warms ~72→144ms over the first few regions (decoded-art cache `imageFileMapSignal` filling — bounded/intended), then stays **flat** walking across town instead of doubling region-over-region. Confirmed by the user.

## Deferred (tracked, non-blocking)

First-paint load time (habiworld module-fetch waterfall) and the pick-path `willReadFrequently` readback jank — see DESIGN 7b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)