### PR TITLE
Add 'Hatchery' teleport address for NeoHabitat Immigration

### DIFF
--- a/db/Hatchery/hatchery.json
+++ b/db/Hatchery/hatchery.json
@@ -1,9 +1,10 @@
 [
   {
-    "ref": "context-hatchery", 
-    "capacity": 64, 
-    "type": "context", 
-    "name": "NeoHabitat Immigration", 
+    "ref": "context-hatchery",
+    "capacity": 64,
+    "type": "context",
+    "name": "NeoHabitat Immigration",
+    "aliases": [ "pop-hatchery" ],
     "mods": [
       {
         "town_dir": UP, 

--- a/db/Text/text-portdir.json
+++ b/db/Text/text-portdir.json
@@ -124,12 +124,12 @@
 		"                                        " +
 		"Downtown   Corner of Skid Row & Broadway" +
 		"Uptown     Corner of 42nd & Maine Sts.  " +
+		"Hatchery   Immigration, meet new Avatars" +
 		"Help       A teleport help info region  " +
 		"Plaza NE   NE corner of Oracle Plaza    " +
 		"Plaza NW   NW corner of Oracle Plaza    " +
 		"Plaza SE   SE corner of Oracle Plaza    " +
 		"Plaza SW   SW corner of Oracle Plaza    " +
-		"                                        " +
 		"                                        " +
 		"                                        " +
 		"                                        " +


### PR DESCRIPTION
Adds a teleport address so helpers can easily reach new users in Immigration:

- `db/Hatchery/hatchery.json`: `aliases: ["pop-hatchery"]` on `context-hatchery` — future db builds prime the `teleports` directory with `pop-hatchery → context-hatchery`. Typing **hatchery** at any Populopolis booth resolves via the `pop-` area code.
- `db/Text/text-portdir.json`: page 8 of the in-world *Populopolis Teleport Directory* now lists `Hatchery   Immigration, meet new Avatars` (40-col layout verified).

The live prod `teleports` and `text-portdir` documents have already been updated to match; the new address activates when elko next restarts (statics load at boot), which the auto-deploy on merging this PR will do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)