### PR TITLE
feat(https): Caddy TLS front on :443 — webclient over HTTPS + wss game socket

### DIFF
--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -271,7 +271,7 @@
         set -euo pipefail
         docker compose {{ neohabitat_compose_files | map('regex_replace', '^', '-f ') | join(' ') }} \
           up -d --pull always --remove-orphans \
-          neohabitatmongo neohabitat bots otel-collector promtail
+          neohabitatmongo neohabitat caddy bots otel-collector promtail
       args:
         chdir: "{{ neohabitat_repo_path }}"
         executable: /bin/bash
@@ -279,15 +279,17 @@
       register: compose_up
       changed_when: "'Recreated' in compose_up.stderr or 'Started' in compose_up.stderr"
 
-    - name: Force-recreate monitoring sidecars every deploy
+    - name: Force-recreate bind-mounted-config services every deploy (sidecars + caddy)
       # Compose can't tell when a bind-mounted config file (otel-collector
-      # config, promtail config) changes content, so changes to those land
-      # via git but never get applied until the container is recreated.
-      # Sidecars are stateless and restart in <5s, so just always recreate.
+      # config, promtail config, caddy/Caddyfile) changes content, so changes
+      # to those land via git but never get applied until the container is
+      # recreated. All three are stateless and restart in <5s (caddy reloads
+      # its already-issued cert from the caddy_data volume — no LE re-issue),
+      # so just always recreate. Caddy's recreate is a ~1s blip on :443 only.
       shell: |
         set -euo pipefail
         docker compose {{ neohabitat_compose_files | map('regex_replace', '^', '-f ') | join(' ') }} \
-          up -d --force-recreate --no-deps otel-collector promtail
+          up -d --force-recreate --no-deps otel-collector promtail caddy
       args:
         chdir: "{{ neohabitat_repo_path }}"
         executable: /bin/bash

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,0 +1,55 @@
+# HTTPS front for habitat.themade.org — terminates TLS on :443 and either serves the Alpha
+# webclient (by reverse-proxying the existing Express pushserver, which keeps the alpha-password
+# gate and serves identical files) or bounces everything else to the untouched HTTP site on :80.
+#
+# Why a separate front instead of adding TLS to Express: it leaves the working HTTP Docent +
+# Emulator site completely alone, and a cert hiccup here cannot take :80 down.
+#
+# Cert: Let's Encrypt via TLS-ALPN-01 on :443. We must NOT use the HTTP-01 challenge or bind :80
+# at all — the Express pushserver owns host :80. `caddy_data` (see compose) persists the cert
+# across redeploys so we don't re-issue and hit LE rate limits.
+{
+	# Don't stand up the usual :80 HTTP->HTTPS redirector — :80 belongs to Express.
+	auto_https disable_redirects
+}
+
+habitat.themade.org {
+	# Force the TLS-ALPN-01 challenge (runs on :443); the HTTP-01 challenge would need :80.
+	tls {
+		issuer acme {
+			disable_http_challenge
+		}
+	}
+
+	# The Alpha webclient and its sibling libs. Proxy to the Express pushserver (container :1701)
+	# rather than re-serving the files, so the alpha-password gate (pushserver/app.js alphaGate)
+	# and the exact deployed assets come along for free. `neohabitat` is the compose service name.
+	handle /webclient/* {
+		reverse_proxy neohabitat:1701
+	}
+	handle /habisound/* {
+		reverse_proxy neohabitat:1701
+	}
+	handle /habiworld/* {
+		reverse_proxy neohabitat:1701
+	}
+
+	# Status page — proxied to Express for now; the eventual "take it over" step swaps this one
+	# route for a local handler.
+	handle /status {
+		reverse_proxy neohabitat:1701
+	}
+
+	# Secure game socket. The webclient connects to wss://<host>/ws (live.js); Caddy upgrades and
+	# pipes to the plain-ws websocketProxy on :1987, which is path-agnostic (WebSocketServer({server})).
+	handle /ws/* {
+		reverse_proxy neohabitat:1987
+	}
+
+	# Bare "/" with no path — and any path this front doesn't own — bounces to the existing HTTP
+	# site so the Docent + Emulator page is preserved untouched. The webclient pulls nothing from
+	# these paths, so there is no mixed-content risk.
+	handle {
+		redir http://habitat.themade.org:80{uri} 302
+	}
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,3 +36,26 @@ services:
       # so the prod overlay's port list (which compose REPLACES rather
       # than merges) doesn't accidentally drop it.
       - "127.0.0.1:2018:2018"
+
+  caddy:
+    # HTTPS front on host :443 (see caddy/Caddyfile). Terminates TLS via Let's Encrypt
+    # (TLS-ALPN-01 on 443 — NOT HTTP-01, since the neohabitat container owns host :80),
+    # reverse-proxies the Alpha webclient + the game WebSocket to the neohabitat container,
+    # and 302-redirects everything else to the existing HTTP site. Prod-only: dev/CI never
+    # publishes 443 or needs a public cert.
+    image: caddy:2
+    restart: unless-stopped
+    depends_on:
+      - neohabitat
+    ports:
+      - "443:443"
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data      # persists the issued cert across redeploys (LE rate limits)
+      - caddy_config:/config
+    networks:
+      - neohabitat
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/webclient/lib/live.js
+++ b/webclient/lib/live.js
@@ -59,13 +59,17 @@ const ESP_MESSAGE_SENT = 7
 const ESP_MESSAGE_RECEIVED = 8
 const ESP_DEACTIVATES = 9
 const q = (k, d) => new URLSearchParams(location.search).get(k) ?? d
-// The websocketProxy runs at the page's HOST on a fixed port (pushserver config listenAddr
-// 0.0.0.0:1987; prod clientAddr habitat.themade.org:1987). Synthesize from location.hostname —
-// NOT location.host, which carries the page's own port — plus the proxy port, with the scheme
-// matched to the page (https page → wss, avoiding mixed-content blocks). A ?ws= param overrides.
+// The game socket reaches the websocketProxy (a byte-pipe to bridge:1986). Over plain HTTP
+// (dev/local) we hit it directly at the page host on its fixed port (pushserver listenAddr
+// 0.0.0.0:1987). Over HTTPS that would be mixed-content (wss required), and exposing a second TLS
+// port is avoidable: the prod Caddy front terminates TLS on 443 and reverse-proxies
+// wss://<host>/ws → ws://…:1987, so use the page's own origin + the /ws path (no explicit port).
+// A ?ws= param overrides either way.
 const WS_PROXY_PORT = 1987
 const wsDefault = () =>
-  q("ws", `${location.protocol === "https:" ? "wss:" : "ws:"}//${location.hostname}:${WS_PROXY_PORT}`)
+  q("ws", location.protocol === "https:"
+    ? `wss://${location.host}/ws`
+    : `ws://${location.hostname}:${WS_PROXY_PORT}`)
 const qNum = (k, d) => {
   const v = Number(q(k, d))
   return Number.isFinite(v) && v > 0 ? v : d


### PR DESCRIPTION
Stand up HTTPS for habitat.themade.org without disturbing the working HTTP site (now that the firewall opened :443).

**New prod-only `caddy:2` service** terminates TLS on :443 (Let's Encrypt via **TLS-ALPN-01** — not HTTP-01, since the `neohabitat` container owns :80) and:
- reverse-proxies `/webclient` `/habisound` `/habiworld` `/status` → Express (`neohabitat:1701`), **preserving the alpha-password gate** and the exact deployed assets;
- proxies `/ws` → the websocketProxy (`neohabitat:1987`), upgrading **wss→ws** so the game socket is secure (no mixed-content);
- 302-redirects bare `/` and any unowned path → `http://…:80` so the **Docent + Emulator page is preserved untouched**.

**`webclient/lib/live.js`**: on HTTPS the game socket targets `wss://<host>/ws`; HTTP/dev still hits `:1987` directly (local dev unaffected).

**`ansible/playbooks/deploy.yml`**: add `caddy` to the compose `up` list + the per-deploy force-recreate step (Caddyfile is bind-mounted; compose can't detect its content changes). Cert persists in the `caddy_data` volume.

Validated locally: `caddy validate` ✓, `docker compose config` ✓, `live.js`/`deploy.yml` parse ✓. Deploys via the normal CI path (the deploy playbook force-pulls the host repo, so the bind-mounted Caddyfile + compose arrive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)