### PR TITLE
Real client IPs for web sessions (PROXY protocol v1 through pushserver)

### DIFF
--- a/bridge_v2/bridge/client_connection.go
+++ b/bridge_v2/bridge/client_connection.go
@@ -79,6 +79,10 @@ func (c *ClientConnection) RemoteAddr() net.Addr {
 	return c.conn.RemoteAddr()
 }
 
+func (c *ClientConnection) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
+}
+
 func NewClientConnectionWithRate(conn net.Conn, dataRate int) *ClientConnection {
 	byteRate := float64(dataRate) / 10.0
 	rateBucket := ratelimit.NewBucketWithRate(byteRate, 1)

--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -97,6 +97,11 @@ type ClientSession struct {
 	qlinkNakSent      bool
 	clientConn        *ClientConnection
 	clientReader      *bufio.Reader
+	// realClientAddr is the origin address reported by a PROXY protocol v1
+	// header from the on-box websocket proxy (pushserver); web sessions
+	// otherwise all appear to come from the proxy itself. Empty for direct
+	// connections — RealClientAddr() falls back to the socket peer.
+	realClientAddr string
 	closeMutex        sync.Mutex
 	connected         bool
 	contentsVector    *ContentsVector
@@ -256,11 +261,14 @@ func (c *ClientSession) TableKey() string {
 // log lines from any goroutine using c.log will have avatar=<name>
 // attached.
 func (c *ClientSession) bindAvatar(name string) {
-	c.log = log.With().
-		Str("ip", c.TableKey()).
+	lc := log.With().
+		Str("ip", c.RealClientAddr()).
 		Str("session_id", c.sessionID).
-		Str("avatar", name).
-		Logger()
+		Str("avatar", name)
+	if c.realClientAddr != "" {
+		lc = lc.Str("proxy_peer", c.TableKey())
+	}
+	c.log = lc.Logger()
 	if c.span != nil {
 		c.span.SetAttributes(observability.AvatarAttr(name))
 	}
@@ -1128,6 +1136,7 @@ func (c *ClientSession) notePresenceArrivalLocked() {
 		regionRef: c.regionRef,
 		newUser:   c.presenceNewUser,
 		json:      c.jsonPassthrough,
+		ip:        c.RealClientAddr(),
 	}
 	if c.user != nil && len(c.user.Mods) > 0 && c.user.Mods[0].Turf != nil {
 		info.turfRef = *c.user.Mods[0].Turf
@@ -1545,7 +1554,99 @@ func (c *ClientSession) recoverElkoConnection() {
 	}
 }
 
+// proxyV1Sig is the fixed prefix of a PROXY protocol v1 header line.
+const proxyV1Sig = "PROXY "
+
+// parseProxyV1Line extracts the source address from a PROXY protocol v1
+// header line ("PROXY TCP4 <src> <dst> <srcport> <dstport>\r\n").
+// Returns ok=false for UNKNOWN or malformed lines.
+func parseProxyV1Line(line []byte) (string, bool) {
+	fields := strings.Fields(strings.TrimSpace(string(line)))
+	if len(fields) < 6 || fields[0] != "PROXY" {
+		return "", false
+	}
+	if fields[1] != "TCP4" && fields[1] != "TCP6" {
+		return "", false
+	}
+	if net.ParseIP(fields[2]) == nil {
+		return "", false
+	}
+	if _, err := strconv.Atoi(fields[4]); err != nil {
+		return "", false
+	}
+	return net.JoinHostPort(fields[2], fields[4]), true
+}
+
+// maybeConsumeProxyHeader consumes an optional PROXY protocol v1 header at
+// the head of the client stream. Web clients reach the bridge through
+// Caddy -> pushserver, so their TCP peer is always an on-box proxy address
+// and every web session used to log the same useless IP; pushserver now
+// prepends a PROXY line carrying the browser's real address (taken from
+// Caddy's X-Forwarded-For). The header is honored ONLY when the socket
+// peer is loopback/private — a public client sending "PROXY ..." is left
+// untouched for normal protocol handling, so origins can't be spoofed
+// from the internet.
+func (c *ClientSession) maybeConsumeProxyHeader() {
+	host, _, err := net.SplitHostPort(c.clientConn.RemoteAddr().String())
+	if err != nil {
+		return
+	}
+	peer := net.ParseIP(host)
+	if peer == nil || !(peer.IsLoopback() || peer.IsPrivate()) {
+		return
+	}
+	// Peek(1) before Peek(len): Peek(n) blocks until n bytes arrive, and
+	// only the proxy path ever starts with 'P' (QLink starts 0x5A, JSON
+	// clients '{'), so this can't stall a real client that sends one byte
+	// and waits. The proxy writes the whole header in a single segment.
+	peek, err := c.clientReader.Peek(1)
+	if err != nil || peek[0] != proxyV1Sig[0] {
+		return
+	}
+	sig, err := c.clientReader.Peek(len(proxyV1Sig))
+	if err != nil || string(sig) != proxyV1Sig {
+		return
+	}
+	// 107 bytes is the v1 spec's maximum header length.
+	line, err := readFirstLineEitherTerminator(c.clientReader, 107)
+	if err != nil {
+		return
+	}
+	// The line reader stops at the '\r' of the "\r\n" terminator; consume
+	// the '\n' too so protocol sniffing sees the client's first real byte.
+	if len(line) > 0 && line[len(line)-1] == '\r' {
+		if next, perr := c.clientReader.Peek(1); perr == nil && next[0] == '\n' {
+			c.clientReader.ReadByte()
+		}
+	}
+	addr, ok := parseProxyV1Line(line)
+	if !ok {
+		c.log.Warn().Str("line", fmt.Sprintf("%q", line)).Msg("Ignoring malformed PROXY header")
+		return
+	}
+	c.realClientAddr = addr
+	c.log = log.With().
+		Str("ip", addr).
+		Str("proxy_peer", c.clientConn.RemoteAddr().String()).
+		Str("session_id", c.sessionID).
+		Logger()
+	if c.span != nil {
+		c.span.SetAttributes(observability.IPAttr(addr))
+	}
+}
+
+// RealClientAddr is the best-known origin for this session: the
+// PROXY-protocol-reported browser address when the connection came through
+// the on-box websocket proxy, else the socket peer.
+func (c *ClientSession) RealClientAddr() string {
+	if c.realClientAddr != "" {
+		return c.realClientAddr
+	}
+	return c.clientConn.RemoteAddr().String()
+}
+
 func (c *ClientSession) Run() {
+	c.maybeConsumeProxyHeader()
 	// Peek ONE byte to decide broad protocol class. Any client sends
 	// at least one byte promptly after the TCP handshake (QLink Reset
 	// frame starts with 0x5A, JSON clients with '{', legacy
@@ -2574,7 +2675,7 @@ func (c *ClientSession) Close() {
 	c.presenceClosed = true
 	c.closeMutex.Unlock()
 	if !presenceNoted && c.bridge != nil && c.bridge.presence != nil {
-		c.bridge.presence.noteDisconnect(c.userRef, c.UserName, c.jsonPassthrough)
+		c.bridge.presence.noteDisconnect(c.userRef, c.UserName, c.jsonPassthrough, c.RealClientAddr())
 	}
 	// Flip the done flags first so other goroutines (notably
 	// writeJsonToClient) can distinguish a teardown-time write failure
@@ -2730,6 +2831,7 @@ func (c *ClientSession) Snapshot() *SessionSnapshot {
 		RegionRef:         c.regionRef,
 		Ref:               c.ref,
 		Who:               c.who,
+		RealClientAddr:    c.realClientAddr,
 		PacketPrefix:      c.packetPrefix,
 		Connected:         c.connected,
 		FirstConnection:   c.firstConnection,
@@ -2833,6 +2935,7 @@ func RestoreSession(b *Bridge, snap *SessionSnapshot, clientConn net.Conn, elkoC
 		waitingForAvatar:         snap.WaitingForAvatar,
 		waitingForAvatarContents: snap.WaitingForAvatarContents,
 		who:                      snap.Who,
+		realClientAddr:           snap.RealClientAddr,
 	}
 
 	// Rebuild the clientReader, prepending any buffered data that was
@@ -2891,6 +2994,9 @@ func RestoreSession(b *Bridge, snap *SessionSnapshot, clientConn net.Conn, elkoC
 	remoteAddr := "unknown"
 	if clientConn != nil && clientConn.RemoteAddr() != nil {
 		remoteAddr = clientConn.RemoteAddr().String()
+	}
+	if snap.RealClientAddr != "" {
+		remoteAddr = snap.RealClientAddr
 	}
 	sess.log = log.With().
 		Str("ip", remoteAddr).

--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -1592,7 +1592,20 @@ func (c *ClientSession) maybeConsumeProxyHeader() {
 		return
 	}
 	peer := net.ParseIP(host)
-	if peer == nil || !(peer.IsLoopback() || peer.IsPrivate()) {
+	if peer == nil {
+		return
+	}
+	// Trusted peers: loopback, RFC1918 (docker networks), or the host's
+	// own address — on prod the pushserver container reaches the
+	// host-systemd bridge through the machine's public IP, so a
+	// self-connection is still the on-box proxy, not the internet.
+	trusted := peer.IsLoopback() || peer.IsPrivate()
+	if !trusted && c.clientConn.LocalAddr() != nil {
+		if localHost, _, lerr := net.SplitHostPort(c.clientConn.LocalAddr().String()); lerr == nil {
+			trusted = localHost == host
+		}
+	}
+	if !trusted {
 		return
 	}
 	// Peek(1) before Peek(len): Peek(n) blocks until n bytes arrive, and

--- a/bridge_v2/bridge/presence.go
+++ b/bridge_v2/bridge/presence.go
@@ -37,6 +37,7 @@ type PresenceEvent struct {
 	RegionRef string    `json:"region_ref,omitempty"`
 	Region    string    `json:"region,omitempty"` // display name, or "their turf"
 	Client    string    `json:"client,omitempty"` // "c64" | "web"
+	IP        string    `json:"ip,omitempty"`     // origin address (PROXY-header-aware)
 	Alerted   bool      `json:"alerted"`
 	Reason    string    `json:"reason,omitempty"` // why a connect was NOT posted
 }
@@ -51,6 +52,7 @@ type presenceConnect struct {
 	turfRef   string
 	newUser   bool
 	json      bool
+	ip        string
 }
 
 type presenceRegistry struct {
@@ -141,7 +143,7 @@ func (p *presenceRegistry) noteConnect(info presenceConnect) {
 	p.record(PresenceEvent{
 		Time: now, Kind: "connect", UserRef: info.userRef, Name: info.name,
 		RegionRef: info.regionRef, Region: eventRegion, Client: clientKind(info.json),
-		Alerted: reason == "", Reason: reason,
+		IP: info.ip, Alerted: reason == "", Reason: reason,
 	})
 	if reason == "" {
 		p.notifier.Post(presenceLoginsChannel, formatLoginAlert(info, regionLabel, atTurf, humans))
@@ -149,7 +151,7 @@ func (p *presenceRegistry) noteConnect(info presenceConnect) {
 }
 
 // noteDisconnect stamps the debounce clock and records history. Never posts.
-func (p *presenceRegistry) noteDisconnect(userRef string, name string, json bool) {
+func (p *presenceRegistry) noteDisconnect(userRef string, name string, json bool, ip string) {
 	if p == nil || userRef == "" {
 		return
 	}
@@ -166,6 +168,7 @@ func (p *presenceRegistry) noteDisconnect(userRef string, name string, json bool
 	p.mu.Unlock()
 	p.record(PresenceEvent{
 		Time: now, Kind: "disconnect", UserRef: userRef, Name: name, Client: clientKind(json),
+		IP: ip,
 	})
 }
 
@@ -305,6 +308,7 @@ func (p *presenceRegistry) record(ev PresenceEvent) {
 		Str("region_ref", ev.RegionRef).
 		Str("region", ev.Region).
 		Str("client", ev.Client).
+		Str("ip", ev.IP).
 		Bool("alerted", ev.Alerted).
 		Str("reason", ev.Reason).
 		Msg("presence_event")

--- a/bridge_v2/bridge/presence_test.go
+++ b/bridge_v2/bridge/presence_test.go
@@ -88,7 +88,7 @@ func TestPresenceAlertsFreshLogin(t *testing.T) {
 
 func TestPresenceDebounceWindow(t *testing.T) {
 	p, hook, now := newTestPresence(t)
-	p.noteDisconnect("user-randy", "Randy", true)
+	p.noteDisconnect("user-randy", "Randy", true, "")
 	*now = now.Add(presenceDebounceWindow - time.Second)
 	p.noteConnect(connectInfo("user-randy", "Randy", "context-Downtown_4f"))
 	if posts := hook.posts(); len(posts) != 0 {
@@ -198,7 +198,7 @@ func TestPresenceNewUserFanfare(t *testing.T) {
 
 func TestPresenceDebounceHandoffRoundTrip(t *testing.T) {
 	p, hook, now := newTestPresence(t)
-	p.noteDisconnect("user-randy", "Randy", true)
+	p.noteDisconnect("user-randy", "Randy", true, "")
 	exported := p.exportDebounce()
 	if len(exported) != 1 {
 		t.Fatalf("export = %v", exported)

--- a/bridge_v2/bridge/proxy_header_test.go
+++ b/bridge_v2/bridge/proxy_header_test.go
@@ -13,9 +13,17 @@ import (
 type addrConn struct {
 	discardConn
 	remote net.Addr
+	local  net.Addr
 }
 
 func (a *addrConn) RemoteAddr() net.Addr { return a.remote }
+
+func (a *addrConn) LocalAddr() net.Addr {
+	if a.local != nil {
+		return a.local
+	}
+	return a.discardConn.LocalAddr()
+}
 
 func newProxyTestSession(peerIP string, stream string) *ClientSession {
 	bridge := &Bridge{DataRate: 1 << 20}
@@ -67,6 +75,27 @@ func TestProxyHeaderConsumedFromPrivatePeer(t *testing.T) {
 	b, err := s.clientReader.Peek(1)
 	if err != nil || b[0] != '{' {
 		t.Fatalf("next byte after header = %q, %v; want '{'", b, err)
+	}
+}
+
+func TestProxyHeaderTrustedFromSelfConnection(t *testing.T) {
+	// Prod topology: the pushserver container dials the host-systemd
+	// bridge through the machine's public IP, so peer == local address.
+	bridge := &Bridge{DataRate: 1 << 20}
+	conn := &addrConn{
+		remote: &net.TCPAddr{IP: net.ParseIP("20.3.249.92"), Port: 33992},
+		local:  &net.TCPAddr{IP: net.ParseIP("20.3.249.92"), Port: 2026},
+	}
+	s := &ClientSession{
+		bridge:     bridge,
+		clientConn: NewClientConnection(bridge, conn),
+		clientReader: bufio.NewReader(strings.NewReader(
+			"PROXY TCP4 60.234.208.18 127.0.0.1 51234 2026\r\n{\"op\":\"x\"}\n")),
+		done: make(chan struct{}),
+	}
+	s.maybeConsumeProxyHeader()
+	if s.realClientAddr != "60.234.208.18:51234" {
+		t.Fatalf("realClientAddr = %q, want 60.234.208.18:51234", s.realClientAddr)
 	}
 }
 

--- a/bridge_v2/bridge/proxy_header_test.go
+++ b/bridge_v2/bridge/proxy_header_test.go
@@ -1,0 +1,112 @@
+package bridge
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"strings"
+	"testing"
+)
+
+// addrConn is a fake net.Conn with a configurable peer address, for
+// exercising the PROXY-header trust check without real sockets.
+type addrConn struct {
+	discardConn
+	remote net.Addr
+}
+
+func (a *addrConn) RemoteAddr() net.Addr { return a.remote }
+
+func newProxyTestSession(peerIP string, stream string) *ClientSession {
+	bridge := &Bridge{DataRate: 1 << 20}
+	conn := &addrConn{remote: &net.TCPAddr{IP: net.ParseIP(peerIP), Port: 55555}}
+	cc := NewClientConnection(bridge, conn)
+	return &ClientSession{
+		bridge:       bridge,
+		clientConn:   cc,
+		clientReader: bufio.NewReader(strings.NewReader(stream)),
+		done:         make(chan struct{}),
+	}
+}
+
+func TestParseProxyV1Line(t *testing.T) {
+	cases := []struct {
+		line string
+		want string
+		ok   bool
+	}{
+		{"PROXY TCP4 60.234.208.18 127.0.0.1 51234 2026\r\n", "60.234.208.18:51234", true},
+		{"PROXY TCP6 2001:db8::7 ::1 51234 2026\r\n", "[2001:db8::7]:51234", true},
+		{"PROXY UNKNOWN\r\n", "", false},
+		{"PROXY TCP4 not-an-ip 127.0.0.1 1 2\r\n", "", false},
+		{"PROXY TCP4 1.2.3.4 127.0.0.1 nope 2\r\n", "", false},
+		{"PROXY TCP4 1.2.3.4 127.0.0.1 1\r\n", "", false},
+		{"GARBAGE LINE\r\n", "", false},
+	}
+	for _, c := range cases {
+		got, ok := parseProxyV1Line([]byte(c.line))
+		if ok != c.ok || got != c.want {
+			t.Errorf("parseProxyV1Line(%q) = (%q, %v), want (%q, %v)",
+				c.line, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestProxyHeaderConsumedFromPrivatePeer(t *testing.T) {
+	s := newProxyTestSession("172.18.0.3",
+		"PROXY TCP4 60.234.208.18 127.0.0.1 51234 2026\r\n{\"op\":\"x\"}\n")
+	s.maybeConsumeProxyHeader()
+	if s.realClientAddr != "60.234.208.18:51234" {
+		t.Fatalf("realClientAddr = %q, want 60.234.208.18:51234", s.realClientAddr)
+	}
+	if got := s.RealClientAddr(); got != "60.234.208.18:51234" {
+		t.Fatalf("RealClientAddr() = %q", got)
+	}
+	// The full header including the trailing \n must be consumed so
+	// protocol sniffing sees the JSON open-brace next.
+	b, err := s.clientReader.Peek(1)
+	if err != nil || b[0] != '{' {
+		t.Fatalf("next byte after header = %q, %v; want '{'", b, err)
+	}
+}
+
+func TestProxyHeaderIgnoredFromPublicPeer(t *testing.T) {
+	stream := "PROXY TCP4 1.2.3.4 127.0.0.1 1 2\r\n"
+	s := newProxyTestSession("8.8.8.8", stream)
+	s.maybeConsumeProxyHeader()
+	if s.realClientAddr != "" {
+		t.Fatalf("realClientAddr = %q, want empty (public peer must not spoof)", s.realClientAddr)
+	}
+	// Stream must be untouched for normal protocol handling.
+	got := make([]byte, len(stream))
+	if _, err := io.ReadFull(s.clientReader, got); err != nil || string(got) != stream {
+		t.Fatalf("stream after ignored header = %q, %v", got, err)
+	}
+}
+
+func TestProxyHeaderLeavesNonProxyDataAlone(t *testing.T) {
+	stream := "Phil:1234\n"
+	s := newProxyTestSession("127.0.0.1", stream)
+	s.maybeConsumeProxyHeader()
+	if s.realClientAddr != "" {
+		t.Fatalf("realClientAddr = %q, want empty", s.realClientAddr)
+	}
+	got := make([]byte, len(stream))
+	if _, err := io.ReadFull(s.clientReader, got); err != nil || string(got) != stream {
+		t.Fatalf("stream after check = %q, %v", got, err)
+	}
+}
+
+func TestProxyHeaderMalformedLineConsumedButNoOverride(t *testing.T) {
+	// A malformed PROXY line from a trusted peer is consumed (it can't be
+	// valid protocol data) but must not set an origin override.
+	s := newProxyTestSession("10.0.0.5", "PROXY TCP4 broken\r\n{\"op\":\"x\"}\n")
+	s.maybeConsumeProxyHeader()
+	if s.realClientAddr != "" {
+		t.Fatalf("realClientAddr = %q, want empty", s.realClientAddr)
+	}
+	b, err := s.clientReader.Peek(1)
+	if err != nil || b[0] != '{' {
+		t.Fatalf("next byte after malformed header = %q, %v; want '{'", b, err)
+	}
+}

--- a/bridge_v2/bridge/snapshot.go
+++ b/bridge_v2/bridge/snapshot.go
@@ -17,6 +17,9 @@ type SessionSnapshot struct {
 	RegionRef    string `json:"region_ref"`
 	Ref          string `json:"ref"`
 	Who          string `json:"who"`
+	// RealClientAddr preserves a PROXY-protocol-reported origin across a
+	// tableflip handoff; the inherited socket only knows the proxy peer.
+	RealClientAddr string `json:"real_client_addr,omitempty"`
 	PacketPrefix string `json:"packet_prefix,omitempty"`
 
 	Connected         bool `json:"connected"`

--- a/pushserver/websocketProxy.js
+++ b/pushserver/websocketProxy.js
@@ -78,6 +78,44 @@ function extractLoginName(message) {
   return null;
 }
 
+function normalizeAddress(addr) {
+  if (!addr) {
+    return '';
+  }
+  // Node reports IPv4 peers on a dual-stack socket as ::ffff:1.2.3.4.
+  return addr.replace(/^::ffff:/i, '');
+}
+
+function isPrivateAddress(addr) {
+  return addr === '::1' ||
+    /^(127\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)/.test(addr);
+}
+
+// The browser's true address. HTTPS clients reach this proxy through Caddy,
+// so the socket peer is an on-box address and the origin arrives in
+// X-Forwarded-For. Trust that header only from private/loopback peers so a
+// direct connection can't spoof its origin.
+function realClientAddress(req) {
+  var peer = normalizeAddress(req.socket.remoteAddress);
+  var xff = req.headers['x-forwarded-for'];
+  if (xff && isPrivateAddress(peer)) {
+    var first = xff.split(',')[0].trim();
+    if (first) {
+      return normalizeAddress(first);
+    }
+  }
+  return peer;
+}
+
+// PROXY protocol v1 header carrying clientAddr as the connection origin,
+// for the bridge to log instead of this proxy's address.
+function proxyProtocolLine(clientAddr, clientPort, targetPort) {
+  var family = clientAddr.indexOf(':') >= 0 ? 'TCP6' : 'TCP4';
+  var dstHost = family === 'TCP6' ? '::1' : '127.0.0.1';
+  return 'PROXY ' + family + ' ' + clientAddr + ' ' + dstHost + ' ' +
+    (clientPort || 0) + ' ' + targetPort + '\r\n';
+}
+
 class LoginNameDetector {
   constructor() {
     this.buffer = Buffer.alloc(0);
@@ -113,7 +151,7 @@ function startWebsocketProxy(config) {
   var wsServer = new WebSocketServer({server: server});
 
   wsServer.on('connection', function(client, req) {
-    var clientAddr = client._socket.remoteAddress;
+    var clientAddr = realClientAddress(req);
     var cookies = parseCookies(req.headers.cookie);
     var docentSessionId = cookies.docentSessionId;
     // Prefer an explicit ?docent=<id> on the WS URL over the cookie: the /neohabitat docent page is
@@ -136,6 +174,16 @@ function startWebsocketProxy(config) {
       log.debug('WebSocket proxy connected %s to %s:%s',
         clientAddr, target.host, target.port);
     });
+
+    // First bytes on the bridge connection: a PROXY protocol v1 header so
+    // the bridge logs the browser's address instead of this proxy's.
+    // Written immediately (not in the connect callback) — net.Socket
+    // queues pre-connect writes in order, so this always precedes any
+    // client data forwarded below.
+    if (clientAddr) {
+      targetSocket.write(
+        proxyProtocolLine(clientAddr, req.socket.remotePort, target.port));
+    }
 
     targetSocket.on('data', function(data) {
       try {
@@ -186,5 +234,7 @@ function startWebsocketProxy(config) {
 
 module.exports = startWebsocketProxy;
 module.exports.extractLoginName = extractLoginName;
+module.exports.realClientAddress = realClientAddress;
+module.exports.proxyProtocolLine = proxyProtocolLine;
 module.exports.LoginNameDetector = LoginNameDetector;
 module.exports.websocketMessageToBuffer = websocketMessageToBuffer;

--- a/pushserver/websocketProxy_test.js
+++ b/pushserver/websocketProxy_test.js
@@ -48,6 +48,46 @@ function testMessageBufferConversionPreservesBytes() {
     Array.from(bytes));
 }
 
+function fakeReq(remoteAddress, xff, remotePort) {
+  return {
+    socket: {remoteAddress: remoteAddress, remotePort: remotePort || 4242},
+    headers: xff ? {'x-forwarded-for': xff} : {},
+  };
+}
+
+function testRealClientAddressTrustsForwardedFromPrivatePeer() {
+  assert.strictEqual(
+    websocketProxy.realClientAddress(fakeReq('::ffff:172.18.0.2', '60.234.208.18')),
+    '60.234.208.18');
+  assert.strictEqual(
+    websocketProxy.realClientAddress(fakeReq('127.0.0.1', '60.234.208.18, 10.0.0.1')),
+    '60.234.208.18');
+}
+
+function testRealClientAddressIgnoresForwardedFromPublicPeer() {
+  assert.strictEqual(
+    websocketProxy.realClientAddress(fakeReq('::ffff:8.8.8.8', '1.2.3.4')),
+    '8.8.8.8');
+}
+
+function testRealClientAddressFallsBackToPeer() {
+  assert.strictEqual(
+    websocketProxy.realClientAddress(fakeReq('::ffff:172.18.0.2', null)),
+    '172.18.0.2');
+}
+
+function testProxyProtocolLine() {
+  assert.strictEqual(
+    websocketProxy.proxyProtocolLine('60.234.208.18', 51234, 2026),
+    'PROXY TCP4 60.234.208.18 127.0.0.1 51234 2026\r\n');
+  assert.strictEqual(
+    websocketProxy.proxyProtocolLine('2001:db8::7', 51234, 2026),
+    'PROXY TCP6 2001:db8::7 ::1 51234 2026\r\n');
+  assert.strictEqual(
+    websocketProxy.proxyProtocolLine('60.234.208.18', undefined, 2026),
+    'PROXY TCP4 60.234.208.18 127.0.0.1 0 2026\r\n');
+}
+
 testExtractsNameOnlyPreamble();
 testExtractsLoginPreamble();
 testExtractsArrayBufferPreamble();
@@ -55,3 +95,7 @@ testDetectsFragmentedPreamble();
 testDetectsFragmentedArrayPreamble();
 testIgnoresNonLoginFrame();
 testMessageBufferConversionPreservesBytes();
+testRealClientAddressTrustsForwardedFromPrivatePeer();
+testRealClientAddressIgnoresForwardedFromPublicPeer();
+testRealClientAddressFallsBackToPeer();
+testProxyProtocolLine();


### PR DESCRIPTION
Web sessions all logged the proxy's own IP; finding a player's real origin meant hoping Caddy logged an aborted eventStream (docent-less sessions like Alex's were untraceable).

## How it works
- **pushserver** (`websocketProxy.js`): when dialing the bridge, first writes a standard `PROXY TCP4 <origin> ...` line. The origin comes from Caddy's `X-Forwarded-For`, trusted only when the websocket peer is private/loopback; otherwise the socket peer is used.
- **bridge_v2**: at session start, if the TCP peer is loopback/private and the stream begins `PROXY `, the header is consumed and the reported address becomes `ip` on every session log line (the proxy hop stays visible as `proxy_peer`), on the OTel span, and on `presence_event` connect/disconnect lines. Public peers sending `PROXY ...` are ignored — no spoofing from the internet. The override survives tableflip via the session snapshot.
- Direct C64/binary/QLink connections are completely unaffected (they already log real IPs).

## Testing
- Go unit tests: header parse, consumed-from-private-peer, ignored-from-public-peer, non-proxy data untouched, malformed line consumed without override. Full `go test ./bridge/` green.
- pushserver node tests: XFF trust rules + PROXY line formatting.
- Local end-to-end: raw TCP with PROXY preamble → bridge logs `ip=203.0.113.77`; full ws path with `X-Forwarded-For: 198.51.100.42` → bridge logs `ip=198.51.100.42 proxy_peer=172.18.0.3`, presence_event carries the IP. Test users/turfs cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)