### PR TITLE
Docs revamp: new docs/ suite + README with browser-play buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,34 @@ NeoHabitat.org: The Neoclassical Habitat Server Project
 [![Twitter Follow](https://img.shields.io/twitter/follow/NeoHabitatProj.svg?style=social&label=Follow)](https://twitter.com/NeoHabitatProj)
 [Developer Discord](https://discord.gg/rspcX27Vt4)
 
-We're recreating [Lucasfilm's Habitat](https://en.wikipedia.org/wiki/Habitat_(video_game)), the world's first MMO, using modern technology.  We'd love it if you joined us!
+We're recreating [Lucasfilm's Habitat](https://en.wikipedia.org/wiki/Habitat_(video_game)), the world's first MMO, using modern technology. We'd love it if you joined us!
 
 Play Habitat Now!
 -----------------
 
-We maintain a demo server running the latest NeoHabitat code and you can connect to it at any time. There's often a few members of the regular crew hanging out there, so come say hey!
+We run a public server at **habitat.themade.org** with the latest NeoHabitat code. There's often a few members of the regular crew hanging out there, so come say hey!
+
+**No install needed — play in your browser:**
+
+| | |
+|---|---|
+| 🕹️ **[Play Original Now](http://habitat.themade.org/)** | The genuine C64 client in an in-browser emulator, with the Docent guide — the authentic 1986 experience. |
+| ⚡ **[Play Accelerated](http://habitat.themade.org/neohabitat)** | The all-JavaScript [web client](docs/webclient.md) + Docent — same world, no emulator, fast and crisp. |
+| 📱 **[Play Mobile](https://habitat.themade.org/webclient/live.html)** | The web client full-page, for phones and tablets. |
+
+**Or install a client:**
+
+- **[C64 emulator (VICE)](docs/c64-clients.md#vice)** — Windows installer, macOS app, or manual Linux/*BSD setup (details also in Step 1 below).
+- **[Ultimate 64 / Ultimate II+](docs/c64-clients.md#ultimate-64)** — run the client on U64 hardware over your home network ([full guide](https://github.com/ssalevan/habiclient/blob/main/docs/U64.md)).
+- **[Real Commodore 64](README-RealC64.md)** — original iron, floppies, and a WiFi modem.
+
+All the ways in, on one page: **[docs/play.md](docs/play.md)**.
 
 **Please note**: NeoHabitat is still in development, so there will likely be some instability. If you see anything weird, please [tell us about it in our Discord](https://discord.gg/rspcX27Vt4).
 
-With all that out of the way, here's how to get started:
-
-- If you want to use Habitat with a real C64, please switch over to [these instructions](https://github.com/frandallfarmer/neohabitat/blob/master/README-RealC64.md) for making disks and using modern connection hardware.
-
-- You can also use our [web based client](http://habitat.themade.org) to connect via a browser. Just skip to **Step 2** below to learn how to get ingame.
-
 ### Step 1 - Download and Install either the Windows or OSX Habitat package (which comes with VICE, the C64 emulator)
+
+*(Skip this step if you're using a browser client above — go straight to Step 2.)*
 
 **Windows**
 
@@ -48,7 +60,7 @@ With all that out of the way, here's how to get started:
 - Install VICE and `nc` (netcat) via your package manager
 - Extract the Windows release of [Neohabitat.zip](https://github.com/frandallfarmer/neohabitat-doc/blob/master/installers/Neohabitat.zip?raw=true) to get the `.d64` files and `fliplist-C64.vfl`
 - Run the VICE C64 emulator with these options set:  
-  `x64 -rsuser -rsuserdev 0 -rsdev1 '|nc 20.3.249.92 1986' -rsuserbaud 1200 -flipname fliplist-C64.vfl Habitat-Boot.d64`
+  `x64 -rsuser -rsuserdev 0 -rsdev1 '|nc habitat.themade.org 1986' -rsuserbaud 1200 -flipname fliplist-C64.vfl Habitat-Boot.d64`
 - There is a bug in current versions of VICE which breaks this network support (https://sourceforge.net/p/vice-emu/bugs/1356). Versions including r38928 and earlier work.
 
 ### Step 2 - Login and play!
@@ -79,7 +91,7 @@ Welcome to NeoHabitat! There's a whole lot you can do here and thousands of exot
 
 Before you go anywhere, **we highly recommend opening up our [Docent support software](http://habitat.themade.org)**. It's a browser based guide that'll help you navigate NeoHabitat, learn the controls and teach you about the history of the world. It's interactive and will update as you move around without you having to lift a finger.
 
-If you are using the web based client mentioned earlier, the Docent support software is already active!
+If you are using one of the browser clients above, the Docent support software is already active!
 
 To learn about all the things you can do in more detail, read the [official Habitat manual](https://frandallfarmer.github.io/neohabitat-doc/docs/Avatar%20Handbook.html) from 1988.
 
@@ -115,20 +127,30 @@ If you're having trouble getting NeoHabitat working, don't worry, we're here to 
 
 If you encounter a glitch whilst playing NeoHabitat, please check to see if it's been filed as an [issue](https://github.com/frandallfarmer/neohabitat/issues). If it hasn't, we'd appreciate it if you let us know what happened so we can investigate.
 
-Developer Documentation
------------------------
+Experiments
+-----------
 
-If you'd like to contribute to NeoHabitat, there are plenty of great opportunities! Come check our our extensive developer documentation:
+Beyond the standard clients there's a growing family of experimental clients, agents, and tools — including **[Sagebot](docs/sagebot.md)**, our LLM-driven resident; the **[3D diorama client](docs/webclient3d.md)**; and the **[text-only terminal client](textclient/README.md)**.
 
-  - [Getting Started for Developers](https://github.com/frandallfarmer/neohabitat-doc/blob/master/docs/getting_started.md)
+👉 **[docs/experiments.md](docs/experiments.md)**
+
+Developer & Operator Documentation
+----------------------------------
+
+If you'd like to contribute to NeoHabitat, there are plenty of great opportunities!
+
+  - **[Run your own server](docs/run-your-own-server.md)** — the full stack (Elko + `bridge_v2` + web clients + bots) via Docker Compose.
+  - [The web client](docs/webclient.md) and its [design doc](webclient/DESIGN.md).
+  - [PROTOCOL.md](PROTOCOL.md) — the Habitat/Elko wire protocol reference.
   - [Developer Wiki](https://github.com/frandallfarmer/neohabitat/wiki/Developers-Documentation)
 
 In-repo clients and libraries (besides the elko server in `src/` and the Go `bridge_v2/`):
 
   - [`textclient/`](textclient/README.md) — a human, text-only terminal client: narrates the world and takes verb-first commands (`GO`/`GET`/`SAY`/…).
-  - [`habibots/`](habibots/README.md) — in-world bots (including the LLM-driven `sagebot`), built on the `HabiBot` connection + world-model layer.
-  - [`habiworld/`](habiworld/README.md) — the canonical client-side world model and 1986-faithful behavior dispatcher that the bots and `textclient` share.
+  - [`habibots/`](habibots/README.md) — in-world bots (including the LLM-driven [`sagebot`](docs/sagebot.md)), built on the `HabiBot` connection + world-model layer.
+  - [`habiworld/`](habiworld/README.md) — the canonical client-side world model and 1986-faithful behavior dispatcher that the clients and bots share.
   - [`habisound/`](habisound/README.md) — plays Habitat's original C64 SID sound effects in the browser, live, from the 1986 `sfx.m` driver bytecode (a client-side consumer of `habiworld`'s sound events). [Soundboard demo](https://frandallfarmer.github.io/neohabitat-doc/docs/sounds/).
+  - [`regionator/`](regionator/README.md) — compile `.rdl` region description files into NeoHabitat JSON regions.
 
 Clients and bots connect through `bridge_v2` (port 2026), never to the elko server directly.
 

--- a/docs/c64-clients.md
+++ b/docs/c64-clients.md
@@ -1,0 +1,76 @@
+# C64 clients — VICE, Ultimate 64, and real hardware
+
+The Habitat client is genuine 1986 C64 software (rebuilt from the original
+Lucasfilm source by **Gary Lake-Schaal**). You can run it three ways: in the
+**VICE** emulator, on an **Ultimate 64**, or on a **real Commodore 64**.
+
+All of them connect to the public server at **`habitat.themade.org` port `1986`**
+(the classic-client port on `bridge_v2`, the protocol bridge — see
+[run-your-own-server.md](run-your-own-server.md) to point them at your own server instead).
+
+> Don't want to install anything? The same C64 client runs in your browser at
+> **[habitat.themade.org](http://habitat.themade.org/)** — see [play.md](play.md).
+
+## VICE
+
+The emulator packages bundle VICE preconfigured with the Habitat disks.
+
+### Windows
+
+1. Download the [NeoHabitat installer](https://github.com/StuBlad/neohabitat-installer/releases/download/1.1/NeoHabitatInstaller1.1.exe) and run it
+   (tested on Windows 11; older versions should be fine).
+2. Check **Launch NeoHabitat** at the end of the install, or use the desktop /
+   Start Menu icon.
+
+### macOS
+
+1. Download [Neohabitat.dmg](https://github.com/frandallfarmer/neohabitat-doc/blob/master/installers/Neohabitat.dmg?raw=true) and open it.
+2. Drag **NeoHabitat** to **Applications** and launch it.
+   If macOS objects to an unknown developer, use **System Preferences →
+   Security & Privacy → Open Anyway**.
+
+### Linux and *BSD
+
+1. Install VICE and `nc` (netcat) from your package manager.
+2. Extract [Neohabitat.zip](https://github.com/frandallfarmer/neohabitat-doc/blob/master/installers/Neohabitat.zip?raw=true) for the `.d64` files and `fliplist-C64.vfl`.
+3. Run:
+
+   ```sh
+   x64 -rsuser -rsuserdev 0 -rsdev1 '|nc habitat.themade.org 1986' \
+       -rsuserbaud 1200 -flipname fliplist-C64.vfl Habitat-Boot.d64
+   ```
+
+> **VICE version note:** current VICE releases have a bug that breaks this
+> network support ([vice-emu bug #1356](https://sourceforge.net/p/vice-emu/bugs/1356)).
+> Versions up to and including **r38928** work.
+
+### First login (all VICE platforms)
+
+At the splash screen **press Enter**, type your avatar name, **Enter** again;
+when asked for the imagery disk press **Alt-n** (⌘-n on Mac), then **Enter** —
+and you'll materialize in downtown Populopolis. Full walkthrough with
+screenshots in the [main README](../README.md#step-2---login-and-play).
+
+Controls, joystick, and keyset remapping: [README Steps 3–4](../README.md#step-3---learn-how-to-play).
+
+## Ultimate 64
+
+Run the client natively on an **Ultimate 64** (or a stock C64 fitted with an
+**Ultimate II/II+ cartridge**) over your home network — HDMI or composite out,
+no floppies, no modem. You copy a cartridge image + modem config to the U64,
+save the config to flash once, and run it from the U64 menu.
+
+**The authoritative setup guide lives in the habiclient repo:**
+👉 **[ssalevan/habiclient — U64.md](https://github.com/ssalevan/habiclient/blob/main/docs/U64.md)**
+
+It covers firmware requirements (3.11+), file transfer (USB/FTP), the modem
+configuration, connecting to the public server or your own, troubleshooting,
+and how it all works.
+
+## Real C64
+
+Original hardware: a C64/C128, a 1541 drive (or 1541 Ultimate / SD2IEC), disks
+made from our D64 images, and a userport WiFi modem.
+
+👉 **[README-RealC64.md](../README-RealC64.md)** — the full guide: supported
+transfer/modem hardware, disk images, connection strings, and hard-won tips.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1,0 +1,76 @@
+# Experiments — alternate clients, agents & tools
+
+NeoHabitat is a living research project as much as a game. Beyond the
+[standard clients](play.md), these are the experimental clients, agents, and
+tools that orbit the world. Everything here is functional but evolving —
+expect rough edges, and bring your findings to the
+[Discord](https://discord.gg/rspcX27Vt4).
+
+## ⭐ Sagebot — an LLM lives in Habitat
+
+An autonomous, Claude-driven resident that wanders the world, remembers who it
+meets, and converses in character — built on the **habibots** framework and
+the **habiworld** world model. The flagship experiment.
+
+👉 **[sagebot.md](sagebot.md)**
+
+## 3D "Diorama" web client
+
+The web client re-presented as a fixed-camera 3D set: real floor and wall
+geometry, billboarded avatars and props, neighbor regions visible down the
+street. Same world model, swapped renderer.
+
+👉 **[webclient3d.md](webclient3d.md)** · play at [habitat.themade.org/neohabitat3d](http://habitat.themade.org/neohabitat3d)
+
+## Text client
+
+Habitat as a MUD: a human-driven, text-only terminal client that narrates
+everything around you and takes verb-first commands (`GO`, `GET`, `SAY`,
+`ESP`, …) targeting objects by name or noid.
+
+👉 **[textclient/README.md](../textclient/README.md)**
+
+## The Inspector
+
+A browser app for exploring (and editing!) the original Habitat art and
+regions: region gallery, avatar bodies, the Hall of Heads, props, beta-only
+art, and a **region editor** whose output you can import into a NeoHabitat
+server. Lives in the [neohabitat-doc](https://github.com/frandallfarmer/neohabitat-doc)
+repo.
+
+👉 **[Inspector app](https://frandallfarmer.github.io/neohabitat-doc/inspector/)** ·
+[source](https://github.com/frandallfarmer/neohabitat-doc/tree/master/inspector)
+
+## habibots — the bot framework
+
+Write your own in-world bot in a few dozen lines of Node: connection, region
+transit, world model, and verb helpers are all handled. Ships with `hatchery`,
+`eliza`, `oracle`, `greeter`, and friends.
+
+👉 **[habibots/README.md](../habibots/README.md)**
+
+## habisound — the 1986 SID driver in your browser
+
+A JS port of Habitat's original C64 sound driver that plays the actual 1986
+`sfx.m` bytecode through Web Audio.
+
+👉 **[habisound/README.md](../habisound/README.md)** ·
+[Soundboard demo](https://frandallfarmer.github.io/neohabitat-doc/docs/sounds/)
+
+## Region & protocol tooling
+
+- **[regionator](../regionator/README.md)** — compile human-writable `.rdl`
+  region description files into NeoHabitat JSON regions.
+- **[log-parser](../tools/log-parser/README.md)** — decode and analyze
+  Habitat protocol traffic from server logs.
+- **[tools/](../tools/README.md)** — VICE login automation, the Book of
+  Records generator, welcomebot, and other operational odds and ends.
+- **[mamelink](https://github.com/frandallfarmer/neohabitat-doc/tree/master/mamelink)** —
+  C tooling for linking an emulated machine to Habitat (the "reno"/"griddle"
+  lineage), in the neohabitat-doc repo.
+
+## Under it all
+
+- **[PROTOCOL.md](../PROTOCOL.md)** — the Habitat/Elko wire protocol reference.
+- **[bridge_v2](../bridge_v2/)** — the Go protocol bridge every client and bot
+  connects through; see [run-your-own-server.md](run-your-own-server.md).

--- a/docs/play.md
+++ b/docs/play.md
@@ -1,0 +1,42 @@
+# Play NeoHabitat — all the ways in
+
+NeoHabitat is the open-source revival of [Lucasfilm's Habitat](https://en.wikipedia.org/wiki/Habitat_(video_game)) (1986),
+the world's first graphical MMO. We run a public server at **habitat.themade.org** —
+pick the client that suits you and come say hey.
+
+## Zero-install: play in your browser right now
+
+| | | |
+|---|---|---|
+| 🕹️ **[Play Original Now](http://habitat.themade.org/)** | The genuine C64 client running in an in-browser emulator, with the **Docent** guide alongside. | The authentic 1986 experience, zero install. |
+| ⚡ **[Play Accelerated](http://habitat.themade.org/neohabitat)** | The all-JavaScript **web client** + Docent. Same world, same art, same rules — no emulator in the middle. | Fast, crisp, modern. |
+| 📱 **[Play Mobile](https://habitat.themade.org/webclient/live.html)** | The web client full-page, sized for phones and tablets (add `?osk=1` for the on-screen keyboard). | Habitat in your pocket. |
+
+The **Docent** is a browser-side companion that watches your avatar and serves
+contextual help, region lore, and history as you move through the world. Both
+hosted flows above include it automatically.
+
+More about the web client: **[webclient.md](webclient.md)**.
+
+## Install a client
+
+- **[C64 emulator (VICE) installs](c64-clients.md#vice)** — Windows installer, macOS app,
+  or manual Linux/*BSD setup. VICE bundled and preconfigured to connect.
+- **[Ultimate 64 / Ultimate II+ cartridge](c64-clients.md#ultimate-64)** — run the
+  client on U64 hardware (or a stock C64 with an Ultimate II/II+ cart) over your
+  home network.
+- **[Real Commodore 64](c64-clients.md#real-c64)** — original iron, floppies, and a
+  WiFi userport modem.
+
+## Learn to play
+
+- **[The Avatar Handbook](https://frandallfarmer.github.io/neohabitat-doc/docs/Avatar%20Handbook.html)** — the official 1988 manual.
+- **[Controls cheat sheet](https://github.com/StuBlad/neohabitat-installer/blob/master/Neohabitat/NeoHabitatControls.pdf)** (for the C64/VICE clients).
+- Stuck? Join the [Discord](https://discord.gg/rspcX27Vt4) **#troubleshooting** channel.
+
+## Beyond the standard clients
+
+Curious about the **3D diorama client**, the **text-only terminal client**, or
+**Sagebot**, our LLM-driven resident? See **[experiments.md](experiments.md)**.
+
+Want to host the world yourself? **[run-your-own-server.md](run-your-own-server.md)**.

--- a/docs/run-your-own-server.md
+++ b/docs/run-your-own-server.md
@@ -1,0 +1,105 @@
+# Run your own NeoHabitat server
+
+The whole stack — game server, protocol bridge, web clients, docent, bots —
+runs from this repo with Docker Compose. Ten minutes from clone to a world of
+your own.
+
+## The architecture, in one picture
+
+```
+ C64 / VICE / U64 ──binary──┐
+ web client ──ws :1987──────┤                        ┌────────────┐
+ textclient / bots ─:2026───┼──►  bridge_v2  ──────► │  Habiproxy │──► Elko game
+                            │   (Go protocol         │   :2018    │    server
+                            │    bridge)             └────────────┘   (Java, src/)
+                            │                                            │
+   browser ──http :1701──► pushserver (Express)                       MongoDB
+              (webclient, docent, help docs)                          (world DB)
+```
+
+**Everything connects through `bridge_v2`** — the Go protocol bridge that
+maintains client sessions, speaks the 1986 binary protocol *and* the web
+client's JSON protocol, and handles region-transit choreography. Clients and
+bots never dial the Elko server directly.
+
+## Quickstart (dev stack)
+
+Prereqs: Docker + Docker Compose, git.
+
+```sh
+git clone https://github.com/frandallfarmer/neohabitat.git
+cd neohabitat
+cp .env.example .env          # optional: add ANTHROPIC_API_KEY etc. — see the file
+docker compose up             # base + docker-compose.override.yml (auto-loaded)
+```
+
+That brings up:
+
+| Service | What it is | Ports (host) |
+|---|---|---|
+| `neohabitat` | Elko game server + Habiproxy + pushserver (web/docent) | `1701` (http), `1987` (ws), `127.0.0.1:2018` (habiproxy), `127.0.0.1:5005` (JVM debug) |
+| `bridge_v2` | the protocol bridge (dev image, hot-reload) | `2026` (clients/bots), `2027` (admin) |
+| `neohabitatmongo` | MongoDB 7 world database | `127.0.0.1:27017` |
+| `bots` | hatchery, eliza (+ sage with an API key) | — (dial `bridge_v2:2026`) |
+
+First boot seeds the world database automatically. Working on the webclient or
+libraries? Use the dev overlay, which bind-mounts the working tree for
+edit-and-reload: `docker compose -f docker-compose.yml -f docker-compose.dev.yml up`
+(or just `./dev.sh`).
+
+## Connect your clients
+
+- **Web client (2D):** http://localhost:1701/webclient/ — set the WebSocket
+  proxy to `ws://localhost:1987`, pick a context and avatar name, Connect.
+  Docent-framed flow: http://localhost:1701/neohabitat.
+- **3D client:** http://localhost:1701/webclient/live3d.html.
+- **Text client:** `node textclient/index.js -c context-Downtown_5f -u myname`
+  (defaults to the dev bridge at `127.0.0.1:2026`).
+- **VICE / C64:** point the emulator's network at the bridge:
+  `x64 -rsuser -rsuserdev 0 -rsdev1 '|nc 127.0.0.1 2026' -rsuserbaud 1200 -flipname fliplist-C64.vfl Habitat-Boot.d64`
+  (the public server also exposes the classic port `1986`; both speak the same
+  binary protocol). Disks: see [c64-clients.md](c64-clients.md).
+- **Ultimate 64:** set your server address in the modem config per the
+  [U64 guide](https://github.com/ssalevan/habiclient/blob/main/docs/U64.md).
+- **Your own bot:** see [habibots](../habibots/README.md) — and remember, bots
+  dial the bridge (`:2026`), never Elko.
+
+## Configuration
+
+`.env` (copied from [`.env.example`](../.env.example)) is loaded by every
+compose service and by `habibots/run`. Notables: `ANTHROPIC_API_KEY` (enables
+[Sagebot](sagebot.md)), `HABIBOTS_SLACK_TOKEN`, per-bot region/user overrides.
+The file documents itself.
+
+## Production notes
+
+Our production deployment (habitat.themade.org) differs from dev in two ways:
+
+1. **`docker-compose.prod.yml`** — production config for the game/web
+   services, plus **Caddy** terminating TLS on :443 in front of the pushserver
+   (`caddy/Caddyfile` routes `/neohabitat`, `/webclient`, `/ws`, docent SSE, …):
+   `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d`
+2. **`bridge_v2` runs on the host, not in Docker** — as a systemd service
+   (listening on `1337`/`1986`/`2026`), because its zero-downtime restart
+   mechanism (tableflip re-exec on SIGHUP) is incompatible with Docker's
+   PID-1 lifecycle. The [`ansible/`](../ansible/README.md) roles build the
+   binary, install the unit, and manage deploys.
+
+Observability sidecars (Grafana Cloud OTLP + log shipping) are optional:
+[`monitoring/README.md`](../monitoring/README.md).
+
+## The legacy path (historical)
+
+The original 2017-era setup — QuantumLink Reloaded, MySQL, port 5190, Vagrant —
+is **obsolete**: the modern client path bypasses Q-Link entirely. The old guide
+is preserved in
+[neohabitat-doc/getting_started.md](https://github.com/frandallfarmer/neohabitat-doc/blob/master/docs/getting_started.md)
+for the curious.
+
+## Going deeper
+
+- [PROTOCOL.md](../PROTOCOL.md) — the wire protocol.
+- [bridge_v2/](../bridge_v2/) — bridge internals (catch-up interlock, Discord
+  alerts, QLink framing).
+- The Elko server sources live in `src/main/java/org/made/neohabitat/`.
+- Questions? [Discord](https://discord.gg/rspcX27Vt4) **#developers**.

--- a/docs/sagebot.md
+++ b/docs/sagebot.md
@@ -1,0 +1,61 @@
+# Sagebot — an LLM-driven Habitat resident
+
+**Sagebot** (the Sage) is a fully autonomous, AI-driven citizen of NeoHabitat.
+It wanders the world, keeps track of the avatars and objects around it, and
+uses [Claude](https://www.anthropic.com/claude) to decide what to do and say —
+in character, with persistent memory of the people it has met. When a new
+avatar appears in its region it walks over and says hello; talk to it and it
+answers.
+
+It is, as far as we know, the first LLM agent living inside the world's first
+graphical MMO — 1986 meets 2026.
+
+## Meet the Sage
+
+Just play ([any client](play.md)) and wander Populopolis — if the Sage is
+about, it will likely find *you*. Speak to it like you'd speak to anyone.
+
+## How it's built
+
+Sagebot is the showcase for two reusable libraries in this repo:
+
+### [habiworld](../habiworld/README.md) — the world model
+
+The canonical client-side Habitat world model: feed it the server's message
+stream and it maintains a faithful mirror of region state — object table,
+container tree, avatar positions — **exactly the way the original 1986 C64
+client did**, with every state delta ported from and cited against the
+original C64 sources. The Sage's situational awareness ("who is here, what are
+they holding, what just happened") is habiworld queries; the same library
+powers the [web client](webclient.md), the [3D client](webclient3d.md), and
+the [text client](../textclient/README.md).
+
+### [habibots](../habibots/README.md) — the bot framework
+
+The connection and agent layer: dialing the server through `bridge_v2`
+(port 2026), region transit, reconnects, and high-level verb helpers
+(`performVerb`, `getIntoHands`, `walkToExit`, `openDoor`, …). Sagebot's Claude
+tool catalogue maps straight onto these helpers, so the model acts in the
+world with the same verbs a human player has.
+
+On top of those, the Sage adds ([habibots/bots/sage.js](../habibots/bots/sage.js)):
+
+- **awareness** — synthesizes the habiworld state into a scene description for the prompt;
+- **memory** — Mongo-backed persistent memory of avatars and conversations;
+- **tools** — the Claude tool catalogue + dispatcher (speak, walk, emote, …);
+- **anti-loop guards** — bot-to-bot silence, greeting cooldowns, rate limits.
+
+## Run your own
+
+With [your own server](run-your-own-server.md) up:
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-...   # or set it in .env
+cd habibots && npm install
+./run sage --persona "a curious old-timer of Habitat who's seen it all"
+```
+
+Options: `ANTHROPIC_MODEL` (default `claude-haiku-4-5-20251001`),
+`HABIBOTS_MONGO_URL` for the memory store, `--wander-seconds` for roaming
+cadence. See [habibots/README.md](../habibots/README.md) and
+[.env.example](../.env.example).

--- a/docs/webclient.md
+++ b/docs/webclient.md
@@ -1,0 +1,46 @@
+# The NeoHabitat web client
+
+An **all-JavaScript, browser-only graphical Habitat client**. No emulator, no
+plugins, no build step — it decodes the original C64 art, replays the original
+animations and SID sound effects, and follows the original C64 client's world
+model faithfully (the C64 client is our ground truth). Same world, same rules,
+same look — just fast and crisp.
+
+## Play it
+
+| URL | What you get |
+|---|---|
+| **[habitat.themade.org/neohabitat](http://habitat.themade.org/neohabitat)** | The web client framed with the **Docent** guide — best on desktop. |
+| **[habitat.themade.org/webclient/live.html](https://habitat.themade.org/webclient/live.html)** | The client full-page — best for **mobile** and small screens. Add `?osk=1` for an on-screen keyboard. |
+
+Log in with your avatar name on the left panel. New avatars hatch through the
+same immigration flow as every other client.
+
+**The Docent** is our browser-side companion software: it tracks your avatar as
+you move and serves contextual help, object documentation, region descriptions,
+and Habitat history — interactive, no clicking required. In the `/neohabitat`
+flow it sits beside the game; in the full-page flow the same help content is
+reachable from the client's Help link.
+
+## What's under the hood
+
+The client is built from small, reusable libraries that live in this repo:
+
+- **[habiworld](../habiworld/README.md)** — the client-side world model and
+  1986-faithful behavior dispatcher (ported from the original C64 sources).
+- **[habirender](../webclient/habirender/README.md)** — the C64 art codec and
+  region render pipeline.
+- **[habisound](../habisound/README.md)** — the original 1986 SID sound driver
+  bytecode, played live via Web Audio.
+
+There is also an experimental **3D diorama** presentation of the same client —
+see **[webclient3d.md](webclient3d.md)**.
+
+## For developers
+
+- **[webclient/README.md](../webclient/README.md)** — how to run it locally
+  (dev compose serves it at `http://localhost:1701/webclient/`, live-reload).
+- **[webclient/DESIGN.md](../webclient/DESIGN.md)** — the canonical
+  architecture document: C64 model, phase roadmap, invariants.
+- **[run-your-own-server.md](run-your-own-server.md)** — the server stack it
+  talks to (WebSocket → `bridge_v2` → Elko).

--- a/docs/webclient3d.md
+++ b/docs/webclient3d.md
@@ -1,0 +1,52 @@
+# The 3D "Diorama" web client (experimental)
+
+A second, **3D-native** presentation of the NeoHabitat web client: each region
+is drawn as a **fixed-camera 3D diorama** — a real floor receding to a real
+back wall, with props and avatars as depth-sorted billboards standing on that
+geometry — instead of the flat 2D scene.
+
+**Try it:**
+
+| URL | |
+|---|---|
+| **[habitat.themade.org/neohabitat3d](http://habitat.themade.org/neohabitat3d)** | 3D client + Docent guide |
+| **[habitat.themade.org/webclient/live3d.html](https://habitat.themade.org/webclient/live3d.html)** | 3D client full-page |
+
+Enter your avatar name at the title screen — it's the same world and the same
+account as every other client.
+
+## Why this works
+
+Habitat was *already 2.5-D* in 1986: an object's `y` coordinate doubles as
+depth, and every region is a single-wall theater set viewed head-on. Because
+our world model ([habiworld](../habiworld/README.md)) is renderer-agnostic, the
+3D client is a **presentation swap, not a rewrite** — it reuses the model,
+verbs, events, sound, and decoded C64 art from the 2D client and replaces only
+the final drawing layer with a Three.js scene. The 2D client is untouched;
+the two share one renderer-agnostic app shell.
+
+## What works today
+
+- Region backdrops as real floor + wall geometry, textured from the region's own art.
+- Avatars (composed head/body/pose) and props as billboards; smooth walks; original SID sound.
+- The full verb set, word balloons, inventory, containers, and region-to-region travel.
+- **Neighbor-region previews**: the side margins are filled with the adjacent
+  regions' pre-rendered backdrops, so Downtown streets visually continue into
+  the next block (disable with `?neighbors=0`).
+- Floating region-name and "To …" exit labels.
+
+## Status & caveats
+
+This is an **experimental** client — a proof of concept that keeps growing.
+Expect rough edges (see the Known limitations section of the
+[render3d README](../webclient/render3d/README.md)). Bugs to
+[Discord](https://discord.gg/rspcX27Vt4) or
+[GitHub issues](https://github.com/frandallfarmer/neohabitat/issues), please.
+
+## For developers
+
+- **[webclient/render3d/README.md](../webclient/render3d/README.md)** — the
+  full design doc: coordinate model, horizon split, backdrop pipeline,
+  picking transform-back, and unit tests.
+- **[webclient/DESIGN.md](../webclient/DESIGN.md)** — the shared client
+  architecture both renderers sit on.

--- a/regionator/README.md
+++ b/regionator/README.md
@@ -1,0 +1,49 @@
+# regionator — region tooling for NeoHabitat
+
+Python tools for building NeoHabitat regions from **RDL** ("Riddle") files —
+the human-writable region description language descended from the original
+Habitat production tooling — and for parsing the original Habitat world
+database.
+
+## RDL → NeoHabitat JSON
+
+`app.py` compiles `.rdl` files into the JSON region documents the NeoHabitat
+server loads (the same format as [`db/`](../db)):
+
+```sh
+python app.py Downtown_4c.rdl                 # emit Downtown_4c.json here
+python app.py --output_dir out/ some_dir/     # convert every .rdl in a dir
+```
+
+An RDL region is a nested declaration of the region, its neighbors and
+orientation, and its object tree (position, orientation byte, style,
+container contents):
+
+```
+@region $ Downtown_4c {
+    north: Downtown_4d.l;
+    region_orientation: FACE_SOUTH;
+    [
+        @wall   { x:0; y:1; or:172; style:6; }
+        @ground { x:0; y:4; or:204; style:1; }
+        ...
+    ]
+}
+```
+
+Class/field translation is driven by `mod_index.yml` (with `mod_defaults.yml`
+and `mod_renames.yml`); sample `.rdl` files sit alongside the scripts.
+
+## Parsing the original 1980s world database
+
+`parse_region_db.py` and `parse_object_db.py` decode the `MC_region` /
+`MC_object` databases from the recovered Habitat **Stratus backup** into
+faithful, uninterpreted JSON — the raw material the restored world was
+rebuilt from. Each script's docstring documents the format knowledge (and
+remaining unknowns).
+
+## See also
+
+- [The Inspector's region editor](https://frandallfarmer.github.io/neohabitat-doc/inspector/) —
+  a graphical way to build a region for import.
+- [docs/experiments.md](../docs/experiments.md) — the rest of the tooling family.


### PR DESCRIPTION
Part 1 of the website/docs revamp (companion: neohabitat-doc site-revamp branch).

## New `docs/` suite
- **play.md** — canonical "all the ways to play" index: Play Original Now (emulator+docent), Play Accelerated (webclient+docent), Play Mobile (full-page), installs, hardware
- **c64-clients.md** — VICE (Win/Mac/Linux, hardcoded IP → `habitat.themade.org`), **Ultimate 64** (links ssalevan/habiclient U64.md as authoritative), real C64
- **webclient.md** / **webclient3d.md** — player-facing pages for the 2D and experimental 3D clients
- **sagebot.md** — Sagebot highlight page, showcasing the habibots + habiworld components it's built on
- **experiments.md** — index of experimental clients, agents & tools (Sagebot featured)
- **run-your-own-server.md** — the bridge_v2-era operator guide: compose quickstart, ports table, per-client connection instructions, prod notes (Caddy, host-systemd bridge), legacy QLink relegated to historical
- **regionator/README.md** — first docs for the RDL tooling

## README.md
Browser-play buttons at the top (Original/Accelerated/Mobile), install links, new Experiments section, Developer & Operator section; fixed the hardcoded `20.3.249.92` Linux VICE line.

Verified: all external URLs 200, all relative links resolve, `docker compose config` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)