### PR TITLE
fix(webclient): defeat Chrome login zoom-stick (viewport reset on submit)

### DIFF
--- a/webclient/lib/title.js
+++ b/webclient/lib/title.js
@@ -151,6 +151,17 @@ export const TitleScreen = ({ onProceed, ready = true }) => {
     e?.preventDefault?.()
     const n = name.trim()
     if (!ready || !n) return
+    // Mobile browsers (notably Chrome) zoom the page IN when the name field is focused and leave
+    // it there, so the client lands stuck at that text-zoom level. Blur the field and momentarily
+    // clamp the visual viewport to scale 1 to snap it back, then restore the normal meta so the
+    // user can still pinch-zoom to fit the 320×SCALE-wide region on a narrow screen. (The 16px
+    // input font alone prevents the zoom on WebKit/iOS but not reliably on Chrome.)
+    inputRef.current?.blur?.()
+    const vp = document.querySelector('meta[name="viewport"]')
+    if (vp) {
+      vp.setAttribute("content", "width=device-width, initial-scale=1, maximum-scale=1")
+      setTimeout(() => vp.setAttribute("content", "width=device-width, initial-scale=1"), 350)
+    }
     try { (await getSound()).stop() } catch (_) { /* fine */ }
     onProceed(n)
   }


### PR DESCRIPTION
Follow-up to #589/#590. The 16px login input stops focus-zoom on WebKit/iOS but **not reliably on Chrome**, where focusing the avatar-name field zooms the page in and the client lands stuck at that text-zoom level. On submit, blur the field and briefly clamp the viewport to `maximum-scale=1` to snap it back to scale 1, then restore the normal meta (~350ms) so pinch-zoom still works to fit the wide region on a narrow screen.

webclient `title.js` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)