### PR TITLE
Welcomebot fixes: never index sentinel noid 256; don't greet yourself

### DIFF
--- a/habibots/bots/hatchery.js
+++ b/habibots/bots/hatchery.js
@@ -91,7 +91,10 @@ HatcheryBot.on('APPEARING_$', (bot, msg) => {
     log.error('No avatar found at noid: %s', msg.appearing)
     return
   }
-  
+  if (avatar.name.toLowerCase() === Argv.username.toLowerCase()) {
+    return
+  }
+
   bot.say("TO: " + avatar.name)
     .then(() => bot.wait(5000))
     .then(() => bot.ESPsayLines(GreetingText))
@@ -108,7 +111,14 @@ HatcheryBot.on('APPEARING_$', (bot, msg) => {
  */
 HatcheryBot.on('make', (bot, msg) => {
   if (msg.obj.mods[0].type == "Avatar") {
-    if (msg.type !== undefined && msg.type === null) {  
+    // Own de-ghost: the bot itself re-enters the hatchery as a ghost on every
+    // restart and ensureCorporated fires this same type:null make — without
+    // this check it runs the whole greeting flow addressed to itself. Case-
+    // insensitive: the avatar name is "WelcomeBot" but -u is "welcomebot".
+    if (msg.obj.name.toLowerCase() === Argv.username.toLowerCase()) {
+      return
+    }
+    if (msg.type !== undefined && msg.type === null) {
     bot.say("TO: " + msg.obj.name) 
       .then(() => bot.wait(5000))
       .then(() => bot.ESPsayLines(GreetingText))

--- a/habibots/habibot.js
+++ b/habibots/habibot.js
@@ -1774,7 +1774,17 @@ class HabiBot {
         // to=item-box-... etc. Underscore-prefix to signal "client-
         // side bookkeeping, never sent back to server."
         o.obj._container = o.to
-        this.noids[o.obj.mods[0].noid] = o.obj
+        // Noids are one byte on the C64 wire; 256 is elko's backend-only
+        // UNASSIGNED_NOID, stamped on a still-ghost avatar and each of its
+        // pocket contents. Indexing those makes would let the last of them
+        // (always the Tokens, "Money for X") squat one table slot, and the
+        // ghost's I_AM_HERE broadcasts APPEARING_$ appearing=256 — which is
+        // how the welcomebot ended up greeting new users' wallets. Sentinel
+        // noids never enter the table; getNoid() then returns null and every
+        // handler's existing null guard skips cleanly.
+        if (o.obj.mods[0].noid <= 255) {
+          this.noids[o.obj.mods[0].noid] = o.obj
+        }
       }
       if (o.you) {
         var split = ref.split('-')

--- a/habibots/test/sentinelNoid.test.js
+++ b/habibots/test/sentinelNoid.test.js
@@ -1,0 +1,43 @@
+/* Sentinel-noid guard — elko stamps a still-ghost avatar and its pocket
+   contents (Head, Paper, Tokens) with backend-only UNASSIGNED_NOID (256),
+   then broadcasts APPEARING_$ appearing=256 on the ghost's I_AM_HERE. The
+   noid table must never index those makes: last-write-wins left the Tokens
+   ("Money for X") at slot 256, and the hatchery welcomebot greeted new
+   users' wallets. Noids are one byte on the C64 wire; >255 never names a
+   real region slot. */
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const HabiBot = require('../habibot.js')
+
+function makeMsg(to, ref, name, modType, noid) {
+  return {
+    op: 'make',
+    to: to,
+    obj: { type: 'item', ref: ref, name: name, mods: [{ type: modType, noid: noid }] },
+  }
+}
+
+test('UNASSIGNED_NOID (256) makes are never indexed in the noid table', () => {
+  const bot = new HabiBot('127.0.0.1', 9, 'testbot')
+  // The new-user burst as elko sends it: avatar then contents, all noid 256.
+  bot.processElkoMessage(makeMsg('context-hatchery', 'user-lostworld-1', 'LOSTWORLD', 'Avatar', 256))
+  bot.processElkoMessage(makeMsg('user-lostworld-1', 'item-head.1-1', 'Default head for LOSTWORLD', 'Head', 256))
+  bot.processElkoMessage(makeMsg('user-lostworld-1', 'item-paper.1-1', 'Paper for LOSTWORLD', 'Paper', 256))
+  bot.processElkoMessage(makeMsg('user-lostworld-1', 'item-tokens.1-1', 'Money for LOSTWORLD', 'Tokens', 256))
+
+  assert.equal(bot.getNoid(256), null, 'sentinel slot must resolve to null, not the Tokens')
+  assert.ok(!(256 in bot.noids))
+  // The avatar is still tracked by name, just not by (nonexistent) noid.
+  assert.equal(bot.avatars['LOSTWORLD'].ref, 'user-lostworld-1')
+})
+
+test('real one-byte noids are still indexed, including the Ghost at 255', () => {
+  const bot = new HabiBot('127.0.0.1', 9, 'testbot')
+  bot.processElkoMessage(makeMsg('context-hatchery', 'user-lostworld-2', 'LOSTWORLD', 'Avatar', 27))
+  bot.processElkoMessage(makeMsg('context-hatchery', 'i-ghost-1', 'Ghost', 'Ghost', 255))
+
+  assert.equal(bot.getNoid(27).name, 'LOSTWORLD')
+  assert.equal(bot.getNoid(255).name, 'Ghost')
+})


### PR DESCRIPTION
Two hatchery-bot bugs, both witnessed on prod (LOSTWORLD's session, 2026-07-20):

1. **Greeting the wallet.** Elko stamps a still-ghost avatar and its pocket contents with backend-only UNASSIGNED_NOID (256) and broadcasts `APPEARING_$ appearing=256` on the bridge-synthesized I_AM_HERE. habibot's noid table indexed every make by noid, so the four noid-256 makes overwrote each other, leaving the Tokens item ("Money for <name>") in the slot — and the welcomebot ran its full greeting flow addressed to "Money for LOSTWORLD", followed by a second (correct) greeting from the de-ghost handler. Fixed at the library level: noids >255 are never indexed (they're one byte on the C64 wire; 256 cannot name a region slot), `getNoid(256)` returns null, and every bot's existing null guard skips cleanly. New users are now greeted exactly once, by the de-ghost handler.

2. **Greeting itself.** On every restart the bot re-enters the hatchery as a ghost and its own ensureCorporated de-ghost make tripped the same greeting handler ("WelcomeBot, your visa was approved..."). Guarded case-insensitively (avatar "WelcomeBot" vs `-u welcomebot`).

Tested on the local stack with a synthetic web client running the complete new-user entry flow (entercontext hatchery:true → CUSTOMIZE → ghost arrival → CORPORATE → door → Downtown_4d): old code reproduces both bugs; fixed code greets once with the right name and the entry flow is unchanged end-to-end. Also validated by an organic webclient session. Unit tests: 13/13 (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)