### PR TITLE
New users arrive corporeal instead of as ghosts

### DIFF
--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -1268,7 +1268,11 @@ func (c *ClientSession) createUserWithAppearance(fullName string, appearance *ha
 			{
 				Type:            StringP("Avatar"),
 				FirstConnection: BoolP(true),
-				AmAGhost:        BoolP(true),
+				// New users arrive corporeal. Ghost arrival was for landing
+				// in crowded public regions (the 2017 fountain-era flow);
+				// Immigration is effectively private, and first-timers were
+				// bouncing without ever finding the deghost control.
+				AmAGhost:        BoolP(false),
 				X:               Uint8P(10),
 				Y:               Uint8P(128 + uint8(rand.Intn(32))),
 				BodyType:        StringP("male"),


### PR DESCRIPTION
Flips `AmAGhost` to `false` in the new-user creation template (`createUserWithAppearance`).

**Why**: ghost arrival for new users is a carry-over from the 2017 fountain-era flow (crowded public arrival regions, where a ghost can never overflow capacity). New users now land in Immigration — effectively private — and the F1 deghost gate is where first-timers bounce: tonight Bron took 44s to find it and RobBobbins closed the tab without ever deghosting, never meeting the WelcomeBot.

**Scope**: new-user creation only. `amAGhost` stays persistent avatar state for returning users, and the existing forced-ghost paths (region heap > 8000, missing last region → turf redirect) are untouched.

**Local e2e verification** (full entry flow, synthetic web client):
- customize → corporeal arrival in hatchery (`amAGhost=false`, real noid — the 256 sentinel never appears)
- `APPEARING_$` fires with the real noid → exactly **1** WelcomeBot greeting via the APPEARING path (ESP welcome + correctly-addressed visa line), no double-fire from the type:null deghost hack, 0 wallet-addressed lines
- door → Downtown_4d transition clean
- bridge_v2 unit suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)