### PR TITLE
fix(https): match bare /ws in Caddy so the wss game socket upgrades

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -40,9 +40,12 @@ habitat.themade.org {
 		reverse_proxy neohabitat:1701
 	}
 
-	# Secure game socket. The webclient connects to wss://<host>/ws (live.js); Caddy upgrades and
-	# pipes to the plain-ws websocketProxy on :1987, which is path-agnostic (WebSocketServer({server})).
-	handle /ws/* {
+	# Secure game socket. The webclient connects to exactly wss://<host>/ws (live.js). `handle`
+	# takes a single matcher token and `/ws/*` does NOT match the bare `/ws` (that dropped the
+	# upgrade through to the redirect → 302), so use a named path matcher for both /ws and /ws/*.
+	# Caddy upgrades and pipes to the plain-ws websocketProxy on :1987 (path-agnostic).
+	@ws path /ws /ws/*
+	handle @ws {
 		reverse_proxy neohabitat:1987
 	}
 


### PR DESCRIPTION
Follow-up to #599. The game socket got a 302 instead of a 101: the webclient connects to exactly `wss://<host>/ws`, but `handle /ws/*` doesn't match the bare `/ws`, so the upgrade fell through to the catch-all redirect. `handle` takes a single matcher token, so use a named path matcher (`@ws path /ws /ws/*`) for both forms. Validated with `caddy validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)