### PR TITLE
Security: Potential Command Injection via process.argv in dbUtils.js

### DIFF
--- a/db/dbUtils.js
+++ b/db/dbUtils.js
@@ -35,6 +35,11 @@ const runDBTests = async () => {
   var mongoHost = process.argv[2];
   var mode = process.argv[3];
 
+  if (!/^[a-zA-Z0-9.-]+$/.test(mongoHost)) {
+    console.error('Invalid MONGO_HOST format');
+    process.exit(-1);
+  }
+
   const client = await MongoClient.connect(`mongodb://${mongoHost}/`, {
     connectTimeoutMS: 15000
   });


### PR DESCRIPTION
## Summary

Security: Potential Command Injection via process.argv in dbUtils.js

## Problem

**Severity**: `Medium` | **File**: `db/dbUtils.js:L28`

The dbUtils.js script uses `process.argv[2]` and `process.argv[3]` directly without validation. While this is a CLI tool, the MongoDB connection string is constructed using template literals with user input (`mongodb://${mongoHost}/`). If `mongoHost` contains malicious input, it could potentially be used for connection string injection, though the impact is limited to MongoDB connection attempts.

## Solution

Validate and sanitize the `mongoHost` parameter. Use a URL parser to validate the host format, and consider using MongoDB connection options object instead of string concatenation.

## Changes

- `db/dbUtils.js` (modified)