### PR TITLE
fix(regions): Plaza SW/NW grey ground trapezoid Color-RAM leak

### DIFF
--- a/db/new_Downtown/Downtown_4e.json
+++ b/db/new_Downtown/Downtown_4e.json
@@ -71,10 +71,15 @@
     "ref": "item-sky90cf", 
     "mods": [
       {
-        "y": 2, 
-        "x": 0, 
-        "style": 7, 
-        "type": "Sky", 
+        "y": 56,
+        "x": 0,
+        "trapezoid_type": 0,
+        "upper_left_x": 0,
+        "upper_right_x": 160,
+        "lower_left_x": 0,
+        "lower_right_x": 160,
+        "height": 8,
+        "type": "Trapezoid",
         "orientation": 172
       }
     ], 
@@ -86,14 +91,14 @@
     "ref": "item-trapezoidc2a4", 
     "mods": [
       {
-        "y": 3, 
+        "y": 0, 
         "x": 0, 
         "trapezoid_type": 2, 
         "upper_left_x": 0, 
         "upper_right_x": 160, 
         "lower_left_x": 0, 
         "lower_right_x": 160, 
-        "height": 47, 
+        "height": 56, 
         "type": "Trapezoid", 
         "orientation": 220
       }

--- a/db/new_Downtown/Downtown_4g.json
+++ b/db/new_Downtown/Downtown_4g.json
@@ -70,10 +70,15 @@
     "ref": "item-sky46d0", 
     "mods": [
       {
-        "y": 2, 
-        "x": 0, 
-        "style": 7, 
-        "type": "Sky", 
+        "y": 56,
+        "x": 0,
+        "trapezoid_type": 0,
+        "upper_left_x": 0,
+        "upper_right_x": 160,
+        "lower_left_x": 0,
+        "lower_right_x": 160,
+        "height": 8,
+        "type": "Trapezoid",
         "orientation": 172
       }
     ], 
@@ -85,14 +90,14 @@
     "ref": "item-trapezoid8b23", 
     "mods": [
       {
-        "y": 3, 
+        "y": 0, 
         "x": 0,
         "trapezoid_type": 2, 
         "upper_left_x": 0, 
         "upper_right_x": 160, 
         "lower_left_x": 0, 
         "lower_right_x": 160, 
-        "height": 47, 
+        "height": 56, 
         "type": "Trapezoid", 
         "orientation": 220
       }

--- a/webclient/habirender/db/new_Downtown/Downtown_4e.json
+++ b/webclient/habirender/db/new_Downtown/Downtown_4e.json
@@ -71,10 +71,15 @@
     "ref": "item-sky90cf", 
     "mods": [
       {
-        "y": 2, 
-        "x": 0, 
-        "style": 7, 
-        "type": "Sky", 
+        "y": 56,
+        "x": 0,
+        "trapezoid_type": 0,
+        "upper_left_x": 0,
+        "upper_right_x": 160,
+        "lower_left_x": 0,
+        "lower_right_x": 160,
+        "height": 8,
+        "type": "Trapezoid",
         "orientation": 172
       }
     ], 
@@ -86,14 +91,14 @@
     "ref": "item-trapezoidc2a4", 
     "mods": [
       {
-        "y": 3, 
+        "y": 0, 
         "x": 0, 
         "trapezoid_type": 2, 
         "upper_left_x": 0, 
         "upper_right_x": 160, 
         "lower_left_x": 0, 
         "lower_right_x": 160, 
-        "height": 47, 
+        "height": 56, 
         "type": "Trapezoid", 
         "orientation": 220
       }

--- a/webclient/habirender/db/new_Downtown/Downtown_4g.json
+++ b/webclient/habirender/db/new_Downtown/Downtown_4g.json
@@ -70,10 +70,15 @@
     "ref": "item-sky46d0", 
     "mods": [
       {
-        "y": 2, 
-        "x": 0, 
-        "style": 7, 
-        "type": "Sky", 
+        "y": 56,
+        "x": 0,
+        "trapezoid_type": 0,
+        "upper_left_x": 0,
+        "upper_right_x": 160,
+        "lower_left_x": 0,
+        "lower_right_x": 160,
+        "height": 8,
+        "type": "Trapezoid",
         "orientation": 172
       }
     ], 
@@ -85,14 +90,14 @@
     "ref": "item-trapezoid8b23", 
     "mods": [
       {
-        "y": 3, 
+        "y": 0, 
         "x": 0,
         "trapezoid_type": 2, 
         "upper_left_x": 0, 
         "upper_right_x": 160, 
         "lower_left_x": 0, 
         "lower_right_x": 160, 
-        "height": 47, 
+        "height": 56, 
         "type": "Trapezoid", 
         "orientation": 220
       }


### PR DESCRIPTION
Fixes the "grey ground doesn't cover the green" render bug in **Plaza Southwest (Downtown_4e)** and **Plaza Northwest (Downtown_4g)**.

**Root cause:** the grey ground `Trapezoid` is wild-colored (Color RAM) with bitmap edges landing mid-8×8-cell, over the wild green `Sky`. The C64's per-cell Color RAM snaps the grey out to the enclosing cells (looks right); a faithful per-pixel renderer draws the literal bitmap → green band at the horizon + green sliver at the floor, and the picker returns Sky for ground. The webclient does not (and shouldn't have to) emulate Color RAM.

**Fix (data, renderer-agnostic):**
- green `Sky` → a thin cell-aligned green `Trapezoid` strip (rows 64–71, `trapezoid_type` 0, non-walkable) — no longer overlaps the grey's territory.
- grey `Trapezoid` → `y=0 h=56` (rows 72–127) — both edges on cell boundaries, reaches the floor.

Confirmed rendering **identically on the C64 and the webclient** for both regions. Plaza West (4f) left alone (its grey floor is hidden behind another object). Prod mongo has already been hot-patched with the same values so the deploy reloads the fixed contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)