### PR TITLE
fix(webclient): full-width name prompt so mobile zoom-to-field fits the region

### DIFF
--- a/webclient/index.html
+++ b/webclient/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
-    <!-- maximum-scale=1 must be present BEFORE any input is focused: Android Chrome zooms IN to a
-         focused field and won't snap back if you only clamp afterward. This blocks zoom-IN (the
-         stuck-zoom bug) but NOT zoom-OUT, so you can still pinch to fit the 960px-wide region on a
-         phone. Do not add user-scalable=no — that would also block the fit-to-screen zoom-out. -->
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <!-- Don't fight the mobile "zoom to the focused field" behavior — aim it. The avatar-name
+         prompt is the full region width (960px = 320*SCALE; see .title-login-input), so when a
+         phone zooms to that focused field it lands exactly at the scale where the whole region
+         fits. No maximum-scale clamp (that only blocked zoom-in and didn't un-stick Android). -->
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>NeoHabitat — Web Client</title>
     <link rel="stylesheet" href="style.css" />
     <!--

--- a/webclient/lib/title.js
+++ b/webclient/lib/title.js
@@ -65,6 +65,7 @@ const COMET = {
 // Ltd." text. habsill3.m is linked into Bitmap_screen_1 ($4b40) by Main/Makefile's slinky call.
 const TITLE_SRC = "./assets/habsill.png"
 const BITMAP_Y = 72 // 9 text rows × 8 — where the bitmap band begins on the C64 screen
+const MAX_NAME_LEN = 14 // Habitat avatar-name limit; enforced on submit (the input is full-width)
 
 // Lazy, shared sound engine. Imported dynamically so a failure to load/init audio
 // (or its AudioWorklet) degrades to a silent-but-working title — the visuals and the
@@ -146,14 +147,19 @@ export const TitleScreen = ({ onProceed, ready = true }) => {
   // Once loaded, the player names their Avatar; submitting it dismisses the curtain and starts
   // the client (no region is asked — the server lands them wherever they last were).
   const [name, setName] = useState(() => new URLSearchParams(location.search).get("user") || "")
+  const [err, setErr] = useState("")
   const inputRef = useRef(null)
   const submit = async (e) => {
     e?.preventDefault?.()
     const n = name.trim()
     if (!ready || !n) return
-    // The mobile zoom-stick (Chrome zooming IN to the focused name field and not snapping back) is
-    // prevented up front by maximum-scale=1 in index.html's viewport meta, so there's nothing to
-    // undo here. Blur the field so the on-screen keyboard dismisses as the client takes over.
+    // The input is full region width (so a phone's zoom-to-focused-field lands at the whole-region
+    // fit scale), which drops the old 14ch visual length cue — so enforce the name limit here.
+    if (n.length > MAX_NAME_LEN) {
+      setErr(`Avatar names are ${MAX_NAME_LEN} characters or fewer.`)
+      return
+    }
+    // Blur the field so the on-screen keyboard dismisses as the client takes over.
     inputRef.current?.blur?.()
     try { (await getSound()).stop() } catch (_) { /* fine */ }
     onProceed(n)
@@ -178,9 +184,10 @@ export const TitleScreen = ({ onProceed, ready = true }) => {
       ${phase === "ready" && (ready
         ? html`<form class="title-login" onSubmit=${submit}>
             <span class="title-login-label">Avatar name</span>
-            <input ref=${inputRef} class="title-login-input" value=${name} maxlength="20"
+            <input ref=${inputRef} class="title-login-input" value=${name} maxlength="32"
                    autocomplete="off" spellcheck="false"
-                   onInput=${(e) => setName(e.target.value)} />
+                   onInput=${(e) => { setName(e.target.value); if (err) setErr("") }} />
+            ${err && html`<div class="title-login-error">${err}</div>`}
             <button class="title-login-go" type="submit" disabled=${!name.trim()}>Enter Habitat</button>
           </form>`
         : html`<div class="balloon">Loading…<span class="balloon-tail"></span></div>`)}

--- a/webclient/style.css
+++ b/webclient/style.css
@@ -148,26 +148,34 @@ header.titlebar .tag {
     position: absolute;
     left: 0; right: 0; bottom: 14px;
     z-index: 3;
+    /* Stack full-width so the input spans the whole region; see the input rule for why. */
     display: flex;
-    align-items: center;
-    justify-content: center;
+    flex-direction: column;
+    align-items: stretch;
     gap: 8px;
+    padding: 0 16px;
+    box-sizing: border-box;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
-.title-login-label { color: #fff; font-size: 13px; text-shadow: 0 1px 3px #000; }
+.title-login-label { color: #fff; font-size: 15px; text-shadow: 0 1px 3px #000; text-align: center; }
 .title-login-input {
-    /* 16px is the threshold below which iOS Safari auto-zooms on focus — and since this input is
-       auto-focused on the load screen (title.js), a smaller size zoomed the whole page in and
-       never zoomed back out to fit the game area. Keep it at 16px so focus never triggers zoom. */
+    /* Full region width on purpose: mobile browsers zoom to fit the focused field, so a field that
+       is ~the region width makes that zoom land at the scale where the whole 960px region fits —
+       instead of zooming into a tiny field and sticking there (the bug we kept chasing). The 14ch
+       visual length cue is gone, so title.js enforces the 14-char name limit by rejecting on
+       submit. 16px also keeps iOS from its own sub-16px focus zoom. */
     font: inherit; font-size: 16px;
-    width: 14ch; padding: 4px 8px;
+    width: 100%; padding: 8px 10px;
+    box-sizing: border-box;
+    text-align: center;
     color: #fff; background: #0a0a18;
     border: 1px solid #706deb; border-radius: 3px;
 }
 .title-login-input:focus { outline: none; border-color: #a9a9ff; }
+.title-login-error { color: #ff9a9a; font-size: 14px; text-align: center; text-shadow: 0 1px 3px #000; }
 .title-login-go {
-    font: inherit; font-size: 13px;
-    padding: 5px 12px; cursor: pointer;
+    font: inherit; font-size: 16px;
+    padding: 8px 12px; cursor: pointer;
     color: #fff; background: #2e2c9b;
     border: 1px solid #706deb; border-radius: 3px;
 }


### PR DESCRIPTION
New approach after the 16px / `maximum-scale` attempts (#591, #592) failed to un-stick Android Chrome's focus zoom: **stop fighting it, aim it.**

- The avatar-name input now spans the **full region width (960px)**, so when a phone zooms to fit the focused field, it lands at the scale where the whole region fits — instead of zooming into a tiny field and sticking there.
- Removed the `maximum-scale=1` clamp (it only blocked zoom-*in* and never un-stuck Android).
- The old 14ch width doubled as the name-length cue; now that the field is full-width, the **14-char Habitat name limit is enforced on submit** with an inline error (maxlength raised to 32 as a backstop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)