### PR TITLE
fix(webclient): title scale 3 so the name prompt is a true 960px

### DIFF
--- a/webclient/lib/title.js
+++ b/webclient/lib/title.js
@@ -21,7 +21,10 @@ import { useEffect, useRef, useState } from "preact/hooks"
 const html = htm.bind(h)
 
 // Region playfield is 320×200 C64 px; the stage shows it at this integer scale.
-const SCALE = 2
+// Match the in-game region Scale (live.js Scale.Provider = 3) so the title stage is the same
+// 960px width. The full-width avatar-name prompt is then a true 960px, so a phone's
+// zoom-to-focused-field lands at the scale where the whole 960px region fits.
+const SCALE = 3
 
 // ── the comet sprite, exactly as poked into sprite 0 by Main/comet.m ──
 // A 24-wide C64 sprite; init.m sets only these first three rows (the rest are 0).


### PR DESCRIPTION
Follow-up to #593. The full-width name prompt was only as wide as the title stage — but the title was `SCALE=2` (640px) while the in-game region renders at `Scale=3` (960px). A phone's zoom-to-focused-field would land where 640px fits, leaving the 960px region overflowing ~50%.

Bump the title to `SCALE=3` so the stage and the full-width prompt are a true 960px, matching the region. Title art is positioned proportionally (%), so it rescales cleanly. Verified locally (Playwright/Pixel 7): stage 960px, input 926px, 14-char names rejected on submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)