### PR TITLE
feat(dev): serve the webclient from Express via working-tree mounts (no python)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,17 @@
 # This file is never loaded in prod — Ansible uses docker-compose.prod.yml only.
 
 services:
+  neohabitat:
+    # Serve the webclient stack from the live working tree instead of the baked image, so edits to
+    # webclient/habisound/habiworld appear immediately at http://localhost:1701/webclient/ — no
+    # rebuild and no separate static server. (The Express pushserver already serves these dirs from
+    # repoRoot=/neohabitat; these read-only mounts shadow the COPY'd copies with the working tree.
+    # This is what `python -m http.server` used to cover.)
+    volumes:
+      - ./webclient:/neohabitat/webclient:ro
+      - ./habisound:/neohabitat/habisound:ro
+      - ./habiworld:/neohabitat/habiworld:ro
+
   bridge_v2:
     build:
       context: ./bridge_v2

--- a/webclient/README.md
+++ b/webclient/README.md
@@ -13,20 +13,29 @@ architecture and phase roadmap.
 ## Running
 
 No build step. Native ES modules + importmap + vendored Preact/htm/signals, served static.
-Serve from the **repo root** (`~/neohabitat`) so the client can reach sibling libraries
-(`habiworld`, `habirender`, `habisound`). Native ESM, importmaps, `fetch`, and the
-habisound `AudioWorklet` all require http(s) — not `file://`.
+The client reaches sibling libraries (`habiworld`, `habirender`, `habisound`) as paths under
+the host root. Native ESM, importmaps, `fetch`, and the habisound `AudioWorklet` all require
+http(s) — not `file://`.
+
+**Preferred (dev compose):** the Express pushserver already serves the client, and the dev
+overlay bind-mounts the working tree so edits show up live — no separate server, no rebuild:
 
 ```sh
-cd ~/neohabitat
-python3 -m http.server 8000
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up   # or ./dev.sh
+# → http://localhost:1701/webclient/   (mirrors prod, where Caddy/Express serve the same paths)
 ```
 
-| URL | Purpose |
+**Standalone (no stack):** serve the **repo root** statically — the original quick option:
+
+```sh
+cd ~/neohabitat && python3 -m http.server 8000   # → http://localhost:8000/webclient/
+```
+
+| URL (dev compose) | Purpose |
 |-----|---------|
-| [http://localhost:8000/webclient/](http://localhost:8000/webclient/) | **The live client** (same as live.html — both are the entry) |
-| [http://localhost:8000/webclient/live.html](http://localhost:8000/webclient/live.html) | **The live client** (WebSocket → habiworld → habirender) |
-| [http://localhost:8000/webclient/region.html](http://localhost:8000/webclient/region.html) | Static region JSON demo |
+| [http://localhost:1701/webclient/](http://localhost:1701/webclient/) | **The live client** (same as live.html — both are the entry) |
+| [http://localhost:1701/webclient/live.html](http://localhost:1701/webclient/live.html) | **The live client** (WebSocket → habiworld → habirender) |
+| [http://localhost:1701/webclient/region.html](http://localhost:1701/webclient/region.html) | Static region JSON demo |
 
 ### Live viewer
 


### PR DESCRIPTION
Dev-only. The dev `neohabitat` container runs the baked image (`COPY . .` at `/neohabitat`), so Express served a stale webclient — devs ran a separate `python -m http.server` for live edits. Bind-mount `webclient`/`habisound`/`habiworld` (read-only) over the baked copies in `docker-compose.dev.yml` so Express serves the live tree at `http://localhost:1701/webclient/` — no separate static server, no rebuild, mirrors prod. README updated; python kept as the standalone option.

No prod impact (`docker-compose.dev.yml` is never loaded in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)