### PR TITLE
Catch-up interlock: hold transiting avatars INVISIBLE (bridge) + 600-baud pacer

### DIFF
--- a/bridge_v2/CATCHUP_INTERLOCK.md
+++ b/bridge_v2/CATCHUP_INTERLOCK.md
@@ -1,0 +1,83 @@
+# Catch-up interlock (avatar "transit invisibility")
+
+## What it is
+
+When an avatar is **transiting** — changing regions and still loading the new region's contents
+vector — it must be **invisible and non-interactive on every screen** until it has caught up. The
+original Habitat client implements this with the `avatar_on_hold` bit (`Main/equates.m`,
+`0b01000000`); `render.m` render-skips any avatar with that bit set, and `actions.m` clears it on
+`APPEARING_$` ("OK!!! DRAW ME!").
+
+This prevents a fast client from drawing or interacting with an avatar that hasn't finished
+loading — important when a slow real C64 is co-present with the JS webclient.
+
+## The original (Stratus PL/1) design — the canon
+
+On the Stratus host (`habitat-orig/sources/stratus`):
+
+- `Processes/regionproc.pl1` — in the **region-change handler**, just before the avatar's
+  descriptor is serialized for the new region: `if (my_noid ^= GHOST) then set_bit(gr_state, 7)`
+  (`bits(7)` = `0x40`). **Ghosts are exempt.** The bit rides along on the avatar's carried state
+  into the new region's contents vector, so everyone there sees it held.
+- `Classes/class_region.pl1` — `region_I_AM_HERE` does `clear_bit(gr_state, 7)` and broadcasts
+  `APPEARING_$`; `region_FINGER_IN_QUE` replies `CAUGHT_UP_$`.
+
+So the bit is set **at the transit**, on the avatar's wire state, and cleared **when it appears**.
+
+## The neohabitat bug this fixes
+
+The elko (Java) server faithfully ports the *clear* half — `Region.I_AM_HERE` does
+`gr_state &= ~INVISIBLE` + broadcasts `APPEARING_$` — but **nothing ever set the bit**. So arrivals
+just popped in mid-load on every client. The "invisible stuff" was always supposed to be there.
+
+## Why the fix lives in the bridge, not elko
+
+elko changes regions as **make/break** (tear down the old context, stand up a new one).
+`bridge_v2`'s job is to hide that seam and present the client one continuous session — which makes
+the bridge the exact elko-era analog of the Stratus `change_region` coordinator. So the bridge sets
+the bit **purely on the wire**, toward the client; **elko and its DB never see it** (no
+`src/main/java` changes). It's pure presentation state, which is what it is.
+
+## How it works (`bridge_v2/bridge/invisible.go` + `client_session.go` + `server_ops.go`)
+
+Transiting is a property of the **avatar**, not of a connection (the bridge holds avatar state
+across elko's per-region make/break, and `Bridge.Sessions` is keyed by socket address, not avatar).
+So it lives in a **global per-avatar latch**, `transitRegistry` (ref → bool, mutex-guarded):
+
+- **mark** on `enterContext` (a region change), keyed by the stable short user-ref (`user-randy`).
+- **clear** on the avatar's **own `APPEARING_$`** (matched by its own noid). *Not* on `ready` —
+  `ready` fires before the cross-session broadcast of the arrival make reaches other sessions, so
+  the latch would already be gone when they check it.
+- **clear immediately when transiting *as a ghost*** — the `you:true` make is a `Ghost` (noid 255),
+  and a ghost skips the `I_AM_HERE → APPEARING_$` handshake ("free up cursor NOW, I am a ghost!"),
+  so no `APPEARING_$` ever comes; without this the latch goes stale and a later in-region deghost
+  is wrongly held. (Ghosts are also never themselves held — they're not `Avatar`-typed makes.)
+- **clear on `Close()`** defensively, so a session dying mid-transit can't strand an avatar.
+
+Any session, when forwarding an avatar make, consults the registry and — if that avatar is
+transiting — sets the on-hold bit:
+
+- **C64 / binary path:** `holdAvatarMod(mod)` mutates the parsed mod; the make is re-encoded from it.
+- **webclient / JSON path:** `holdAvatarRaw(raw, mod)` patches the single `"gr_state":N` in the raw
+  elko bytes (that path forwards raw, so a struct change isn't enough).
+
+### Release, client-side
+
+The hold is released by `APPEARING_$`, which the bridge does **not** alter:
+
+- C64 clears `avatar_on_hold` natively (`actions.m`).
+- The JS webclient clears it in `habiworld/lib/behaviors/avatar_choreography_host.js`
+  (`region_APPEARING`), and `webclient/lib/world-adapter.js` skips any `Avatar` with `gr_state & 0x40`
+  from both render and pick.
+
+### CORPORATE (deghost) is *not* a transit
+
+A deghost re-makes the corporeal avatar **in place** — it never calls `enterContext`, so it's never
+marked, so its make is never held. That's the same distinction Stratus drew by setting the bit only
+in the `change_region` handler.
+
+## Related: outbound pacing
+
+`webclient/lib/transport.js` also paces outbound messages to an effective **600 baud** (leaky
+bucket; isolated messages immediate, bursts throttled), so a webclient can't outrun a co-present
+C64's serial buffer. `?baud=0` disables.

--- a/bridge_v2/bridge/bridge.go
+++ b/bridge_v2/bridge/bridge.go
@@ -27,6 +27,10 @@ type Bridge struct {
 	QLinkMode        bool
 	Sessions         map[string]*ClientSession
 
+	// transit is the global per-avatar transiting latch (see invisible.go). Shared across all
+	// sessions because transiting is a property of the avatar, not of any single connection.
+	transit *transitRegistry
+
 	// listeners and listenAddrs are 1:1 by index. Multiple listeners
 	// let one stateful bridge process serve multiple host ports
 	// (1337/1986/2026 historically) without splitting session state
@@ -438,6 +442,7 @@ func NewBridge(
 		OriginalHatchery: originalHatcheryEnabled(),
 		QLinkMode:        qlinkMode,
 		Sessions:         make(map[string]*ClientSession),
+		transit:          newTransitRegistry(),
 		acceptDone:       make(chan struct{}),
 		listenAddrs:      addrs,
 		elkoHost:         elkoHost,

--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -466,6 +466,14 @@ func (c *ClientSession) handleElkoMessage(msg *ElkoMessage) {
 		name := msg.Obj.Name
 		mod := msg.Obj.Mods[0]
 
+		// Arriving AS a ghost: a ghost skips the I_AM_HERE→APPEARING_$ handshake (it's visible
+		// at once — Stratus exempts GHOST from the hold), so our own APPEARING_$ clear never
+		// fires. Clear the transit latch now, or it goes stale and a later in-region deghost is
+		// wrongly held.
+		if mod.Type != nil && *mod.Type == "Ghost" {
+			c.bridge.transit.clear(c.userRef)
+		}
+
 		c.log.Debug().Str("name", name).Msg("Avatar arrived")
 		c.bindAvatar(name)
 
@@ -656,6 +664,13 @@ func (c *ClientSession) handleElkoMessage(msg *ElkoMessage) {
 			return
 		}
 		if msg.className == "Avatar" {
+			// Catch-up interlock: hold the make INVISIBLE iff this avatar is currently
+			// transiting (global latch) — covers our own avatar entering and any neighbor
+			// arriving. A deghost (CORPORATE) isn't transiting, so it stays visible. The C64
+			// re-encodes the make from this mod downstream, so mutating gr_state here is enough.
+			if c.bridge.transit.isTransiting(msg.Obj.Ref) {
+				holdAvatarMod(mod)
+			}
 			// msg.You is *bool and may be absent from Elko messages for
 			// re-make events such as corporate/discorporate, where the
 			// server sends a fresh Avatar "make" without re-asserting
@@ -1834,6 +1849,28 @@ func (c *ClientSession) handleElkoMessageJson(raw []byte, msg *ElkoMessage) {
 		if msg.To != nil {
 			c.regionRef = *msg.To
 		}
+		// Remember our own noid in this region so we can recognize our own APPEARING_$ below.
+		if msg.Obj != nil && len(msg.Obj.Mods) > 0 {
+			mod := msg.Obj.Mods[0]
+			if mod.Noid != nil {
+				n := uint8(*mod.Noid)
+				c.avatarNoid = &n
+			}
+			// Arriving AS a ghost: ghosts skip the I_AM_HERE→APPEARING_$ handshake (visible at
+			// once — Stratus exempts GHOST), so clear the transit latch now rather than waiting
+			// for an APPEARING_$ that never comes; otherwise a later in-region deghost is held.
+			if mod.Type != nil && *mod.Type == "Ghost" {
+				c.bridge.transit.clear(c.userRef)
+			}
+		}
+	}
+
+	// Transit complete for our own avatar: clear our global transit latch on our own APPEARING_$
+	// (not on `ready`, which fires too early for other sessions to see the latch while they
+	// forward our arrival make to them).
+	if msg.Op != nil && *msg.Op == "APPEARING_$" && msg.Appearing != nil &&
+		c.avatarNoid != nil && uint16(*c.avatarNoid) == *msg.Appearing {
+		c.bridge.transit.clear(c.userRef)
 	}
 
 	if msg.Type == "changeContext" {
@@ -1894,6 +1931,20 @@ func (c *ClientSession) handleElkoMessageJson(raw []byte, msg *ElkoMessage) {
 		return
 	}
 
+	// Catch-up interlock: hold an arriving avatar on the wire so the client neither draws nor
+	// interacts with it until APPEARING_$ (mirrors Stratus regionproc set_bit; cleared
+	// client-side). Hold the transiting avatar itself (you:true) and any avatar that arrives
+	// after our make-storm (steady state); occupants present during the make-storm stay visible.
+	if msg.Op != nil && *msg.Op == "make" && msg.Obj != nil && len(msg.Obj.Mods) > 0 {
+		mod := msg.Obj.Mods[0]
+		// Catch-up interlock: hold an avatar make INVISIBLE iff that avatar is currently
+		// transiting (global latch) — covers our own region entry and any neighbor arrival. A
+		// deghost (CORPORATE) is not a transit, so its corporeal re-make stays visible. The JSON
+		// path forwards the raw elko bytes, so patch gr_state in place.
+		if mod.Type != nil && *mod.Type == "Avatar" && c.bridge.transit.isTransiting(msg.Obj.Ref) {
+			raw = holdAvatarRaw(raw, mod)
+		}
+	}
 	c.writeJsonToClient(raw)
 }
 
@@ -2169,6 +2220,10 @@ func (c *ClientSession) handleClientMessage(data []byte) {
 
 func (c *ClientSession) enterContext(context string) {
 	c.log.Debug().Str("context", context).Msg("Entering context")
+	// This avatar is now TRANSITING into a region. Mark its global latch so every session holds
+	// its makes INVISIBLE until it appears. Cleared on the region's `ready` (above). A deghost
+	// (CORPORATE) does not call enterContext, so it is never marked — it stays visible.
+	c.bridge.transit.mark(c.userRef)
 	enterContextMsg := &ElkoMessage{
 		To:      StringP("session"),
 		Op:      StringP("entercontext"),
@@ -2325,6 +2380,11 @@ func (c *ClientSession) Start() {
 }
 
 func (c *ClientSession) Close() {
+	// Defensive: if this session dies mid-transit (before its APPEARING_$ cleared the latch),
+	// release its global transit entry so the avatar isn't held invisible to others forever.
+	if c.bridge != nil && c.bridge.transit != nil {
+		c.bridge.transit.clear(c.userRef)
+	}
 	// Flip the done flags first so other goroutines (notably
 	// writeJsonToClient) can distinguish a teardown-time write failure
 	// from a mid-session one. closeChannels also signals elkoWriter via

--- a/bridge_v2/bridge/invisible.go
+++ b/bridge_v2/bridge/invisible.go
@@ -1,0 +1,114 @@
+package bridge
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// avatarOnHold is the gr_state bit (0x40) that marks an avatar as not-yet-drawable — identical to
+// the C64 client's avatar_on_hold (Main/equates.m) and elko's Constants.INVISIBLE. The original
+// Stratus server set it on the transiting avatar's carried descriptor in the region-change handler
+// (Processes/regionproc.pl1: set_bit(gr_state, 7)) and cleared it on I_AM_HERE. bridge_v2 is the
+// elko-era analog of that transit coordinator, so it sets the bit purely on the wire toward the
+// client — elko and its DB never see it. The hold is released client-side on APPEARING_$ (C64
+// clears avatar_on_hold natively; the JS webclient clears it in habiworld region_APPEARING).
+const avatarOnHold uint8 = 0x40
+
+// transitRegistry tracks which avatars (by stable user-ref) are currently TRANSITING — i.e.
+// changing regions and not yet caught up. It is global to the bridge process (one shared instance)
+// because the bridge presents a single continuous session over elko's per-region make/break:
+// "transiting" is a property of the AVATAR, not of any one connection, so every session must agree
+// on it. Any session consults it when forwarding an avatar make; a make for a transiting avatar
+// gets the on-hold bit so the client neither draws nor interacts with it until it appears.
+//
+// Crucially, only an actual region change marks the registry (ClientSession.enterContext). A
+// deghost (CORPORATE) is an in-place re-make, not a transit, so it never marks — its corporeal
+// make stays visible. That is the distinction Stratus drew by setting the bit only in the
+// change_region handler.
+type transitRegistry struct {
+	mu  sync.RWMutex
+	set map[string]bool
+}
+
+func newTransitRegistry() *transitRegistry {
+	return &transitRegistry{set: make(map[string]bool)}
+}
+
+// The methods are nil-receiver-safe: a ClientSession whose Bridge was built without
+// newTransitRegistry() (e.g. a struct literal in tests) simply gets no-op transit tracking
+// instead of a nil-pointer panic.
+func (t *transitRegistry) mark(ref string) {
+	if t == nil || ref == "" {
+		return
+	}
+	key := avatarShortRef(ref)
+	t.mu.Lock()
+	t.set[key] = true
+	t.mu.Unlock()
+}
+
+func (t *transitRegistry) clear(ref string) {
+	if t == nil || ref == "" {
+		return
+	}
+	key := avatarShortRef(ref)
+	t.mu.Lock()
+	delete(t.set, key)
+	t.mu.Unlock()
+}
+
+func (t *transitRegistry) isTransiting(ref string) bool {
+	if t == nil || ref == "" {
+		return false
+	}
+	key := avatarShortRef(ref)
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.set[key]
+}
+
+// avatarShortRef normalizes a full avatar ref ("user-randy-2629094263478067525") to the stable
+// per-user key ("user-randy") — the form ClientSession.userRef already holds and the one that
+// survives elko's per-region re-makes. Non-user / short refs pass through unchanged.
+func avatarShortRef(ref string) string {
+	parts := strings.SplitN(ref, "-", 3)
+	if len(parts) >= 2 {
+		return parts[0] + "-" + parts[1]
+	}
+	return ref
+}
+
+// holdAvatarMod sets the on-hold bit on a parsed avatar mod. The C64/binary path re-encodes the
+// make from this mod (EncodeElkoModState), so mutating it here is sufficient. nil-safe.
+func holdAvatarMod(mod *HabitatMod) {
+	if mod == nil {
+		return
+	}
+	if mod.GrState == nil {
+		v := avatarOnHold
+		mod.GrState = &v
+		return
+	}
+	*mod.GrState |= avatarOnHold
+}
+
+// holdAvatarRaw rewrites the avatar's gr_state value in a raw elko JSON make so the bit rides on
+// the wire. The JSON-passthrough (webclient) path forwards the raw elko bytes unchanged, so
+// mutating the parsed struct is not enough — we patch the single "gr_state":N occurrence (an
+// Avatar make carries exactly one; its pocket items arrive as separate makes). If the bit is
+// already set, the bytes are returned untouched.
+func holdAvatarRaw(raw []byte, mod *HabitatMod) []byte {
+	var old uint8
+	if mod != nil && mod.GrState != nil {
+		old = *mod.GrState
+	}
+	next := old | avatarOnHold
+	if next == old {
+		return raw
+	}
+	return bytes.Replace(raw,
+		[]byte(fmt.Sprintf(`"gr_state":%d`, old)),
+		[]byte(fmt.Sprintf(`"gr_state":%d`, next)), 1)
+}

--- a/bridge_v2/bridge/server_ops.go
+++ b/bridge_v2/bridge/server_ops.go
@@ -13,6 +13,13 @@ func init() {
 	ServerOps["APPEARING_$"] = &ServerOp{
 		Reqno: 18,
 		ToClient: func(o *ElkoMessage, buf *HabBuf, s *ClientSession) bool {
+			// Transit complete: if this is OUR OWN appearance, clear our global transit latch
+			// (the avatar has finished arriving). Clearing here — not on `ready` — keeps the
+			// latch set long enough that other sessions reliably see it while forwarding our
+			// arrival make to them.
+			if s.avatarNoid != nil && o.Appearing != nil && uint16(*s.avatarNoid) == *o.Appearing {
+				s.bridge.transit.clear(s.userRef)
+			}
 			// noidU8 narrows uint16 → uint8, mapping UNASSIGNED_NOID
 			// (256) → GHOST_NOID (255) so the C64 client sees a valid
 			// noid byte instead of a silent truncation to 0.

--- a/habiworld/lib/behaviors/avatar_choreography_host.js
+++ b/habiworld/lib/behaviors/avatar_choreography_host.js
@@ -138,8 +138,23 @@ function avatar_BUGOUT(ctx) {
   return { ok: true }
 }
 
-// Region.java APPEARING_$ — arrival notification; make follows separately.
-function region_APPEARING() {
+// gr_state bit the server sets on an ARRIVING avatar's make (Region.I_AM_HERE clears it server-
+// side and broadcasts APPEARING_$). Identical value to the C64's avatar_on_hold (equates.m 0x40),
+// which render.m render-skips until APPEARING. Render-only: headless consumers (sagebot) ignore it.
+const AVATAR_INVISIBLE = 0x40
+
+// Region.java APPEARING_$ — the avatar (args.appearing) has caught up loading the region's
+// contents vector. Clear its INVISIBLE / on-hold bit (C64 actions.m "OK!!! DRAW ME!") and notify
+// so renderers repaint it — until now it was held (the make set the bit). The arriving avatar is
+// the only one held; avatars already present in your make-storm never had the bit, so they drew
+// immediately. (No-op for everything except the held avatar.)
+function region_APPEARING(ctx) {
+  const noid = ctx.args && ctx.args.appearing
+  const av = noid != null ? ctx.world.get(noid) : null
+  if (av && av.mod && (av.mod.gr_state & AVATAR_INVISIBLE)) {
+    av.mod.gr_state &= ~AVATAR_INVISIBLE
+    ctx.world.emit('stateChanged', av)
+  }
   return { ok: true }
 }
 

--- a/webclient/lib/live.js
+++ b/webclient/lib/live.js
@@ -357,6 +357,9 @@ async function main() {
     }
     transport = new Transport({
       url: ws,
+      // 7d: pace outbound to an effective C64 line rate (default 600 baud) so request bursts
+      // can't overflow a co-present C64's serial buffer. ?baud=0 disables; ?baud=N overrides.
+      baud: qNum("baud", 600),
       onMessage: (m) => {
         gotMsg = true
         const traceChore = SOUND_TRACE && (m.op === "PLAY_$"

--- a/webclient/lib/transport.js
+++ b/webclient/lib/transport.js
@@ -10,7 +10,7 @@
 // both binary and text and buffer partial lines across frames.
 
 export class Transport {
-  constructor({ url, onMessage, onOpen, onClose, onError } = {}) {
+  constructor({ url, onMessage, onOpen, onClose, onError, baud = 600 } = {}) {
     this.url = url
     this.onMessage = onMessage || (() => {})
     this.onOpen = onOpen || (() => {})
@@ -21,6 +21,11 @@ export class Transport {
     this._decoder = new TextDecoder()
     this._pendingReply = null
     this._replyListeners = new Set()
+    // 7d outbound pacer (see send()): cap the effective OUTBOUND rate to `baud` bits/sec so a
+    // burst of webclient requests can't outrun a co-present C64's serial buffer. 0 disables.
+    this._baud = baud > 0 ? baud : 0
+    this._wireFreeAt = 0          // ms timestamp the (virtual) wire next becomes idle
+    this._paceTimers = new Set()  // outstanding scheduled sends, cleared on connect/close
   }
 
   onReply(fn) {
@@ -58,6 +63,7 @@ export class Transport {
   }
 
   connect() {
+    this._resetPacer()
     const ws = new WebSocket(this.url)
     ws.binaryType = "arraybuffer"
     this.ws = ws
@@ -83,8 +89,34 @@ export class Transport {
 
   send(obj) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return false
-    this.ws.send(JSON.stringify(obj) + "\n\n")
+    const data = JSON.stringify(obj) + "\n\n"
+    if (this._baud <= 0) { this.ws.send(data); return true }
+    // 7d traffic pacing — a leaky bucket at `baud` bits/sec (8N1 → 10 bits/byte, so
+    // bytes/sec = baud/10). Isolated messages go IMMEDIATELY (the wire is idle), keeping the
+    // client responsive when solo; only back-to-back bursts queue and drain at the wire rate,
+    // which is the case that would overflow a co-present C64. Per-message delay, not per-char.
+    // (JSON length over-estimates the smaller binary the C64 actually receives — conservative.)
+    const transmitMs = (data.length * 10 / this._baud) * 1000
+    const now = Date.now()
+    if (now >= this._wireFreeAt) {
+      this._wireFreeAt = now + transmitMs
+      this.ws.send(data)
+    } else {
+      const sendAt = this._wireFreeAt
+      this._wireFreeAt += transmitMs
+      const t = setTimeout(() => {
+        this._paceTimers.delete(t)
+        if (this.ws && this.ws.readyState === WebSocket.OPEN) this.ws.send(data)
+      }, sendAt - now)
+      this._paceTimers.add(t)
+    }
     return true
+  }
+
+  _resetPacer() {
+    for (const t of this._paceTimers) clearTimeout(t)
+    this._paceTimers.clear()
+    this._wireFreeAt = 0
   }
 
   // The whole login handshake: a single entercontext (no prior auth in dev). The avatar
@@ -97,6 +129,7 @@ export class Transport {
   }
 
   close() {
+    this._resetPacer()
     if (this.ws) this.ws.close()
   }
 }

--- a/webclient/lib/world-adapter.js
+++ b/webclient/lib/world-adapter.js
@@ -35,6 +35,15 @@ export function worldToObjects(world) {
   }
 
   for (const rec of world.objects.values()) {
+    // Catch-up interlock (7d): an ARRIVING avatar's make carries gr_state INVISIBLE (0x40, == the
+    // C64 avatar_on_hold) — it is held (not drawn, and not in the pick list since pick reads this
+    // same array) until its APPEARING_$ clears the bit (habiworld region_APPEARING). Only avatars
+    // are ever held; the Ghost and all props always render. This keeps us from drawing or
+    // interacting with an avatar that hasn't finished loading — important when a slow C64 client
+    // is co-present and still catching up. (render.m skips avatar_on_hold the same way.)
+    if (rec.mod && rec.mod.type === "Avatar" && !rec.mod.amAGhost && (rec.mod.gr_state & 0x40)) {
+      continue
+    }
     // The singleton Ghost (noid 255) renders as the floating EYE icon (class_ghost image
     // ghost_image = Images/eye0.bin) — it represents all observers and IS shown (to ghosts and
     // avatars alike) whenever ghosts are present. It is NOT filtered. See GHOST_MODE.md.


### PR DESCRIPTION
Restores Habitat's avatar transit-invisibility (`avatar_on_hold` / `gr_state 0x40`): an avatar transiting into a region is invisible and non-interactive on every client until it's caught up, then `APPEARING_$` reveals it.

**This fixes a long-standing neohabitat bug** — the server had the *clear* half (`Region.I_AM_HERE`) but **nothing ever SET the bit**, so arrivals popped in mid-load. The invisible behavior was always supposed to be there.

### Implemented in the bridge, not elko
The bridge hides elko's per-region make/break and is the analog of the Stratus `change_region` coordinator, so it sets the bit purely on the wire — **elko and its DB never see it (zero `src/main/java` changes)**. Transiting is a global per-avatar latch: marked on `enterContext`, cleared on the avatar's own `APPEARING_$`, cleared immediately when transiting *as a ghost* (ghosts skip the handshake), cleared on `Close`. Both client paths honored (C64 binary re-encode + webclient JSON raw patch).

Client side: habiworld `region_APPEARING` clears it, webclient `world-adapter` skips held avatars from render+pick. Plus a **600-baud outbound pacer** so a webclient can't outrun a co-present C64.

Design: `bridge_v2/CATCHUP_INTERLOCK.md`. Canon: PL/1 `regionproc.pl1 set_bit(gr_state,7)`.

Tested live (webclient + C64 emulator): neighbor arrival holds→appears, deghost stays visible, ghost transit no longer strands. Regression: bridge `go test` ok, habiworld 135/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)