### PR TITLE
Habilink: emit CONNECT only as a fallback for transparent modems

### DIFF
--- a/bridge_v2/bridge/qlink_session.go
+++ b/bridge_v2/bridge/qlink_session.go
@@ -206,7 +206,9 @@ func readHabilinkPreamble(r *bufio.Reader, sessionID string) (string, error) {
 				return "", fmt.Errorf("%w: EOF before username found", ErrQLinkPreamble)
 			}
 			if err != io.EOF {
-				return "", fmt.Errorf("%w: read error: %v", ErrQLinkPreamble, err)
+				// %w on the underlying error too, so callers can errors.As it
+				// (e.g. runHabilink detects a read-deadline timeout this way).
+				return "", fmt.Errorf("%w: read error: %w", ErrQLinkPreamble, err)
 			}
 		}
 		log.Trace().Str("session_id", sessionID).Str("line", line).Msg("Habilink preamble line")
@@ -286,7 +288,38 @@ func (c *ClientSession) runHabilink() {
 
 	// Phase 1: Habilink JSON preamble — read text lines until we see the
 	// {"name":"..."} field.
+	//
+	// CONNECT fallback for modems that don't emit their own. dial_modem() blocks
+	// after ATDT waiting for a Hayes "CONNECT" result code. A proper modem emits it
+	// (pipe_modem.py does; a correct Hayes modem should) and the client sends its
+	// login immediately. The Ultimate 64's built-in modem, however, opens the TCP
+	// transparently and never emits CONNECT — the client hangs at "Dialing" forever
+	// (the same gap qlink's HabilinkListener papered over). Rather than always
+	// injecting CONNECT — which prepends junk to a well-behaved client's stream —
+	// send it ONLY as a fallback: read the preamble under a 2s deadline; if the
+	// {"name":...} login doesn't arrive, the modem gave no CONNECT, so we supply one
+	// and read again. Peeking for "any byte" is NOT enough — a transparent modem
+	// forwards the client's dial chatter, which isn't the login.
+	if conn := c.clientConn.conn; conn != nil {
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	}
 	username, err := readHabilinkPreamble(c.clientReader, c.sessionID)
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		if conn := c.clientConn.conn; conn != nil {
+			_ = conn.SetReadDeadline(time.Time{})
+		}
+		if _, werr := c.clientConn.WriteRaw([]byte("\r\rCONNECT\r")); werr != nil {
+			c.log.Error().Err(werr).Msg("Habilink CONNECT fallback write failed")
+			go c.Close()
+			return
+		}
+		c.log.Debug().Msg("no login within 2s — sent CONNECT fallback (transparent modem)")
+		username, err = readHabilinkPreamble(c.clientReader, c.sessionID)
+	}
+	if conn := c.clientConn.conn; conn != nil {
+		_ = conn.SetReadDeadline(time.Time{})
+	}
 	if err != nil {
 		c.log.Error().Err(err).Msg("Habilink preamble failed")
 		go c.Close()


### PR DESCRIPTION
## Problem

The C64 Habitat launcher's `dial_modem()` blocks after sending `ATDT` until it sees a Hayes **`CONNECT`** result code — only then does it send its JSON login preamble. A real Hayes modem emits `CONNECT` itself. The **Ultimate 64's built-in modem opens the TCP connection transparently and never emits it**, so the client sits at "Dialing…" forever.

The bridge had been papering over this by **unconditionally injecting `CONNECT`** at the top of every Habilink session. That fixes the U64 but prepends `\r\rCONNECT\r` to the stream of any client whose modem already did the right thing.

## Fix

Send `CONNECT` only when it's actually missing. Read the login preamble under a **2-second read deadline**:

- Login arrives (modem supplied its own `CONNECT`, or client doesn't wait for one) → do nothing, proceed.
- Deadline fires with no login → synthesize a `CONNECT` and re-read the preamble.

The timeout is detected via `errors.As(err, &netErr) && netErr.Timeout()`, which required wrapping the underlying read error with `%w` in `readHabilinkPreamble`.

**Why not just peek for a byte:** a transparent modem forwards the client's own dial chatter (the echoed `ATDT…`), so a byte arrives that *isn't* the login. Keying off the actual `{"name":...}` preamble is what makes the heuristic correct.

## Behavior

| Client's modem | Before | After |
|---|---|---|
| Emits CONNECT (real Hayes / `pipe_modem.py`) | CONNECT injected anyway (junk prefix) | silent — login lands < 2s |
| Transparent (Ultimate 64) | CONNECT injected | login times out → CONNECT sent, ~2s to connect |

## Testing

- **Ultimate 64** (transparent modem): fallback fires, login lands ~2s after the socket opens.
- **VICE** user-port client against **production** (`app.neohabitat.org:1986`): login lands immediately, fallback never fires.

## Scope

Single file (`bridge_v2/bridge/qlink_session.go`). Deliberately excludes two changes that were tangled up in the same local experiment branch but don't belong here:

- **`MAX_PACKET_SIZE 100→55`** — rode along with a throttle-bypass experiment that was itself reverted; the VICE-vs-prod test confirms the client works fine on production's `100`.
- **A local `docker-compose` run overlay** (hardcoded IPs, external volume) — dev scaffolding.
