### PR TITLE
bridge: refuse to mint users for garbage login names (turf leak)

### DIFF
--- a/bridge_v2/bridge/avatar_name_test.go
+++ b/bridge_v2/bridge/avatar_name_test.go
@@ -1,0 +1,46 @@
+package bridge
+
+import "testing"
+
+// validAvatarName gates new-user creation in ensureUserCreated. Names that
+// fail are refused a user doc (and therefore a turf); existing users are
+// never checked against it.
+func TestValidAvatarName(t *testing.T) {
+	accept := []string{
+		"Randy",
+		"c64 noob",
+		"webclient2549",
+		"hatchtest1782755507633",
+		"Ya Mama",
+		"O'Brien",
+		"Mr. X",
+		"a_b-c",
+		"69",
+		"Z",
+	}
+	for _, name := range accept {
+		if !validAvatarName.MatchString(name) {
+			t.Errorf("validAvatarName rejected legitimate name %q", name)
+		}
+	}
+
+	reject := []string{
+		"",
+		" leading space",
+		"-leading punct",
+		"'leading quote",
+		"name\x00with nul",
+		"name\twith tab",
+		"café",
+		"12345678901234567890123456789012X", // 33 chars
+		// The first bytes of a TLS ClientHello, as sent by internet scanners
+		// to the binary port — the exact garbage that was minting users.
+		"z\x16\x03\x01\x02\x00\x01\x00\x01\xfc\x03\x03",
+		"Z*\x00\xba\xba\xc0\x12\xc0\x13\xc0\x07\xc0'\xcc\x14",
+	}
+	for _, name := range reject {
+		if validAvatarName.MatchString(name) {
+			t.Errorf("validAvatarName accepted garbage name %q", name)
+		}
+	}
+}

--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"net"
 	"net/textproto"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -1297,6 +1298,16 @@ func (c *ClientSession) createUserWithAppearance(fullName string, appearance *ha
 	return
 }
 
+// validAvatarName gates minting a NEW user document from a client-supplied
+// login name. The binary port receives arbitrary internet garbage (TLS
+// handshakes, scanner probes): handleInitialClientMessage treats everything
+// before the first ':' byte as the login name, so before this check every
+// probe minted a user doc — and permanently leaked a turf, since
+// ensureTurfAssigned runs on every creation. Printable ASCII only, starts
+// alphanumeric, max 32 chars. Deliberately NOT applied to existing users:
+// a doc already in mongo can always log back in, whatever its name.
+var validAvatarName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9 ._'-]{0,31}$`)
+
 func (c *ClientSession) ensureUserCreated(fullName string) (err error) {
 	c.userRef = fmt.Sprintf("user-%s", strings.Replace(
 		strings.ToLower(fullName), " ", "_", -1))
@@ -1324,7 +1335,13 @@ func (c *ClientSession) ensureUserCreated(fullName string) (err error) {
 			c.user = user
 			return
 		}
-		// No user doc: a brand-new avatar is being born this session (whether via the
+		// No user doc: this login would mint a brand-new avatar, so the name
+		// must look like one a person typed (see validAvatarName).
+		if !validAvatarName.MatchString(fullName) {
+			c.log.Warn().Str("full_name", fmt.Sprintf("%q", fullName)).Msg("Refusing to create user for invalid avatar name")
+			return fmt.Errorf("invalid avatar name %q", fullName)
+		}
+		// A brand-new avatar is being born this session (whether via the
 		// hatchery below or the immediate default create) — the presence alert gets the
 		// birth-announcement variant.
 		c.presenceNewUser = true


### PR DESCRIPTION
Companion to #629. The binary port's `handleInitialClientMessage` reads everything before the first `:` byte as a login name — so internet scanners probing with TLS handshakes have minted ~370 garbage users on prod since Dec 2024 (~20-30/month, one as recent as July 2026), each permanently leaking a turf via `ensureTurfAssigned`.

**Fix**: `ensureUserCreated` validates the name against `^[A-Za-z0-9][A-Za-z0-9 ._'-]{0,31}$` **only when no user doc exists** — creation is gated, lookup is not, so any existing user logs in regardless of name. Invalid names log a warning and close the session.

Covers all three creation paths (binary `name:` prefix, QLink/Habilink preamble, web-client JSON) since they all funnel through `ensureUserCreated`.

**Tests**: new `TestValidAvatarName` includes real prod-observed legitimate names and actual TLS-ClientHello byte prefixes; full bridge suite passes.

Cleanup of the ~370 existing debris users is #629's never-played rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)