### PR TITLE
Mirror item transfers in the bridge containment map (fixes C64 Fatal Error #11)

### DIFF
--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -987,6 +987,39 @@ func (c *ClientSession) removeNoid(noid uint8) error {
 	return nil
 }
 
+// handItem returns the tracked object currently in the given avatar's
+// hand (container == avatarNoid, slot == AVATAR_HAND), or nil when
+// nothing is tracked there.
+func (c *ClientSession) handItem(avatarNoid uint8) *ElkoMessage {
+	for _, obj := range c.objects {
+		if obj != nil && obj.container == avatarNoid &&
+			obj.mod != nil && obj.mod.Y != nil && *obj.mod.Y == AVATAR_HAND {
+			return obj
+		}
+	}
+	return nil
+}
+
+// noteContainerChange records that a tracked object now lives in
+// `container` at slot/position `y`. Every server broadcast or reply
+// that moves an object between containers must be mirrored here:
+// removeNoid's recursive sweep trusts this map to decide what leaves
+// the region with a departing avatar, and a stale entry makes it
+// GOAWAY an object the C64 can still legitimately receive asyncs for
+// — which the C64 treats as fatal heap corruption (error #11,
+// missing_object). Y is a region coordinate when container is the
+// region, a slot index otherwise — same convention as the C64 heap.
+func (c *ClientSession) noteContainerChange(item *ElkoMessage, container, y uint8) {
+	if item == nil {
+		return
+	}
+	item.container = container
+	if item.mod != nil {
+		slot := y
+		item.mod.Y = &slot
+	}
+}
+
 // setFirstConnection sets mods.0.firstConnection = true on the user
 // document. Called from ensureUserCreated for returning users.
 //

--- a/bridge_v2/bridge/constants.go
+++ b/bridge_v2/bridge/constants.go
@@ -34,6 +34,11 @@ const UNASSIGNED_NOID uint16 = 256
 // Habitat2ElkoBridge.js's ContentsVector.send path.
 const GHOST_NOID uint8 = 255
 
+// AVATAR_HAND is the avatar containment slot holding the in-hand item
+// (C64 dataequates.m `define AVATAR_HAND = 5`; Java Constants.HANDS).
+// A contained object's mod.Y is its slot index within its container.
+const AVATAR_HAND uint8 = 5
+
 type ServerMessage uint8
 
 const (

--- a/bridge_v2/bridge/container_tracking_test.go
+++ b/bridge_v2/bridge/container_tracking_test.go
@@ -1,0 +1,177 @@
+package bridge
+
+// Tests for the containment-map mirrors that keep ClientSession.objects
+// consistent with the C64's own heap when items move between hands,
+// the floor, and containers. Regression coverage for the 2026-07-23
+// Fatal Error #11 incident: a HAND transfer went unmirrored, the giver
+// left the region, and the sweep GOAWAY'd the item out of the
+// receiver's hand — the item's next async then referenced a noid the
+// C64 had deleted, which it treats as fatal heap corruption.
+
+import "testing"
+
+// addTrackedObject inserts an object with full derived containment
+// state (mod, container, slot) the way unpackHabitatObject would.
+func addTrackedObject(s *ClientSession, noid uint8, ref string, className string, container uint8, y uint8) *ElkoMessage {
+	slot := y
+	o := &ElkoMessage{
+		Obj:       &HabitatObject{Ref: ref},
+		mod:       &HabitatMod{Type: &className, Y: &slot},
+		ref:       ref,
+		container: container,
+	}
+	s.objects[noid] = o
+	s.RefToNoid[ref] = noid
+	s.objectNoidOrder = append(s.objectNoidOrder, noid)
+	return o
+}
+
+// incidentSession builds the Popustop.1019 cast as a bystander session
+// saw it: giver avatar 30 holding item 24, receiver avatar 10.
+func incidentSession() *ClientSession {
+	s := newTestSession()
+	addTrackedObject(s, 30, "user-giver", "Avatar", 0, 0)
+	addTrackedObject(s, 10, "user-receiver", "Avatar", 0, 0)
+	addTrackedObject(s, 24, "item-changomatic", "Changomatic", 30, AVATAR_HAND)
+	return s
+}
+
+// GRABFROM$ must move the giver's in-hand item to the receiver in the
+// tracked map.
+func TestGrabfromMirrorsHandTransfer(t *testing.T) {
+	s := incidentSession()
+	receiver, giver := uint8(10), uint8(30)
+	msg := &ElkoMessage{Noid: &receiver, AvatarNoid: &giver}
+	ServerOps["GRABFROM$"].ToClient(msg, NewHabBufEmpty(), s)
+
+	if got := s.objects[24].container; got != receiver {
+		t.Errorf("item container = %d, want %d (receiver)", got, receiver)
+	}
+}
+
+// The incident end-to-end: after a mirrored GRABFROM$, sweeping the
+// departing giver must NOT remove the item now in the receiver's hand.
+func TestSweepAfterGrabfromKeepsTransferredItem(t *testing.T) {
+	s := incidentSession()
+	receiver, giver := uint8(10), uint8(30)
+	msg := &ElkoMessage{Noid: &receiver, AvatarNoid: &giver}
+	ServerOps["GRABFROM$"].ToClient(msg, NewHabBufEmpty(), s)
+
+	if err := s.removeNoid(30); err != nil {
+		t.Fatalf("removeNoid err = %v", err)
+	}
+	if s.objects[24] == nil {
+		t.Fatal("item was swept out of the receiver's hand (Fatal Error #11 regression)")
+	}
+	if s.objects[30] != nil {
+		t.Error("departed avatar still tracked")
+	}
+}
+
+// Control: without a transfer, the giver's in-hand item still leaves
+// with them (the original orphan fix must keep working).
+func TestSweepStillRemovesCarriedItem(t *testing.T) {
+	s := incidentSession()
+	if err := s.removeNoid(30); err != nil {
+		t.Fatalf("removeNoid err = %v", err)
+	}
+	if s.objects[24] != nil {
+		t.Error("carried item not swept with departing avatar")
+	}
+}
+
+// GET$ must mirror a bystander-observed pickup from the floor.
+func TestGetAsyncMirrorsPickup(t *testing.T) {
+	s := incidentSession()
+	addTrackedObject(s, 12, "item-token", "Tokens", 0, 140)
+	picker, target, how := uint8(10), uint8(12), uint8(0)
+	msg := &ElkoMessage{Noid: &picker, Target: &target, How: &how}
+	ServerOps["GET$"].ToClient(msg, NewHabBufEmpty(), s)
+
+	item := s.objects[12]
+	if item.container != picker {
+		t.Errorf("item container = %d, want %d", item.container, picker)
+	}
+	if item.mod.Y == nil || *item.mod.Y != AVATAR_HAND {
+		t.Errorf("item slot = %v, want AVATAR_HAND", item.mod.Y)
+	}
+}
+
+// THROW$ must mirror the object landing back on the region floor.
+func TestThrowMirrorsLanding(t *testing.T) {
+	s := incidentSession()
+	obj, x, y, hit := uint8(24), uint8(80), uint8(140), uint8(1)
+	msg := &ElkoMessage{ObjectNoid: &obj, X: &x, Y: &y, Hit: &hit}
+	ServerOps["THROW$"].ToClient(msg, NewHabBufEmpty(), s)
+
+	item := s.objects[24]
+	if item.container != REGION_NOID {
+		t.Errorf("thrown item container = %d, want region", item.container)
+	}
+	if item.mod.Y == nil || *item.mod.Y != y {
+		t.Errorf("thrown item y = %v, want %d", item.mod.Y, y)
+	}
+}
+
+// HAND reply: the initiator (giver) mirrors from the success reply.
+func TestHandReplyMirrorsGiveaway(t *testing.T) {
+	s := incidentSession()
+	myNoid := uint16(30)
+	s.Avatar = &HabitatMod{Noid: &myNoid}
+	receiver, ok := uint8(10), uint8(1)
+	msg := &ElkoMessage{Noid: &receiver, Err: &ok}
+	Translators["HAND"].ToClient(msg, NewHabBufEmpty(), s)
+
+	if got := s.objects[24].container; got != receiver {
+		t.Errorf("item container = %d, want %d (receiver)", got, receiver)
+	}
+}
+
+// HAND failure reply must not move anything.
+func TestHandReplyFailureLeavesMapAlone(t *testing.T) {
+	s := incidentSession()
+	myNoid := uint16(30)
+	s.Avatar = &HabitatMod{Noid: &myNoid}
+	receiver, fail := uint8(10), uint8(0)
+	msg := &ElkoMessage{Noid: &receiver, Err: &fail}
+	Translators["HAND"].ToClient(msg, NewHabBufEmpty(), s)
+
+	if got := s.objects[24].container; got != 30 {
+		t.Errorf("item container = %d, want 30 (unchanged)", got)
+	}
+}
+
+// GRAB reply: the initiator (receiver) mirrors the grabbed item into
+// its own hand; item_noid 0 means refused.
+func TestGrabReplyMirrorsTake(t *testing.T) {
+	s := incidentSession()
+	myNoid := uint16(10)
+	s.Avatar = &HabitatMod{Noid: &myNoid}
+	victim, item := uint8(30), uint8(24)
+	msg := &ElkoMessage{Noid: &victim, ItemNoid: &item}
+	Translators["GRAB"].ToClient(msg, NewHabBufEmpty(), s)
+
+	if got := s.objects[24].container; got != 10 {
+		t.Errorf("item container = %d, want 10 (grabber)", got)
+	}
+}
+
+// GET reply: the initiator mirrors the picked-up item (reply noid)
+// into its own hand on success.
+func TestGetReplyMirrorsPickup(t *testing.T) {
+	s := incidentSession()
+	addTrackedObject(s, 12, "item-token", "Tokens", 0, 140)
+	myNoid := uint16(10)
+	s.Avatar = &HabitatMod{Noid: &myNoid}
+	itemNoid, ok := uint8(12), uint8(1)
+	msg := &ElkoMessage{Noid: &itemNoid, Err: &ok}
+	Translators["GET"].ToClient(msg, NewHabBufEmpty(), s)
+
+	item := s.objects[12]
+	if item.container != 10 {
+		t.Errorf("item container = %d, want 10", item.container)
+	}
+	if item.mod.Y == nil || *item.mod.Y != AVATAR_HAND {
+		t.Errorf("item slot = %v, want AVATAR_HAND", item.mod.Y)
+	}
+}

--- a/bridge_v2/bridge/server_ops.go
+++ b/bridge_v2/bridge/server_ops.go
@@ -88,8 +88,8 @@ func init() {
 			// recursive removeNoid sweep can later identify this
 			// object as a child of its current holder. See PUT$ for
 			// the full rationale.
-			if obj := s.objects[*o.ObjectNoid]; obj != nil {
-				obj.container = *o.ContainerNoid
+			if s != nil {
+				s.noteContainerChange(s.objects[*o.ObjectNoid], *o.ContainerNoid, u8(o.Y))
 			}
 			return false
 		},
@@ -175,6 +175,12 @@ func init() {
 		ToClient: func(o *ElkoMessage, buf *HabBuf, s *ClientSession) bool {
 			buf.AddInt(*o.Target)
 			buf.AddInt(*o.How)
+			// Mirror the pickup: the target item is now in the message
+			// avatar's hand. See noteContainerChange for why every
+			// container move must be tracked.
+			if s != nil && o.Noid != nil {
+				s.noteContainerChange(s.objects[*o.Target], *o.Noid, AVATAR_HAND)
+			}
 			return false
 		},
 	}
@@ -193,6 +199,18 @@ func init() {
 		Reqno: 17,
 		ToClient: func(o *ElkoMessage, buf *HabBuf, s *ClientSession) bool {
 			buf.AddInt(*o.AvatarNoid)
+			// Mirror the hand-to-hand transfer: the item in
+			// avatar_noid's hand moves into the message avatar's hand
+			// (C64 avatar_GRABFROM.m: changeContainers into the
+			// actor's AVATAR_HAND). Elko emits this for both the HAND
+			// and GRAB verbs. Skipping this mirror is what crashed a
+			// C64 with Fatal Error #11 on 2026-07-23: the giver left
+			// the region and the sweep GOAWAY'd the item out of the
+			// receiver's hand, so the item's next legitimate async
+			// referenced a noid the client had deleted.
+			if s != nil && o.Noid != nil {
+				s.noteContainerChange(s.handItem(*o.AvatarNoid), *o.Noid, AVATAR_HAND)
+			}
 			return false
 		},
 	}
@@ -341,8 +359,8 @@ func init() {
 			// of the region, removeNoid doesn't see it as a child,
 			// and the C64 client is left rendering the object as an
 			// orphan floating wherever the holder last stood.
-			if obj := s.objects[*o.ObjectNoid]; obj != nil {
-				obj.container = *o.Cont
+			if s != nil {
+				s.noteContainerChange(s.objects[*o.ObjectNoid], *o.Cont, u8(o.Y))
 			}
 			return false
 		},
@@ -462,6 +480,12 @@ func init() {
 			buf.AddInt(*o.X)
 			buf.AddInt(*o.Y)
 			buf.AddInt(*o.Hit)
+			// Mirror the throw: the object leaves the thrower's hand
+			// and lands on the region floor. Without this the sweep
+			// would GOAWAY a floor item when the thrower later exits.
+			if s != nil {
+				s.noteContainerChange(s.objects[*o.ObjectNoid], REGION_NOID, u8(o.Y))
+			}
 			return false
 		},
 	}

--- a/bridge_v2/bridge/translation.go
+++ b/bridge_v2/bridge/translation.go
@@ -24,6 +24,15 @@ func init() {
 	Translators["GET"] = &Translator{
 		ToClient: func(o *ElkoMessage, b *HabBuf, s *ClientSession) bool {
 			b.AddInt(u8(o.Err))
+			// The initiator of a transfer never sees the GET$/GRABFROM$
+			// neighbor async — its own containment map must be mirrored
+			// from the reply. GET runs on the item, so the reply noid
+			// IS the item; on success (err == TRUE = 1) it is now in
+			// our avatar's hand.
+			if s != nil && u8(o.Err) == 1 && o.Noid != nil &&
+				s.Avatar != nil && s.Avatar.Noid != nil {
+				s.noteContainerChange(s.objects[*o.Noid], uint8(*s.Avatar.Noid), AVATAR_HAND)
+			}
 			return false
 		},
 	}
@@ -628,6 +637,15 @@ func init() {
 	Translators["GRAB"] = &Translator{
 		ToClient: func(o *ElkoMessage, b *HabBuf, s *ClientSession) bool {
 			b.AddInt(u8(o.ItemNoid))
+			// Reply mirror (see GET): on success the reply carries the
+			// noid of the item we grabbed out of the other avatar's
+			// hand — it is now in our own hand. item_noid == 0 means
+			// the grab was refused.
+			if s != nil && s.Avatar != nil && s.Avatar.Noid != nil {
+				if itemNoid := u8(o.ItemNoid); itemNoid != 0 {
+					s.noteContainerChange(s.objects[itemNoid], uint8(*s.Avatar.Noid), AVATAR_HAND)
+				}
+			}
 			return false
 		},
 	}
@@ -635,6 +653,13 @@ func init() {
 	Translators["HAND"] = &Translator{
 		ToClient: func(o *ElkoMessage, b *HabBuf, s *ClientSession) bool {
 			b.AddInt(u8(o.Err))
+			// Reply mirror (see GET): HAND runs on the receiving
+			// avatar, so the reply noid is the receiver; on success
+			// the item leaves our hand for theirs.
+			if s != nil && u8(o.Err) == 1 && o.Noid != nil &&
+				s.Avatar != nil && s.Avatar.Noid != nil {
+				s.noteContainerChange(s.handItem(uint8(*s.Avatar.Noid)), *o.Noid, AVATAR_HAND)
+			}
 			return false
 		},
 	}


### PR DESCRIPTION
## The bug

The bridge expands elko's single avatar `delete` into per-noid GOAWAYs using its per-session containment map (`removeNoid`'s recursive sweep), but only `PUT$` and `CHANGE_CONTAINERS_$` kept that map current. Hand-to-hand transfers (`GRABFROM$` — emitted for both the HAND and GRAB verbs), floor pickups (`GET$`), and throws (`THROW$`) were never mirrored — and the *initiator* of a transfer, who gets only a reply rather than the neighbor async, was never mirrored at all.

## The incident (2026-07-23, Popustop.1019)

Randy handed his Change-O-Matic to Zarry (03:22:21, `GRABFROM$`) and walked out at 03:24:05. Ivan's C64 session still had the machine mapped inside Randy's avatar, so the sweep GOAWAY'd it out of Zarry's hand. Zarry's next (fully legitimate) CHANGE broadcast referenced a noid Ivan's client had been told to delete — the C64 correctly declared heap corruption: **Fatal Error #11** (`missing_object`, `comm_control.m`). Elko behaved correctly throughout; the stale map was ours.

## The fix

- `noteContainerChange()` centralizes the mirror (container + slot; a contained object's `y` is its slot index, per the C64 heap convention)
- `handItem()` resolves the object in an avatar's hand (`AVATAR_HAND = 5`, C64 `dataequates.m` / Java `Constants.HANDS`)
- Mirrors added: `GET$`, `GRABFROM$`, `THROW$` (bystander asyncs) and `GET`/`GRAB`/`HAND` reply translators (initiator side); `PUT$`/`CHANGE_CONTAINERS_$` now keep the slot fresh too
- Semantics ported from C64 `avatar_GRABFROM.m` (`changeContainers 0, AVATAR_HAND, actor_noid`) and Java `Avatar.HAND`/`GRAB`/`generic_GET`

## Verification

- `go vet` clean; full bridge suite passes (16.8s) including 9 new tests in `container_tracking_test.go` — among them an end-to-end regression of the incident: mirrored GRABFROM$ → sweep of the departed giver keeps the transferred item, and the control test confirms carried items still leave with their holder (the original orphan fix)
- Local compose stack: rebuilt bridge_v2, ran the synthetic new-user entry-flow e2e — corporeal arrival (noid 19, amAGhost=false), exactly one visa greeting, WelcomeBot ESP, no regressions
- Local test user and turf cleaned up (`$unset mods.0.resident`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)