### PR TITLE
fix(edge-transit): ground trapezoid GO ran sky_go, not walk

### DIFF
--- a/habiworld/lib/behaviors/index.js
+++ b/habiworld/lib/behaviors/index.js
@@ -219,7 +219,14 @@ B.wall_go = async (ctx) => {
 
 // Behaviors/trap_go.m: a Flat's 'go' re-dispatches to internal slot
 // 8 + flat_type (8 = sky_go, 9 = wall_go, 10 = goToCursor, 11 = noEffect).
-B.trap_go = async (ctx) => ctx.doAction(8 + (ctx.pointed.mod.flat_type || 0))
+// A Flat carries the type as `flat_type`; a Trapezoid/Super_trapezoid carries it as
+// `trapezoid_type` (elko Polygonal.encodePolygonal emits trapezoid_type and does NOT emit
+// flat_type). Read whichever is present — else a GROUND trapezoid (type 2) falls to slot 8
+// = sky_go and a GO on the ground wrongly leaves the region "up".
+B.trap_go = async (ctx) => {
+  const m = ctx.pointed.mod
+  return ctx.doAction(8 + (m.flat_type ?? m.trapezoid_type ?? 0))
+}
 
 // Behaviors/trap_put.m: PUT (drop) the held item onto a Trapezoid/Flat/
 // Super_trapezoid — but ONLY when it's a GROUND-type surface

--- a/webclient/lib/app-shell.js
+++ b/webclient/lib/app-shell.js
@@ -710,7 +710,11 @@ export async function createClientShell(adapter) {
     const coord = adapter.edgeCoord?.(edge, e, world.region) // { cx, cy, scale } | null
     if (coord) cursorWarp.value = { x: coord.cx, y: coord.cy } // snap the (2D) cursor to the destination
     return withBusy(async () => {
+      // Walk to the edge (a GROUND trapezoid GO is now a real walk — see habiworld trap_go).
       if (coord) await runRegionVerb(ACTION_GO, { canvasX: coord.cx * coord.scale, canvasY: coord.cy * coord.scale, scale: coord.scale }, `edge-${edge}`)
+      // Let the walk ANIMATION finish before leaving (walkTo only awaits the WALK reply) — else the
+      // transit fires mid-walk. Same settle the command interlock uses below.
+      if (world.me?.noid != null) await avatarMotion.whenIdle?.(world.me.noid)
       await dispatchClient.changeRegion(edge)
     }, CURSOR_GO) // exiting the region is a GO — blink the GO icon, not the last verb
   }


### PR DESCRIPTION
Region-edge walk-off ("chevron" GO) transited to the **wrong neighbour** (e.g. right edge in Downtown_4g → General Store instead of Meeting Hall), behaving "as if you did a GO on the SKY".

**Root cause:** an edge GO lands on the grey ground `Trapezoid` (streets/ground don't reach the edges). `trap_go` dispatches on `mod.flat_type` (`8 + flat_type`; 8=sky_go, 10=walk), but elko's `Polygonal.encodePolygonal` emits `trapezoid_type` and **never** `flat_type`. So a Trapezoid arrives with no `flat_type` → `8 + 0` = `sky_go` → transit "up" → wrong neighbour.

**Fix:**
- `habiworld trap_go`: read `flat_type ?? trapezoid_type ?? 0`. Ground trapezoids (type 2) → slot 10 (walk); horizon strip (type 0) → slot 8 (sky_go). Fixes every trapezoid-ground edge in every region, 2D + 3D. Strict correctness improvement for sagebot/habibots.
- `app-shell onEdgeClick`: `await avatarMotion.whenIdle` before `changeRegion`, so the transit fires when the walk animation finishes, not mid-walk.

Confirmed fixed live (right chevron in 4g now walks to the edge then transits to the Meeting Hall). All 152 habiworld tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)