### PR TITLE
fix(webclient): prevent Android Chrome login zoom-stick (maximum-scale=1)

### DIFF
--- a/webclient/index.html
+++ b/webclient/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- maximum-scale=1 must be present BEFORE any input is focused: Android Chrome zooms IN to a
+         focused field and won't snap back if you only clamp afterward. This blocks zoom-IN (the
+         stuck-zoom bug) but NOT zoom-OUT, so you can still pinch to fit the 960px-wide region on a
+         phone. Do not add user-scalable=no — that would also block the fit-to-screen zoom-out. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <title>NeoHabitat — Web Client</title>
     <link rel="stylesheet" href="style.css" />
     <!--

--- a/webclient/lib/title.js
+++ b/webclient/lib/title.js
@@ -151,17 +151,10 @@ export const TitleScreen = ({ onProceed, ready = true }) => {
     e?.preventDefault?.()
     const n = name.trim()
     if (!ready || !n) return
-    // Mobile browsers (notably Chrome) zoom the page IN when the name field is focused and leave
-    // it there, so the client lands stuck at that text-zoom level. Blur the field and momentarily
-    // clamp the visual viewport to scale 1 to snap it back, then restore the normal meta so the
-    // user can still pinch-zoom to fit the 320×SCALE-wide region on a narrow screen. (The 16px
-    // input font alone prevents the zoom on WebKit/iOS but not reliably on Chrome.)
+    // The mobile zoom-stick (Chrome zooming IN to the focused name field and not snapping back) is
+    // prevented up front by maximum-scale=1 in index.html's viewport meta, so there's nothing to
+    // undo here. Blur the field so the on-screen keyboard dismisses as the client takes over.
     inputRef.current?.blur?.()
-    const vp = document.querySelector('meta[name="viewport"]')
-    if (vp) {
-      vp.setAttribute("content", "width=device-width, initial-scale=1, maximum-scale=1")
-      setTimeout(() => vp.setAttribute("content", "width=device-width, initial-scale=1"), 350)
-    }
     try { (await getSound()).stop() } catch (_) { /* fine */ }
     onProceed(n)
   }


### PR DESCRIPTION
Follow-up to #591, which tried to *undo* the zoom on submit — that doesn't work on Android Chrome (once it zooms IN to the focused name field it won't snap back when `maximum-scale` is removed later). The reliable fix is to **prevent** the zoom: `maximum-scale=1` must be in the viewport meta *before* any field is focused, so it goes in `index.html` from page load.

Blocks zoom-IN (the stuck-zoom bug) but **not** zoom-OUT — the player can still pinch to fit the 960px-wide region on a phone (deliberately no `user-scalable=no`). Removes the redundant submit-time viewport juggling in `title.js`; keeps the blur so the keyboard dismisses on handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)