### PR TITLE
Webclient + server bug-fix batch: god tool, ESP, scrollback, trap/box picking, wisher, page-wrap

### DIFF
--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -849,9 +849,20 @@ func (c *ClientSession) unpackHabitatObject(o *ElkoMessage, containerRef string)
 				*field = &newVal
 			}
 		}
+		// Wisher is *uint16 (it can be UNASSIGNED_NOID = 256 when no wish is in flight).
+		// Only real avatar noids (0–255) are remappable; skip the 256 sentinel.
+		rewriteNestedNoid16 := func(field **uint16) {
+			if field == nil || *field == nil || **field > 255 {
+				return
+			}
+			if saved, found := c.restoreElkoToSaved[uint8(**field)]; found && saved != uint8(**field) {
+				newVal := uint16(saved)
+				*field = &newVal
+			}
+		}
 		rewriteNestedNoid(&mod.SittingIn)
 		rewriteNestedNoid(&mod.Restrainer)
-		rewriteNestedNoid(&mod.Wisher)
+		rewriteNestedNoid16(&mod.Wisher)
 	}
 
 	if clientMessages, found := ObjectClientMessages[*mod.Type]; found {

--- a/bridge_v2/bridge/elko_state_encoders.go
+++ b/bridge_v2/bridge/elko_state_encoders.go
@@ -249,7 +249,7 @@ func init() {
 	ElkoStateEncoders["Magic_lamp"] = func(state *HabitatMod, container uint8, buf *HabBuf) *HabBuf {
 		buf = ElkoStateEncoders["common"](state, container, buf)
 		buf.AddInt(u8or(state.LampState, 0))
-		buf.AddInt(u8or(state.Wisher, 0))
+		buf.AddInt(noidU8(state.Wisher)) // *uint16 → byte (UNASSIGNED_NOID 256 → GHOST_NOID)
 		return buf
 	}
 

--- a/bridge_v2/bridge/restore_noid_rewrite_test.go
+++ b/bridge_v2/bridge/restore_noid_rewrite_test.go
@@ -177,7 +177,7 @@ func TestRestore_RewritesWisherUsingPriorMapping(t *testing.T) {
 	}
 
 	lampMsg := makeMsg("Magic_lamp", "item-lamp-1", 60)
-	wisher := uint8(31) // elko's noid for randy
+	wisher := uint16(31) // elko's noid for randy
 	lampMsg.Obj.Mods[0].Wisher = &wisher
 	if err := sess.unpackHabitatObject(lampMsg, "context-Downtown_5c"); err != nil {
 		t.Fatalf("lamp unpack: %v", err)

--- a/bridge_v2/bridge/schema.go
+++ b/bridge_v2/bridge/schema.go
@@ -392,7 +392,11 @@ type HabitatMod struct {
 	WhoAmI          *uint8    `json:"Who_am_I,omitempty" bson:"Who_am_I,omitempty"`
 	Width           *uint8    `json:"width,omitempty" bson:"width,omitempty"`
 	WindLevel       *uint8    `json:"wind_level,omitempty" bson:"wind_level,omitempty"`
-	Wisher          *uint8    `json:"wisher,omitempty" bson:"wisher,omitempty"`
+	// *uint16 (not *uint8): Magic_lamp's wisher is UNASSIGNED_NOID (256) when no wish is
+	// in flight (Magic_lamp.java), which overflows uint8 — json.Unmarshal then dropped the
+	// whole `make` message ("cannot unmarshal number 256 into ... uint8"). Same convention
+	// as Appearing/Speaker; narrowed back to a byte at binary-encode time via noidU8.
+	Wisher          *uint16   `json:"wisher,omitempty" bson:"wisher,omitempty"`
 	X               *uint8    `json:"x,omitempty" bson:"x,omitempty"`
 	XOffset1        *uint8    `json:"x_offset_1,omitempty" bson:"x_offset_1,omitempty"`
 	XOffset2        *uint8    `json:"x_offset_2,omitempty" bson:"x_offset_2,omitempty"`

--- a/src/main/java/org/made/neohabitat/Document.java
+++ b/src/main/java/org/made/neohabitat/Document.java
@@ -167,7 +167,14 @@ public abstract class Document extends HabitatMod {
     public void READ(User from, OptInteger page) {
         int page_to_read = page.value(0);
         if (page_to_read == 254) { // aka -1: BACK pressed on UI.
-            page_to_read = Math.max(1, next_page - 2);
+            // BACK is circular, symmetric with NEXT's forward wrap below: going back
+            // from page 1 wraps to the last page. Previously this clamped to page 1
+            // (Math.max(1, ...)), so back never left the first page — you could page
+            // forward all the way around but not backward off page 1.
+            page_to_read = next_page - 2;
+            if (page_to_read < 1) {
+                page_to_read = last_page;
+            }
         } else if (page_to_read == 0) {
             page_to_read = next_page;
         }

--- a/webclient/habirender/pick.mjs
+++ b/webclient/habirender/pick.mjs
@@ -94,6 +94,19 @@ export const hitTestFrame = (frame, canvasX, canvasY, itemPx, itemPy) => {
   const lx = Math.floor(canvasX - itemPx)
   const ly = Math.floor(canvasY - itemPy)
   if (lx < 0 || ly < 0 || lx >= frame.canvas.width || ly >= frame.canvas.height) return false
+  // pointer.m boundary_check: a trapezoid (cel_trap) is hit-tested GEOMETRICALLY (trap.m —
+  // is the cursor inside the slanted quad), NOT by cel-pixel opacity. A textured ground
+  // trapezoid has transparent gaps in its fill; without this, clicks landing in a gap miss
+  // the ground and fall through to the sky Flat behind it → wrongful sky_go. Check the quad
+  // coverage spans first; everything else falls through to the cel-pixel test below.
+  if (frame.trapLayers) {
+    for (const tl of frame.trapLayers) {
+      const ty = ly - tl.offsetY
+      if (ty < 0 || ty >= tl.spans.length) continue
+      const span = tl.spans[ty]
+      if (span && lx >= span[0] + tl.offsetX && lx <= span[1] + tl.offsetX) return true
+    }
+  }
   const ctx = frame.canvas.getContext("2d", { willReadFrequently: true })
   const { data } = ctx.getImageData(lx, ly, 1, 1)
   return data[3] > 0

--- a/webclient/habirender/render.js
+++ b/webclient/habirender/render.js
@@ -334,8 +334,14 @@ celLayerRenderer.trap = (cel, colors, x, y) => {
         throw new Error("Trapezoids with height 1 will cause an infinite loop in the C64 renderer")
     }
 
+    // Per-scanline quad coverage [xaStart, xbEnd] — the exact span the rasterizer fills below.
+    // The pick uses this for GEOMETRIC trapezoid containment (C64 pointer.m boundary_check →
+    // trap.m): a textured ground trapezoid with transparent gaps still catches clicks anywhere
+    // inside its shape, instead of letting them fall through to the sky behind → wrongful sky_go.
+    cel.trapSpans = []
     for (let y = 0; y < cel.height; y ++) {
         const line = cel.bitmap[y]
+        cel.trapSpans[y] = [xa, xb]
         if (cel.border && (y == 0 || y == (cel.height - 1))) {
             // top and bottom border line
             horizontalLine(cel.bitmap, xa, xb, y, 0xaa, true)
@@ -384,7 +390,7 @@ celLayerRenderer.trap = (cel, colors, x, y) => {
         celColors.pattern = 15
     }
     const canvas = canvasFromBitmap(cel.bitmap, celColors)
-    return { canvas, minX: cel.xCorrection - xOrigin, minY: y - cel.height, maxX: cel.xCorrection - xOrigin + cel.width, maxY: y }
+    return { canvas, trapSpans: cel.trapSpans, minX: cel.xCorrection - xOrigin, minY: y - cel.height, maxX: cel.xCorrection - xOrigin + cel.width, maxY: y }
 }
 
 // We try to consistently model Habitat's coordinate space in our rendering code as y=0 for the bottom, with increasing y meaning going up.
@@ -445,6 +451,17 @@ export const frameFromCels = (cels, { colors: celColors, paintOrder, firstCelOri
         const [ox, oy] = topLeftCanvasOffset(celSpace, layer)
         const offsetX = flipHorizontal ? frame.canvas.width - ox - layer.canvas.width : ox
         frame.celLayers.push({ canvas: layer.canvas, offsetX, offsetY: oy, celIndex: layer.celIndex })
+    }
+    // Trapezoid quad coverage, in frame-canvas coords, for geometric picking (see celLayerRenderer
+    // .trap). Skipped when flipHorizontal (region ground/sky flats are never mirrored, so the
+    // un-mirrored spans would be wrong — those frames fall back to cel-pixel picking).
+    frame.trapLayers = []
+    if (!flipHorizontal) {
+        for (const layer of layers) {
+            if (!layer || !layer.trapSpans) continue
+            const [ox, oy] = topLeftCanvasOffset(celSpace, layer)
+            frame.trapLayers.push({ offsetX: ox, offsetY: oy, spans: layer.trapSpans })
+        }
     }
     frame.xOrigin = xCorrect
     frame.yOrigin = yCorrect

--- a/webclient/habirender/render.js
+++ b/webclient/habirender/render.js
@@ -263,6 +263,18 @@ celLayerRenderer.default = (cel, colors, x, y) => {
         return null
     }
 }
+// cel_box: pointer.m boundary_check box-picks a box cel by its full rect (no fine_cel_point /
+// pixel test), so a CLEAR box — e.g. a vending machine's glass front — still BLOCKS selection
+// of the items behind it. The webclient otherwise pixel-tests, letting clicks pass through a
+// transparent box. Reuse the trapezoid quad-span pick path: every scanline spans the whole box.
+celLayerRenderer.box = (cel, colors, x, y) => {
+    const layer = celLayerRenderer.default(cel, colors, x, y)
+    if (layer?.canvas) {
+        const w = layer.canvas.width, h = layer.canvas.height
+        layer.trapSpans = Array.from({ length: h }, () => [0, w - 1])
+    }
+    return layer
+}
 
 celLayerRenderer.text = (cel, colors, x, y) => {
     const textColors = {...colors}

--- a/webclient/lib/balloons.js
+++ b/webclient/lib/balloons.js
@@ -4,7 +4,7 @@
 
 import { h } from "preact"
 import htm from "htm"
-import { useContext, useEffect, useMemo, useState } from "preact/hooks"
+import { useContext, useEffect, useMemo, useState, useRef } from "preact/hooks"
 import { Scale, canvasImage, c64Colors, frameFromText } from "../habirender/render.js"
 import { charset, until } from "../habirender/data.js"
 import { makeCanvas } from "../habirender/shim.js"
@@ -99,9 +99,16 @@ export function balloonPanelHeightPx(maxDisplayLines) {
   return maxDisplayLines * LINE_PX_H
 }
 
-function composePanel(lines, charsetData, maxDisplayLines) {
+function composePanel(lines, charsetData, maxDisplayLines, scrollOffset = 0) {
   if (!lines.length || !charsetData) return null
-  const rendered = lines.map((row) => renderLineCanvas(row.bytes, row.vicColor, charsetData)).filter(Boolean)
+  // Show a window of maxDisplayLines, scrolled up from the bottom by scrollOffset lines
+  // (0 = newest at the bottom). The history can be much longer (maxHistoryLines).
+  const maxOffset = Math.max(0, lines.length - maxDisplayLines)
+  const off = Math.max(0, Math.min(scrollOffset, maxOffset))
+  const end = lines.length - off
+  const start = Math.max(0, end - maxDisplayLines)
+  const visible = lines.slice(start, end)
+  const rendered = visible.map((row) => renderLineCanvas(row.bytes, row.vicColor, charsetData)).filter(Boolean)
   if (!rendered.length) return null
   const panelH = balloonPanelHeightPx(maxDisplayLines)
   const nativePanelW = LAYOUT_PANEL_PX_W * NATIVE_FONT_SCALE
@@ -122,11 +129,14 @@ function composePanel(lines, charsetData, maxDisplayLines) {
 export function createBalloonState({
   maxDisplayLines = 10,
   maxBalloonLines = C64_MAX_BALLOON_LINES,
+  maxHistoryLines = 100,
 } = {}) {
   return {
     maxDisplayLines,
     maxBalloonLines,
+    maxHistoryLines,
     lines: [],
+    scrollOffset: 0, // lines scrolled up from the bottom (0 = newest visible)
     talkerSlots: [0, 0, 0, 0, 0, 0],
     quip: null,
     espPending: null,
@@ -137,10 +147,32 @@ export function createBalloonState({
 
 export function clearBalloonState(state) {
   state.lines = []
+  state.scrollOffset = 0
   state.quip = null
   state.espPending = null
   state.espAt = 0
   state.revision++
+}
+
+// Scroll the balloon scrollback by `delta` lines (positive = toward older / up). Clamped to
+// [0, history-window]. Returns true if the offset changed.
+export function scrollBalloons(state, delta) {
+  const maxOffset = Math.max(0, state.lines.length - state.maxDisplayLines)
+  const next = Math.max(0, Math.min(state.scrollOffset + delta, maxOffset))
+  if (next === state.scrollOffset) return false
+  state.scrollOffset = next
+  state.revision++
+  return true
+}
+
+// Set the scroll offset directly (for the scrollbar thumb). Clamped.
+export function setBalloonScroll(state, offset) {
+  const maxOffset = Math.max(0, state.lines.length - state.maxDisplayLines)
+  const next = Math.max(0, Math.min(Math.round(offset), maxOffset))
+  if (next === state.scrollOffset) return false
+  state.scrollOffset = next
+  state.revision++
+  return true
 }
 
 export function pushBalloon(state, world, text, meta = {}) {
@@ -189,7 +221,11 @@ export function pushBalloon(state, world, text, meta = {}) {
   for (const bytes of formatted) {
     state.lines.push({ bytes, vicColor })
   }
-  while (state.lines.length > state.maxDisplayLines) state.lines.shift()
+  // Webclient-only bounded scrollback. The C64's slow modem made bursts (e.g. the god-tool
+  // `d`ump's noid list) readable as they arrived; instant web comms scroll them off in <1s,
+  // so we retain up to maxHistoryLines and let the user scroll back. Snap to newest on push.
+  while (state.lines.length > state.maxHistoryLines) state.lines.shift()
+  state.scrollOffset = 0
 
   const anchorPx = speakerX > 0 ? speakerAnchorForRecord(world?.get?.(speaker)) : 0
   if (showQuip && quipX > 0 && anchorPx > 0) {
@@ -261,6 +297,10 @@ function useQuipExpiry(stateSignal, state) {
   }, [state?.quip?.until, state?.revision])
 }
 
+// C64 VIC palette → CSS hex (c64Colors entries are 0xRRGGBB integers).
+const c64css = (idx) => `#${c64Colors[idx].toString(16).padStart(6, "0")}`
+const SCROLLBAR_W = 16 // px, sits over the right edge / right chevron
+
 export function BalloonStage({ stateSignal, children, textInput = null }) {
   const scale = useContext(Scale)
   const state = stateSignal.value
@@ -269,24 +309,71 @@ export function BalloonStage({ stateSignal, children, textInput = null }) {
 
   const panelCanvas = useMemo(
     () => (charsetData && state.lines.length
-      ? composePanel(state.lines, charsetData, state.maxDisplayLines)
+      ? composePanel(state.lines, charsetData, state.maxDisplayLines, state.scrollOffset)
       : null),
-    [charsetData, state.revision, state.lines.length, state.maxDisplayLines],
+    [charsetData, state.revision, state.lines.length, state.maxDisplayLines, state.scrollOffset],
   )
   const panelW = LAYOUT_PANEL_PX_W * scale
   const panelH = balloonPanelHeightPx(state.maxDisplayLines) * scale
   const TextInputLine = textInput?.Line
   const [pointerInGraphics, setPointerInGraphics] = useState(false)
+  const dragRef = useRef(null)
+
+  // Scrollback metrics. Offset 0 = newest at the bottom; maxOffset = oldest line at the top.
+  const total = state.lines.length
+  const maxOffset = Math.max(0, total - state.maxDisplayLines)
+  const hasScroll = maxOffset > 0
+  const off = Math.max(0, Math.min(state.scrollOffset, maxOffset))
+  const thumbH = hasScroll ? Math.max(18, panelH * (state.maxDisplayLines / total)) : 0
+  const thumbTop = (1 - (maxOffset > 0 ? off / maxOffset : 0)) * (panelH - thumbH)
+  const dragging = !!dragRef.current
+
+  const onWheel = (e) => {
+    if (!hasScroll) return
+    e.preventDefault()
+    if (scrollBalloons(state, e.deltaY < 0 ? 3 : -3)) stateSignal.value = { ...state }
+  }
+  const onThumbDown = (e) => {
+    e.preventDefault(); e.stopPropagation()
+    e.currentTarget.setPointerCapture?.(e.pointerId)
+    dragRef.current = { startY: e.clientY, startOff: off }
+    stateSignal.value = { ...state }
+  }
+  const onThumbMove = (e) => {
+    const d = dragRef.current
+    if (!d) return
+    const span = panelH - thumbH
+    if (span <= 0) return
+    // Drag the thumb DOWN (dy>0) → toward the newest line → smaller offset.
+    const newOff = d.startOff - ((e.clientY - d.startY) / span) * maxOffset
+    if (setBalloonScroll(state, newOff)) stateSignal.value = { ...state }
+  }
+  const onThumbUp = (e) => {
+    dragRef.current = null
+    e.currentTarget.releasePointerCapture?.(e.pointerId)
+    stateSignal.value = { ...state }
+  }
 
   return html`
     <div class="balloon-stage" style="width: ${panelW}px;">
       ${panelCanvas
-        ? html`<div class="balloon-panel" style="width: ${panelW}px; height: ${panelH}px; overflow: hidden;">
+        ? html`<div class="balloon-panel" style="width: ${panelW}px; height: ${panelH}px; overflow: hidden;" onWheel=${onWheel}>
             <img
               class="balloon-panel-canvas"
               style=${`width: ${panelW}px; height: ${panelH}px;`}
               src=${panelCanvas.toDataURL()}
               alt="" />
+          </div>`
+        : null}
+      ${hasScroll
+        ? html`<div class="balloon-scrollbar"
+            style=${`width:${SCROLLBAR_W}px; height:${panelH}px; left:${panelW}px; background:${c64css(11)};`}
+            title="Scroll word-balloon history">
+            <div class="balloon-scrollbar-thumb"
+              style=${`height:${thumbH}px; top:${thumbTop}px; background:${dragging ? c64css(1) : c64css(15)};`}
+              onPointerDown=${onThumbDown}
+              onPointerMove=${onThumbMove}
+              onPointerUp=${onThumbUp} />
           </div>`
         : null}
       <div

--- a/webclient/lib/balloons.js
+++ b/webclient/lib/balloons.js
@@ -154,11 +154,17 @@ export function pushBalloon(state, world, text, meta = {}) {
   if (op === "OBJECTSPEAK_$" || body.startsWith("ESP from ")) {
     const header = body.match(ESP_HEADER_RE)
     if (header) {
+      // ESP attribution header ("ESP from X: "). The C64 draws this as its own balloon
+      // line; previously we returned false here and dropped it, so the recipient saw the
+      // body with no idea who sent it. Show it — and arm espPending so the body message
+      // that follows is recognized as the ESP it completes. Render over the RECIPIENT
+      // (ESP is telepathic — it appears over you, not the sender, who may not even be in
+      // the region), with no quip tail.
       state.espPending = header[1]
       state.espAt = Date.now()
-      return false
-    }
-    if (state.espPending && Date.now() - state.espAt < ESP_TTL_MS) {
+      speaker = meNoid
+      showQuip = false
+    } else if (state.espPending && Date.now() - state.espAt < ESP_TTL_MS) {
       speaker = speaker ?? meNoid
       showQuip = false
       state.espPending = null

--- a/webclient/lib/live.js
+++ b/webclient/lib/live.js
@@ -31,6 +31,8 @@ import {
   createTextInputState,
   applyEspReply,
   clearTextLine,
+  setPromptLine,
+  endPrompt,
 } from "./text-input.js"
 import { Scale } from "../habirender/render.js"
 import { dispatchVerb, dispatchVerbAtPick, pickRegionTarget } from "./verb-dispatch.js"
@@ -219,6 +221,17 @@ async function main() {
       console.warn("[live] text submit: avatar not in region yet")
       return
     }
+    if (payload.kind === "prompt") {
+      // god-tool / server prompt REPL (Region.PROMPT_REPLY): send the FULL line back —
+      // including the prompt prefix the server matches on (e.g. "Edit: ") — then leave
+      // prompt mode. The server re-sends PROMPT_USER_$ for the next command; an empty line
+      // (prefix only) tells it to exit. One-shot per prompt, mirroring the C64 path.
+      const regionRef = world.region?.ref
+      if (regionRef) transport.send({ op: "PROMPT_REPLY", to: regionRef, text: payload.text })
+      endPrompt(textInputState.value)
+      textInputState.value = { ...textInputState.value }
+      return
+    }
     // C64 talk:: clears the line after send_string; ESP reply handled via getResponse.
     clearTextLine(textInputState.value)
     textInputState.value = { ...textInputState.value }
@@ -308,6 +321,22 @@ async function main() {
       // mirrors habibot.js. passage_id=0 — no door involved.
       if (m.op === "AUTO_TELEPORT_$") {
         if (world.me?.ref) transport.send({ op: "NEWREGION", to: world.me.ref, direction: 4 })
+        return
+      }
+      // PROMPT_USER_$ (C64 MESSAGE_PROMPT_USER): server-driven text prompt — the god tool's
+      // "Edit:" REPL, hatchery onboarding, sign editing, etc. Show the prompt in the input
+      // line (setPromptLine locks the prefix via leftBound; the user types after it); the
+      // submitted line goes back via PROMPT_REPLY (onTextSubmit). Not a world-state op.
+      if (m.op === "PROMPT_USER_$") {
+        // The server sends "<PROMPT> " — GOD_TOOL_PROMPT + a DISPLAY space (Magical.java).
+        // The reply must echo back exactly "<PROMPT><input>": Region.PROMPT_REPLY strips
+        // GOD_TOOL_PROMPT.length() ("Edit:" = 5) and treats an empty remainder as "exit".
+        // The C64 lets the first typed char OVERWRITE that trailing space (wait_for_text_string),
+        // so it transmits "Edit:" + input, never "Edit: " + input. Drop the one trailing space
+        // here to match — otherwise the server sees a leading space and no command (or exit,
+        // on an empty line) ever matches.
+        setPromptLine(textInputState.value, String(m.text ?? "").replace(/ $/, ""))
+        textInputState.value = { ...textInputState.value }
         return
       }
       world.apply(m)

--- a/webclient/lib/text-input.mjs
+++ b/webclient/lib/text-input.mjs
@@ -127,8 +127,11 @@ export function displayBytes(state, { showCursor = true, cursorChar = BLANK_CHAR
 
 export function submitPayload(state) {
   if (state.awaitingPrompt) {
+    // Always submit in prompt mode, even with nothing typed past the prefix: the server
+    // (god tool) treats an empty command — the prompt prefix alone — as "exit god mode".
+    // Only suppress if there's no prompt at all (empty buffer).
     const text = state.buffer
-    if (!text || text.length <= effectiveLeftBound(state)) return null
+    if (!text) return null
     return { kind: "prompt", text }
   }
 
@@ -146,10 +149,24 @@ export function submitPayload(state) {
   return { kind: "speak", text }
 }
 
+// God-tool "Edit:" nudge — in a server prompt, the arrow keys are command codes 124–127
+// (ARROW_U/D/L/R in Magical.java's god_tool_revisited), each moving the target object 1px.
+const PROMPT_ARROW_CODE = { ArrowUp: 124, ArrowDown: 125, ArrowLeft: 126, ArrowRight: 127 }
+
 export function handleKey(state, key, { ctrlKey = false } = {}) {
   if (key === "Enter") {
     const payload = submitPayload(state)
     return { state, action: payload ? "submit" : "noop", payload }
+  }
+  // Arrow nudge: only while a prompt is active. Submit immediately (one press = one 1px
+  // move) so the object slides live; the prompt prefix is already in the buffer, so append
+  // the arrow's command code. Normal-mode arrows are untouched (fall through to noop).
+  if (state.awaitingPrompt && PROMPT_ARROW_CODE[key] !== undefined) {
+    return {
+      state,
+      action: "submit",
+      payload: { kind: "prompt", text: state.buffer + String.fromCharCode(PROMPT_ARROW_CODE[key]) },
+    }
   }
   if (key === "Backspace") {
     deleteChar(state)

--- a/webclient/style.css
+++ b/webclient/style.css
@@ -218,6 +218,23 @@ header.titlebar .tag {
     display: block;
     image-rendering: pixelated;
 }
+/* Webclient-only word-balloon scrollback bar — sits over the right edge / right chevron,
+   in the C64 palette (set inline from c64Colors). Sharp, pixelated, no rounded corners. */
+.balloon-scrollbar {
+    position: absolute;
+    top: 0;
+    z-index: 3;
+    image-rendering: pixelated;
+    box-shadow: inset 1px 0 0 #000;
+}
+.balloon-scrollbar-thumb {
+    position: absolute;
+    left: 2px;
+    right: 2px;
+    cursor: grab;
+    touch-action: none;
+}
+.balloon-scrollbar-thumb:active { cursor: grabbing; }
 .balloon-graphics-band {
     position: relative;
     z-index: 0;


### PR DESCRIPTION
A batch of fixes found while testing the Alpha web client (all verified in-browser except where noted).

## Webclient
- **ESP "from X:" header** now shows on incoming ESP (was dropped, leaving the body with no sender).
- **God-tool command mode** — wired the `PROMPT_USER_$` REPL (Edit: prompt, letter commands, arrow-key 1px nudges, empty-Enter exit). Matches the C64 `MESSAGE_PROMPT_USER` round-trip.
- **Scrollable word-balloon history** — bounded 100-line scrollback + scrollbar (instant comms scrolled god-tool `d`umps off in <1s).
- **Geometric trapezoid picking** — ground clicks above the depth line no longer fall through to the sky (`sky_go`); ports `pointer.m boundary_check` → `trap.m`.
- **Box-pick clear cels** — a vending machine's glass front now blocks selection of items behind it (C64 box-picks `cel_box` by rect, no pixel test).

## Server
- **bridge**: `Wisher *uint16` — Magic_lamp's `wisher: 256` (UNASSIGNED_NOID) no longer overflows `uint8` and drops the whole `make` (the library genie). go build/vet/tests green.
- **elko**: teleporter/document page **BACK wraps** from page 1 to the last page (was clamped at 1). Server-side; surfaced via the web client. *(Verify after deploy — Java isn't hot-reloaded locally.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)