### PR TITLE
bridge_v2: watchdog + metrics for silent region-transition stalls

### DIFF
--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -35,6 +35,13 @@ var nextSessionID uint64
 
 const MaxClientMessages = 500
 
+// regionTransitWatchdogTimeout bounds how long the bridge waits for the client's
+// follow-up MESSAGE_DESCRIBE after an immediate:false changeContext before it
+// force-enters the new region to break a silent lockup. Generous vs the normal
+// sub-second DESCRIBE so it only fires on a genuine stall. A var (not const) so
+// tests can shorten it.
+var regionTransitWatchdogTimeout = 15 * time.Second
+
 var ElkoMsgTerminator = []byte("\n\n")
 
 type outboundElkoMessage struct {
@@ -121,11 +128,16 @@ type ClientSession struct {
 	largeRequestCache    []byte
 	nextRegion           string
 	nextRegionSet        bool
-	log                  zerolog.Logger  // sticky avatar/ip/session_id structured fields
-	sessionID            string          // monotonic session handle, also a log + span attribute
-	ctx                  context.Context // context carrying the session root span
-	span                 trace.Span      // root span for this session, ended in Close()
-	jsonPassthrough      bool            // true => client speaks JSON directly to Elko; bridge relays
+	// regionTransitGen is bumped when a region transition is armed (changeContext
+	// immediate:false) and on every enterContext. The transit watchdog captures
+	// it at arm time and only fires if it's unchanged at timeout — i.e. no client
+	// DESCRIBE (enterContext) or newer transition resolved it. Guarded by stateMu.
+	regionTransitGen uint64
+	log              zerolog.Logger  // sticky avatar/ip/session_id structured fields
+	sessionID        string          // monotonic session handle, also a log + span attribute
+	ctx              context.Context // context carrying the session root span
+	span             trace.Span      // root span for this session, ended in Close()
+	jsonPassthrough  bool            // true => client speaks JSON directly to Elko; bridge relays
 	// bridgeAutoEnteredContext records the most recent context the
 	// bridge entered on the client's behalf (after a server-initiated
 	// changeContext in JSON-passthrough mode). Used to suppress the
@@ -562,6 +574,16 @@ func (c *ClientSession) handleElkoMessage(msg *ElkoMessage) {
 		// the binary handleClientMessage path; same outcome.
 		if boolor(msg.Immediate, false) {
 			c.enterContext(c.nextRegion)
+		} else {
+			// immediate:false — the transition now hinges entirely on the
+			// client sending MESSAGE_DESCRIBE (which drives enterContext). If it
+			// never does — e.g. its region change raced a co-present avatar's
+			// arrival, so the C64 dropped the follow-up DESCRIBE — habiproxy's
+			// Elko-side stays torn down and the session hangs forever with NO
+			// error anywhere (the Snogpitch lockup, 2026-07). Arm a watchdog to
+			// force the entry as a recovery net.
+			observability.IncRegionTransits(c.ctx)
+			c.armRegionTransitWatchdog(c.nextRegion)
 		}
 		return
 	}
@@ -2402,6 +2424,49 @@ func (c *ClientSession) enterContext(context string) {
 	c.nextRegion = ""
 	c.nextRegionSet = true
 	c.firstConnection = false
+	// Advance the transit epoch: we've entered a context, so any pending
+	// region-transit watchdog is now moot and must not fire.
+	c.regionTransitGen++
+}
+
+// armRegionTransitWatchdog starts a one-shot timer for the pending
+// immediate:false region transition to region. If the client's MESSAGE_DESCRIBE
+// (which drives enterContext) hasn't fired by regionTransitWatchdogTimeout,
+// regionTransitWatchdogFired force-enters the region so the session can't hang
+// forever. Caller must hold stateMu.
+func (c *ClientSession) armRegionTransitWatchdog(region string) {
+	c.regionTransitGen++
+	gen := c.regionTransitGen
+	time.AfterFunc(regionTransitWatchdogTimeout, func() {
+		c.regionTransitWatchdogFired(gen, region)
+	})
+}
+
+// regionTransitWatchdogFired runs regionTransitWatchdogTimeout after arming. It
+// force-enters the stalled region iff nothing resolved the transition in the
+// meantime (regionTransitGen unchanged) and the session is still alive. Emits a
+// WARN and the region_transit.stalls metric so the recovery is observable.
+func (c *ClientSession) regionTransitWatchdogFired(gen uint64, region string) {
+	// Lock-free early out if the session was torn down while we waited.
+	select {
+	case <-c.done:
+		return
+	default:
+	}
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	if c.regionTransitGen != gen {
+		// A client DESCRIBE (enterContext) or a newer changeContext already
+		// advanced the epoch — nothing stalled.
+		return
+	}
+	observability.IncRegionTransitStalls(c.ctx)
+	c.log.Warn().
+		Str("region", region).
+		Dur("after", regionTransitWatchdogTimeout).
+		Msg("region transition stalled — client never sent DESCRIBE; force-entering to recover")
+	// enterContext advances regionTransitGen, so this cannot re-fire/loop.
+	c.enterContext(region)
 }
 
 func (c *ClientSession) enterContextAfterRegionChecks(context string) {

--- a/bridge_v2/bridge/region_transit_watchdog_test.go
+++ b/bridge_v2/bridge/region_transit_watchdog_test.go
@@ -1,0 +1,150 @@
+package bridge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Coverage for the region-transition watchdog (ClientSession.armRegionTransit-
+// Watchdog / regionTransitWatchdogFired), which force-enters a region when the
+// client never sends the follow-up MESSAGE_DESCRIBE after an immediate:false
+// changeContext — the Snogpitch lockup (2026-07). enterContext queues its
+// entercontext on elkoSendChan, so we assert on that (no live Elko needed).
+
+// newWatchdogTestSession builds the minimal ClientSession the watchdog +
+// enterContext touch: a buffered (never-closed) elkoSendChan, a done channel, a
+// nil transit registry (no-op in tests, per invisible.go), and a discard logger.
+func newWatchdogTestSession() *ClientSession {
+	return &ClientSession{
+		bridge:        &Bridge{Sessions: make(map[string]*ClientSession)},
+		ctx:           context.Background(),
+		done:          make(chan struct{}),
+		elkoSendChan:  make(chan *outboundElkoMessage, MaxClientMessages),
+		log:           zerolog.Nop(),
+		userRef:       "user-test",
+		NoidClassList: []uint8{},
+		NoidContents:  make(map[uint8][]uint8),
+		RefToNoid:     make(map[string]uint8),
+		objects:       make(map[uint8]*ElkoMessage),
+	}
+}
+
+// armWatchdog arms the transit watchdog under stateMu, as the changeContext
+// handler does.
+func (c *ClientSession) armWatchdog(region string) {
+	c.stateMu.Lock()
+	c.armRegionTransitWatchdog(region)
+	c.stateMu.Unlock()
+}
+
+// recvEnterContext waits up to timeout for an entercontext on the session's Elko
+// send channel and returns its target context. ok=false on timeout (none sent).
+func recvEnterContext(t *testing.T, ch chan *outboundElkoMessage, timeout time.Duration) (string, bool) {
+	t.Helper()
+	select {
+	case out := <-ch:
+		if out.msg == nil || out.msg.Op == nil || *out.msg.Op != "entercontext" {
+			t.Fatalf("expected an entercontext message, got %+v", out.msg)
+		}
+		if out.msg.Context == nil {
+			return "", true
+		}
+		return *out.msg.Context, true
+	case <-time.After(timeout):
+		return "", false
+	}
+}
+
+// shortenWatchdog drops the (package-wide) timeout for the duration of a test.
+// Tests run sequentially, so mutating the package var is safe.
+func shortenWatchdog(t *testing.T) {
+	t.Helper()
+	restore := regionTransitWatchdogTimeout
+	regionTransitWatchdogTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { regionTransitWatchdogTimeout = restore })
+}
+
+// The client never sends DESCRIBE → the watchdog must force-enter the region.
+func TestRegionTransitWatchdog_FiresOnStall(t *testing.T) {
+	shortenWatchdog(t)
+	sess := newWatchdogTestSession()
+	const region = "context-Popustop.afront2.line1106"
+
+	sess.armWatchdog(region)
+
+	got, ok := recvEnterContext(t, sess.elkoSendChan, 500*time.Millisecond)
+	if !ok {
+		t.Fatal("watchdog never fired: no entercontext after the timeout")
+	}
+	if got != region {
+		t.Fatalf("watchdog entered %q, want %q", got, region)
+	}
+	sess.stateMu.Lock()
+	defer sess.stateMu.Unlock()
+	if !sess.nextRegionSet {
+		t.Fatal("nextRegionSet should be true after the forced enterContext")
+	}
+}
+
+// A normal DESCRIBE (enterContext) resolves the transition → the watchdog must
+// NOT fire a second, spurious entercontext.
+func TestRegionTransitWatchdog_NoFireAfterDescribe(t *testing.T) {
+	shortenWatchdog(t)
+	sess := newWatchdogTestSession()
+	const region = "context-Downtown_5f"
+
+	sess.stateMu.Lock()
+	sess.armRegionTransitWatchdog(region)
+	// The client's DESCRIBE arrives: enterContext runs, advancing the epoch.
+	sess.enterContext(region)
+	sess.stateMu.Unlock()
+
+	// Drain the legitimate entercontext from the DESCRIBE-driven enter.
+	if got, ok := recvEnterContext(t, sess.elkoSendChan, 200*time.Millisecond); !ok || got != region {
+		t.Fatalf("expected the DESCRIBE-driven entercontext for %q (ok=%v got=%q)", region, ok, got)
+	}
+	if got, ok := recvEnterContext(t, sess.elkoSendChan, 5*regionTransitWatchdogTimeout); ok {
+		t.Fatalf("watchdog fired after a normal DESCRIBE — spurious entercontext for %q", got)
+	}
+}
+
+// A newer changeContext supersedes an earlier one → only the latest transition's
+// watchdog force-enters, exactly once.
+func TestRegionTransitWatchdog_SupersededByNewerTransition(t *testing.T) {
+	shortenWatchdog(t)
+	sess := newWatchdogTestSession()
+	const r1 = "context-A"
+	const r2 = "context-B"
+
+	sess.stateMu.Lock()
+	sess.armRegionTransitWatchdog(r1) // epoch G
+	sess.armRegionTransitWatchdog(r2) // epoch G+1, supersedes r1
+	sess.stateMu.Unlock()
+
+	got, ok := recvEnterContext(t, sess.elkoSendChan, 500*time.Millisecond)
+	if !ok {
+		t.Fatal("newer transition's watchdog never fired")
+	}
+	if got != r2 {
+		t.Fatalf("watchdog entered %q, want the newer %q", got, r2)
+	}
+	if got, ok := recvEnterContext(t, sess.elkoSendChan, 5*regionTransitWatchdogTimeout); ok {
+		t.Fatalf("stale (superseded) watchdog also fired: extra entercontext for %q", got)
+	}
+}
+
+// A torn-down session (done closed) → the watchdog must bail without entering.
+func TestRegionTransitWatchdog_NoFireWhenClosed(t *testing.T) {
+	shortenWatchdog(t)
+	sess := newWatchdogTestSession()
+
+	sess.armWatchdog("context-C")
+	close(sess.done) // session torn down before the timer fires
+
+	if got, ok := recvEnterContext(t, sess.elkoSendChan, 5*regionTransitWatchdogTimeout); ok {
+		t.Fatalf("watchdog fired on a closed session: entercontext for %q", got)
+	}
+}

--- a/bridge_v2/observability/instruments.go
+++ b/bridge_v2/observability/instruments.go
@@ -32,6 +32,21 @@ var (
 	ClientCrashes  metric.Int64Counter
 )
 
+// Diagnostic metrics — specific failure modes we've had to reconstruct from
+// logs after the fact (silent region-transition stalls, etc.). Surfacing them
+// as first-class counters lets the dashboard alert on them directly instead of
+// waiting for a tester to report a lockup.
+var (
+	// RegionTransits counts NEWREGION-driven (immediate:false) context changes
+	// started — the denominator for the stall rate.
+	RegionTransits metric.Int64Counter
+	// RegionTransitStalls counts transitions the watchdog had to force-recover
+	// because the client never sent its follow-up DESCRIBE within the window
+	// (see ClientSession.regionTransitWatchdogFired). Each one was a silent,
+	// permanent client lockup before the watchdog existed.
+	RegionTransitStalls metric.Int64Counter
+)
+
 // Attribute key constants used as both span attributes and zerolog
 // structured-log field names so a trace and its surrounding logs share
 // keys for indexing in Grafana Cloud.
@@ -117,6 +132,23 @@ func InitInstruments() error {
 		return fmt.Errorf("client.crashes: %w", err)
 	}
 
+	// Diagnostic metrics.
+	RegionTransits, err = meter.Int64Counter(
+		"bridge_v2.region_transit.total",
+		metric.WithDescription("NEWREGION-driven (immediate:false) context changes started"),
+	)
+	if err != nil {
+		return fmt.Errorf("region_transit.total: %w", err)
+	}
+
+	RegionTransitStalls, err = meter.Int64Counter(
+		"bridge_v2.region_transit.stalls",
+		metric.WithDescription("Region transitions the watchdog force-recovered (client never sent DESCRIBE)"),
+	)
+	if err != nil {
+		return fmt.Errorf("region_transit.stalls: %w", err)
+	}
+
 	return nil
 }
 
@@ -170,4 +202,18 @@ func IncClientCrashes(ctx context.Context, attrs ...attribute.KeyValue) {
 		return
 	}
 	ClientCrashes.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+func IncRegionTransits(ctx context.Context, attrs ...attribute.KeyValue) {
+	if RegionTransits == nil {
+		return
+	}
+	RegionTransits.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+func IncRegionTransitStalls(ctx context.Context, attrs ...attribute.KeyValue) {
+	if RegionTransitStalls == nil {
+		return
+	}
+	RegionTransitStalls.Add(ctx, 1, metric.WithAttributes(attrs...))
 }


### PR DESCRIPTION
## Problem — a silent, permanent region-transition lockup

A tester locked up: they invited a bot, walked to a region edge as the bot arrived, and their client froze with the **GO cursor stuck** — the bot never appeared, no error anywhere.

Tracing it end-to-end (U64 → `bridge_v2` → `habiproxy` → Elko):

- On an `immediate:false` `changeContext` (the typical `NEWREGION`-driven case), `bridge_v2` saves the target region and **waits for the C64 client's `MESSAGE_DESCRIBE`** to drive `enterContext` (`client_session.go` changeContext handler → DESCRIBE handler).
- `habiproxy.cycleServerSide` tears down the Elko-side socket on the `changeContext` and **re-opens it lazily on the bridge's next write** (the entercontext). That's correct by design.
- **But if the client never sends `DESCRIBE`** — its region change raced a co-present avatar's arrival, so the C64 dropped the follow-up — `enterContext` never fires, habiproxy never reconnects, and the session hangs **forever with nothing logged**. `habiproxy` is (correctly) waiting; `bridge_v2` has no timeout.

## Fix — a region-transition watchdog

Arm a per-session watchdog when the `immediate:false` `changeContext` sets `nextRegion`. If `enterContext` hasn't run within **15s**, force it — the same call `DESCRIBE` would have made ("same outcome" per the existing comment) — to break the lockup.

Correctness guards:
- A **`regionTransitGen` epoch** (bumped on every arm and every `enterContext`): a real `DESCRIBE` *or* a newer `changeContext` advances it, so the stale timer no-ops. Cancellation without tracking timer handles.
- A **lock-free `done`-channel check**: no action on a torn-down session.
- The force-enter runs under `stateMu` (same as the existing `enterContext` call sites), and `enterContext` bumps the epoch so it can't re-fire/loop.
- A late/slow `DESCRIBE` arriving *after* a forced recovery is harmlessly ignored (`nextRegion` already cleared → the DESCRIBE handler's `else` path).

15s is far beyond the normal sub-second `DESCRIBE`, so it only fires on a genuine stall.

## Observability — a Diagnostics section

So this class of failure stops being invisible:
- `bridge_v2.region_transit.total` — `immediate:false` transitions started (denominator)
- `bridge_v2.region_transit.stalls` — transitions the watchdog force-recovered (numerator)

Plus a `WARN` on each fire. `stalls / total` is now a graphable stall rate instead of a log-archaeology exercise after a tester reports a lockup.

## Tests

`region_transit_watchdog_test.go` — drives the real `enterContext` (which queues its `entercontext` on `elkoSendChan`, so no live Elko needed) and covers:
- fires + force-enters on a stall
- **no** fire after a normal `DESCRIBE` (epoch cancels it)
- superseded by a newer transition → only the latest fires, once
- **no** fire on a closed session

All pass under `-race`; the full `./bridge/` suite still passes under `-race` (no regression from the `enterContext`/`changeContext` edits).

Also verified live in a local VICE session against the rebuilt bridge — happy-path region transitions are unaffected.
