### PR TITLE
fix(webclient): prescale to 960px game width + solid login panel

### DIFF
--- a/webclient/index.html
+++ b/webclient/index.html
@@ -2,11 +2,13 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
-    <!-- Don't fight the mobile "zoom to the focused field" behavior — aim it. The avatar-name
-         prompt is the full region width (960px = 320*SCALE; see .title-login-input), so when a
-         phone zooms to that focused field it lands exactly at the scale where the whole region
-         fits. No maximum-scale clamp (that only blocked zoom-in and didn't un-stick Android). -->
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Prescale the whole app to the game display width. The client is laid out at a fixed 960px
+         (320 * Scale 3 — the in-game region width, matched by the SCALE=3 title), so declaring the
+         viewport width AS 960 makes mobile browsers scale the page to fit the device width: the
+         whole thing fits on load, no pinch and no fragile zoom-to-focused-field. Desktop browsers
+         ignore viewport width and render the 960px layout normally. The full-width avatar-name
+         input additionally keeps focusing it from zooming in past this fit. -->
+    <meta name="viewport" content="width=960" />
     <title>NeoHabitat — Web Client</title>
     <link rel="stylesheet" href="style.css" />
     <!--

--- a/webclient/style.css
+++ b/webclient/style.css
@@ -146,15 +146,22 @@ header.titlebar .tag {
 /* Avatar-name prompt shown once the client has loaded (replaces "press any key"). */
 .title-login {
     position: absolute;
-    left: 0; right: 0; bottom: 14px;
+    left: 0; right: 0; bottom: 0;
     z-index: 3;
     /* Stack full-width so the input spans the whole region; see the input rule for why. */
     display: flex;
     flex-direction: column;
     align-items: stretch;
     gap: 8px;
-    padding: 0 16px;
+    /* No horizontal padding: the input must be the FULL 960px stage width so a phone's
+       zoom-to-focused-field shows the whole region with nothing clipped (16px of side padding
+       left the title art clipped at the edges). Vertical padding + an opaque backdrop turn the
+       prompt into a clean bottom panel instead of floating label/fields over the title
+       cityscape, which read as an ugly overlap. */
+    padding: 14px 0;
     box-sizing: border-box;
+    background: #000;
+    border-top: 2px solid #4a48a0;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 .title-login-label { color: #fff; font-size: 15px; text-shadow: 0 1px 3px #000; text-align: center; }


### PR DESCRIPTION
Device-tested follow-up to the mobile-zoom saga. Switches from chasing the focus-zoom to **prescaling** (Randy's suggestion).

- **Prescale to the game width** — declare the viewport `width=960` (the fixed 320×Scale-3 layout). Mobile browsers scale the page to fit the device on load; the whole title/region is visible with nothing clipped, no pinch, no fragile zoom-to-field. Desktop ignores viewport width. (The previous zoom-to-field approach left the 960px title clipped because the field was 16px short.)
- **Solid login panel** — drop the form's horizontal padding (input is now the full 960px), give it a black backdrop + divider, flush at the bottom. Fixes the label/fields overlapping the title cityscape.

Verified locally (Playwright/Pixel 7): prescales to fit, input 958px, full title visible, 14-char rejection works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)