### PR TITLE
fix(webclient): collect avatar name via native prompt (no zoom)

### DIFF
--- a/webclient/lib/title.js
+++ b/webclient/lib/title.js
@@ -147,31 +147,24 @@ export const TitleScreen = ({ onProceed, ready = true }) => {
     }
   }
 
-  // Once loaded, the player names their Avatar; submitting it dismisses the curtain and starts
-  // the client (no region is asked — the server lands them wherever they last were).
+  // Once loaded, the player names their Avatar via the browser's native prompt — it's one short
+  // field, and a native OS dialog avoids the zoom/scroll a page-embedded text input triggers on
+  // mobile under our prescaled (width=960) viewport. The server lands them wherever they last
+  // were — no region is asked.
   const [name, setName] = useState(() => new URLSearchParams(location.search).get("user") || "")
-  const [err, setErr] = useState("")
-  const inputRef = useRef(null)
-  const submit = async (e) => {
-    e?.preventDefault?.()
-    const n = name.trim()
-    if (!ready || !n) return
-    // The input is full region width (so a phone's zoom-to-focused-field lands at the whole-region
-    // fit scale), which drops the old 14ch visual length cue — so enforce the name limit here.
-    if (n.length > MAX_NAME_LEN) {
-      setErr(`Avatar names are ${MAX_NAME_LEN} characters or fewer.`)
-      return
+  const enter = async () => {
+    if (!ready) return
+    const ask = (def) => (window.prompt(`Avatar name (${MAX_NAME_LEN} characters max):`, def) ?? "").trim()
+    let n = ask(name)
+    while (n && n.length > MAX_NAME_LEN) {
+      window.alert(`Avatar names are ${MAX_NAME_LEN} characters or fewer.`)
+      n = ask(n.slice(0, MAX_NAME_LEN))
     }
-    // Blur the field so the on-screen keyboard dismisses as the client takes over.
-    inputRef.current?.blur?.()
+    if (!n) return // cancelled or left empty — stay on the title screen
+    setName(n)
     try { (await getSound()).stop() } catch (_) { /* fine */ }
     onProceed(n)
   }
-
-  // Focus the name field as soon as it appears.
-  useEffect(() => {
-    if (phase === "ready" && ready) inputRef.current?.focus()
-  }, [phase, ready])
 
   const onStageClick = () => { if (phase === "idle") begin() }
 
@@ -185,14 +178,9 @@ export const TitleScreen = ({ onProceed, ready = true }) => {
       ${phase === "idle" && html`
         <div class="title-prompt">▶ Click to begin</div>`}
       ${phase === "ready" && (ready
-        ? html`<form class="title-login" onSubmit=${submit}>
-            <span class="title-login-label">Avatar name</span>
-            <input ref=${inputRef} class="title-login-input" value=${name} maxlength="32"
-                   autocomplete="off" spellcheck="false"
-                   onInput=${(e) => { setName(e.target.value); if (err) setErr("") }} />
-            ${err && html`<div class="title-login-error">${err}</div>`}
-            <button class="title-login-go" type="submit" disabled=${!name.trim()}>Enter Habitat</button>
-          </form>`
+        ? html`<div class="title-login">
+            <button class="title-login-go" onClick=${enter}>Enter Habitat</button>
+          </div>`
         : html`<div class="balloon">Loading…<span class="balloon-tail"></span></div>`)}
     </div>`
 }

--- a/webclient/style.css
+++ b/webclient/style.css
@@ -143,51 +143,31 @@ header.titlebar .tag {
 }
 @keyframes blink { 50% { opacity: 0.25; } }
 
-/* Avatar-name prompt shown once the client has loaded (replaces "press any key"). */
+/* Avatar-name entry shown once the title finishes loading. The name is collected via the browser's
+   native prompt (title.js) — a native dialog avoids the mobile zoom/scroll a page-embedded input
+   triggers under the prescaled width=960 viewport — so this is just a button on a bottom panel. */
 .title-login {
     position: absolute;
     left: 0; right: 0; bottom: 0;
     z-index: 3;
-    /* Stack full-width so the input spans the whole region; see the input rule for why. */
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    gap: 8px;
-    /* No horizontal padding: the input must be the FULL 960px stage width so a phone's
-       zoom-to-focused-field shows the whole region with nothing clipped (16px of side padding
-       left the title art clipped at the edges). Vertical padding + an opaque backdrop turn the
-       prompt into a clean bottom panel instead of floating label/fields over the title
-       cityscape, which read as an ugly overlap. */
-    padding: 14px 0;
+    /* Opaque bottom panel + divider so the button sits on a clean bar rather than floating over
+       the title cityscape (the earlier inline prompt overlapped the art). */
+    padding: 14px 16px;
     box-sizing: border-box;
     background: #000;
     border-top: 2px solid #4a48a0;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
-.title-login-label { color: #fff; font-size: 15px; text-shadow: 0 1px 3px #000; text-align: center; }
-.title-login-input {
-    /* Full region width on purpose: mobile browsers zoom to fit the focused field, so a field that
-       is ~the region width makes that zoom land at the scale where the whole 960px region fits —
-       instead of zooming into a tiny field and sticking there (the bug we kept chasing). The 14ch
-       visual length cue is gone, so title.js enforces the 14-char name limit by rejecting on
-       submit. 16px also keeps iOS from its own sub-16px focus zoom. */
-    font: inherit; font-size: 16px;
-    width: 100%; padding: 8px 10px;
-    box-sizing: border-box;
-    text-align: center;
-    color: #fff; background: #0a0a18;
-    border: 1px solid #706deb; border-radius: 3px;
-}
-.title-login-input:focus { outline: none; border-color: #a9a9ff; }
-.title-login-error { color: #ff9a9a; font-size: 14px; text-align: center; text-shadow: 0 1px 3px #000; }
 .title-login-go {
     font: inherit; font-size: 16px;
-    padding: 8px 12px; cursor: pointer;
+    padding: 10px 12px; cursor: pointer;
     color: #fff; background: #2e2c9b;
     border: 1px solid #706deb; border-radius: 3px;
 }
-.title-login-go:hover:not(:disabled) { background: #4a48c0; }
-.title-login-go:disabled { opacity: 0.5; cursor: default; }
+.title-login-go:hover { background: #4a48c0; }
 
 /* C64 word balloon panel (Main/balloons.m) — charset border above the graphics band. */
 .habitat-viewport {


### PR DESCRIPTION
Even with the prescaled `width=960` viewport (kept), focusing the in-page name field still made mobile browsers zoom/scroll. Collect the name with the browser's native `window.prompt()` instead — one short field, and a native OS dialog never zooms the page.

The title now shows just an "Enter Habitat" button; tapping it prompts for the name (re-prompts with an alert if it exceeds the 14-char limit). Removes the dead inline input/label/error markup + CSS.

Verified locally (Playwright/Pixel 7): button renders on the bottom panel, full title visible, prompt → 15-char rejected via alert → re-prompt → 14-char accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)