### PR TITLE
feat(https): redirect plain-HTTP /webclient to HTTPS

### DIFF
--- a/pushserver/app.js
+++ b/pushserver/app.js
@@ -60,6 +60,22 @@ function alphaGate(req, res, next) {
   res.set('WWW-Authenticate', 'Basic realm="Neohabitat Alpha"').status(401).end('Authentication required.');
 }
 var repoRoot = path.join(__dirname, '..');
+
+// The Alpha client needs a secure context (habisound AudioWorklet) and a wss game socket, so it
+// must run over HTTPS. In prod the Caddy front terminates TLS on :443 and proxies to us with
+// X-Forwarded-Proto: https; a request without that header arrived over plain HTTP on :80, so bounce
+// it up to the HTTPS URL. Only /webclient is forced — /habisound and /habiworld are shared libs that
+// other plain-HTTP pages may embed, and the HTTPS client already fetches them over https via Caddy.
+// Gated on config.requireHttps so local dev (no TLS) is unaffected.
+function forceHttps(req, res, next) {
+  if (config.requireHttps && req.headers['x-forwarded-proto'] !== 'https') {
+    var host = (req.headers.host || 'habitat.themade.org').replace(/:\d+$/, '');
+    return res.redirect(302, 'https://' + host + req.originalUrl);
+  }
+  next();
+}
+app.use('/webclient', forceHttps);
+
 ['webclient', 'habisound', 'habiworld'].forEach(function (dir) {
   app.use('/' + dir, alphaGate, express.static(path.join(repoRoot, dir)));
 });

--- a/pushserver/config.prod.yml
+++ b/pushserver/config.prod.yml
@@ -5,6 +5,11 @@ viceJsUrl: https://sgeo.github.io/experimental/neohabitat-joystick/x64.js
 # developer build that can overflow co-present C64 clients, so it's locked. Unset = open (dev).
 alphaPassword: oracle
 
+# Force /webclient onto HTTPS (the Caddy front on :443). A plain-HTTP hit to /webclient 302s to the
+# https URL so the client always runs in a secure context (habisound + wss). Prod-only — left unset
+# in dev so local http://localhost serving isn't redirected. See pushserver/app.js forceHttps.
+requireHttps: true
+
 websocketProxy:
   clientAddr: habitat.themade.org:1987
   listenAddr: 0.0.0.0:1987


### PR DESCRIPTION
Follow-up to #599/#600. The Alpha client needs a secure context (habisound AudioWorklet + wss socket), so force `/webclient` onto HTTPS: a request without `X-Forwarded-Proto: https` (direct HTTP on :80, not via the Caddy :443 front) 302s to the https URL. Only `/webclient` is forced — `/habisound`/`/habiworld` are shared libs other HTTP pages may embed (and the HTTPS client already pulls them over https via Caddy). Gated on `config.requireHttps` (prod-only; dev unaffected).

Verified the HTTPS client loads clean (Playwright): 200, `isSecureContext: true`, `wss://…/ws`, no mixed-content/TLS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)