### PR TITLE
fix(webclient): prescale to 1040 so open-terrain regions don't clip on mobile

### DIFF
--- a/webclient/index.html
+++ b/webclient/index.html
@@ -2,12 +2,13 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
-    <!-- Prescale the whole app to the game display width. The client is laid out at a fixed 960px
-         (320 * Scale 3 — the in-game region width, matched by the SCALE=3 title), so declaring the
-         viewport width AS 960 makes mobile browsers scale the page to fit the device width: the
-         whole thing fits on load, no pinch and no fragile zoom-to-focused-field. Desktop browsers
-         ignore viewport width and render the 960px layout normally. -->
-    <meta name="viewport" content="width=960" />
+    <!-- Prescale the whole app to the WIDEST the client gets: an open-terrain region frame is the
+         960px game (320 * Scale 3) plus a 34px edge chevron on each side ≈ 1028px, rounded up to
+         the #app max-width 1040. Declaring the viewport width AS 1040 makes mobile browsers scale
+         the whole client (game, chevrons, keyboard) to fit the device with nothing clipped — and
+         since game + keyboard are center-aligned, the keyboard sits right under the game. Desktop
+         browsers ignore viewport width and render the 1040 layout normally. -->
+    <meta name="viewport" content="width=1040" />
     <title>NeoHabitat</title>
     <link rel="stylesheet" href="style.css" />
     <!--

--- a/webclient/live.html
+++ b/webclient/live.html
@@ -2,9 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
-    <!-- Prescale to the 960px game width so mobile browsers fit the whole client on load; desktop
-         ignores viewport width. Same entry as index.html — both ./ and ./live.html run the client. -->
-    <meta name="viewport" content="width=960" />
+    <!-- Prescale to the widest the client gets (open-terrain region frame: 960 game + 34px edge
+         chevron each side ≈ 1028, rounded to the #app max-width 1040) so mobile fits the whole
+         client with nothing clipped; desktop ignores viewport width. Same entry as index.html. -->
+    <meta name="viewport" content="width=1040" />
     <title>NeoHabitat</title>
     <link rel="stylesheet" href="style.css" />
     <script type="importmap">

--- a/webclient/style.css
+++ b/webclient/style.css
@@ -21,7 +21,10 @@ body {
 #app {
     max-width: 1040px;
     margin: 0 auto;
-    padding: 16px;
+    /* No horizontal padding: the open-terrain region frame (960 game + 34px edge chevron each
+       side = 1028px) must fit inside the prescaled 1040 viewport. 16px side padding would shrink
+       the content box below 1028 and clip the chevroned frame. Vertical padding stays. */
+    padding: 16px 0;
     display: flex;
     flex-direction: column;
     gap: 12px;


### PR DESCRIPTION
Mobile left-clip (Randy's screenshot). An open-terrain region frame is 1028px (960 game + 34px edge chevron each side) — wider than the `width=960` prescale — so it overflowed, and the centered layout split the overflow across both edges, clipping the game's left and the keyboard's left column. Prescale to the widest the client gets: `width=1040` (the `#app` max-width) and drop the `#app` horizontal padding so the 1028 frame fits.

Verified (Playwright, 412px device): viewport 1040, zero horizontal overflow, the 1028 frame fits (6px each side), game viewport + keyboard both center at 520 (aligned, nothing clipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)