### PR TITLE
feat(webclient): scale per-command pacing by room population

### DIFF
--- a/webclient/lib/app-shell.js
+++ b/webclient/lib/app-shell.js
@@ -37,7 +37,7 @@ import {
 import { Scale } from "../habirender/render.js"
 import { dispatchVerb } from "./verb-dispatch.js"
 import { actionFromCommand, CURSOR_NORMAL, CURSOR_GO, CURSOR_STOP } from "./cursor.mjs"
-import { BusyState, shouldPace, SETTLE_GAP_MS } from "./busy.mjs"
+import { BusyState, shouldPace, paceCount, minWaitMs, SETTLE_GAP_MS } from "./busy.mjs"
 import { modeState, MODE_REGION, MODE_INVENTORY, MODE_TEXT, MODE_CUSTOMIZE, resolveMode, pickFromContainerUI } from "./modes.js"
 import { InventoryView } from "./inventory-view.js"
 import { CustomizeView } from "./customize-view.js"
@@ -157,7 +157,7 @@ export async function createClientShell(adapter) {
   const withBusy = async (fn, icon = CURSOR_STOP) => {
     if (busy.value) return undefined
     busyIcon.value = icon
-    busyState.armCommand()
+    busyState.armCommand(nowMs())
     refreshBusy()
     try {
       const out = await fn()
@@ -167,7 +167,10 @@ export async function createClientShell(adapter) {
     } catch (e) {
       console.warn("[live] command failed:", e)
     } finally {
-      busyState.releaseCommand(nowMs())
+      // Per-command minimum wait, scaled by room population (BASE_WAIT_MS + PER_AVATAR_MS per
+      // additional avatar) — measured from arm, so it only holds a command whose own work
+      // finished faster than a C64's turn rate would. paceCount applies the ghost-as-#2 rule.
+      busyState.releaseCommand(nowMs(), minWaitMs(paceCount(world)))
       refreshBusy()
     }
   }

--- a/webclient/lib/busy.mjs
+++ b/webclient/lib/busy.mjs
@@ -10,7 +10,14 @@
 //     (maintain_flashing, cursor.m:195). All keyboard / joystick input is ignored while
 //     busy (keyboard.m:8-18 bails on command_selected, region_is_ready, custom_running).
 //   • start_cursor_flashing (cursor.m:233) also starts throttle_running — the C64 already
-//     imposed a post-command throttle. THROTTLE_MS is that throttle_duration.
+//     imposed a post-command throttle. We generalize that into a per-command MINIMUM WAIT
+//     (measured from when the command is armed) so the webclient can't issue commands faster
+//     than a C64's turn rate: BASE_WAIT_MS solo, +PER_AVATAR_MS for each additional avatar in
+//     the room. This emulates real C64 behavior — its frame rate (and thus command cadence)
+//     degrades as avatar_count rises (Main/actions.m, database.m), so an all-C64 room
+//     self-throttles to a shared turn rate; the instantly-responsive webclient has no such
+//     degradation and must reproduce it deliberately or it overruns a co-present C64's tiny
+//     serial buffer (the 2026-07-23 Ivan HELP/F7 congestion drop).
 //   • event_handler (comm_control.m:69) releases once the throttle expires and the reply
 //     lands; animation_wait_bit / reply_wait_bit are the "world settling" interlock, whose
 //     web analogs are the dispatch reply await + avatarMotion.whenIdle.
@@ -19,10 +26,12 @@
 // instantly, but a co-present native C64 must load resources from floppy (~1s per object in
 // an arriving contents vector; ~5s to load a newly-arrived avatar's head/hands/3 pockets).
 // We hold the cursor that much longer so the C64 stays in lockstep and isn't overrun — but
-// ONLY when someone else is present (shouldPace); solo play stays instant.
+// ONLY when someone else is present (shouldPace); the co-presence catch-up stays off in solo
+// play (the base per-command wait below still applies).
 
 // ── tunable constants (calibrate against the C64 flash_rate / throttle_duration + VICE) ──
-export const THROTTLE_MS = 250 // base post-command throttle (always on — faithful per-command)
+export const BASE_WAIT_MS = 2000 // minimum wait per command, solo — a C64-like per-command turn rate
+export const PER_AVATAR_MS = 1000 // added to the minimum wait for each additional avatar in the room
 export const OBJECT_LOAD_MS = 1000 // co-presence: per object in a make-storm I triggered
 export const ARRIVAL_MS = 5000 // co-presence: hold on my own arrival (others load my avatar)
 export const SETTLE_GAP_MS = 300 // a make-storm is "settled" after this quiet gap
@@ -42,6 +51,28 @@ export function shouldPace(world, meNoid = world && world.meNoid) {
   return !!ghost && meNoid !== GHOST_NOID
 }
 
+// paceCount returns N — the number of command-generating occupants in the room, INCLUDING me
+// — which scales the per-command minimum wait (minWaitMs). Each corporeal avatar counts: they
+// issue commands, and their resulting traffic is what a co-present C64 must absorb. A lone
+// observing ghost (noid 255 — one or more ghosted watchers ride the single record) counts as
+// avatar #2 and NO more: ghosting exists partly to shed a non-essential avatar's command /
+// traffic load, so a ghost is presence without command generation. Once ≥2 corporeal avatars
+// are here, the ghost adds nothing. Reads world; never mutates it.
+export function paceCount(world, meNoid = world && world.meNoid) {
+  if (!world || typeof world.avatars !== "function") return 1
+  const corporeal = world.avatars().length // includes me when I'm corporeal
+  if (corporeal >= 2) return corporeal
+  const ghost = typeof world.ghost === "function" ? world.ghost() : null
+  if (ghost && meNoid !== GHOST_NOID) return 2 // a lone observing ghost is avatar #2
+  return Math.max(1, corporeal)
+}
+
+// minWaitMs maps a room population (paceCount) to the per-command minimum wait: BASE_WAIT_MS
+// alone, plus PER_AVATAR_MS for every avatar beyond the first (2s, 3s, 4s… for 1, 2, 3…).
+export function minWaitMs(count) {
+  return BASE_WAIT_MS + PER_AVATAR_MS * Math.max(0, count - 1)
+}
+
 // The busy state. Two overlapping notions of "busy", mirroring the C64:
 //   • commandActive — a command of mine is in flight (command_selected >= 0). True from
 //     armCommand() until releaseCommand(); makes that land in this window are "mine" and
@@ -56,13 +87,16 @@ export class BusyState {
     this.busyUntil = 0
     this.lastMakeAt = 0 // when the most recent make landed (for the settle gap)
     this.sawMakeThisCommand = false
+    this.commandArmedAt = 0 // when the outstanding command was armed (base-floor anchor)
   }
 
   // A user command begins (pie verb / gesture / F-key / speak-verb / edge-walk). Freeze +
   // blink immediately; the wall-clock tail is set at release once we know reply/anim/storm.
-  armCommand() {
+  // `now` anchors the per-command minimum-wait floor (see releaseCommand).
+  armCommand(now = 0) {
     this.commandActive = true
     this.sawMakeThisCommand = false
+    this.commandArmedAt = now
     return this
   }
 
@@ -78,10 +112,13 @@ export class BusyState {
   }
 
   // The command's reply + animation have completed and its make-storm has settled. End the
-  // command-active freeze and set the throttle tail (always — faithful throttle_duration).
-  releaseCommand(now) {
+  // command-active freeze and enforce the per-command MINIMUM WAIT, measured from when the
+  // command was ARMED — so a command whose own work already outran the floor adds nothing,
+  // while a trivial one is still held to it. minWait = BASE_WAIT_MS + PER_AVATAR_MS × (others
+  // in the room); the caller passes minWaitMs(paceCount(world)). Defaults to the solo base.
+  releaseCommand(now, minWait = BASE_WAIT_MS) {
     this.commandActive = false
-    this.busyUntil = Math.max(this.busyUntil, now + THROTTLE_MS)
+    this.busyUntil = Math.max(this.busyUntil, this.commandArmedAt + minWait)
     return this
   }
 
@@ -106,6 +143,7 @@ export class BusyState {
     this.busyUntil = 0
     this.lastMakeAt = 0
     this.sawMakeThisCommand = false
+    this.commandArmedAt = 0
     return this
   }
 

--- a/webclient/test-busy.mjs
+++ b/webclient/test-busy.mjs
@@ -1,12 +1,12 @@
 // Node tests: the busy/wait-cursor state machine (lib/busy.mjs).
 import {
-  BusyState, shouldPace,
-  THROTTLE_MS, OBJECT_LOAD_MS, ARRIVAL_MS, SETTLE_GAP_MS,
+  BusyState, shouldPace, paceCount, minWaitMs,
+  BASE_WAIT_MS, PER_AVATAR_MS, OBJECT_LOAD_MS, ARRIVAL_MS, SETTLE_GAP_MS,
 } from "./lib/busy.mjs"
 
 const assert = (cond, msg) => { if (!cond) throw new Error(msg) }
 
-// A minimal world stub for shouldPace (only avatars()/ghost()/meNoid are read).
+// A minimal world stub for shouldPace/paceCount (only avatars()/ghost()/meNoid are read).
 const world = ({ avatars = [], ghost = null, meNoid = 1 }) => ({
   meNoid,
   avatars: () => avatars,
@@ -22,40 +22,74 @@ const world = ({ avatars = [], ghost = null, meNoid = 1 }) => ({
   assert(shouldPace(null) === false, "no world → no pace")
 }
 
-// ── base throttle: ALWAYS applied at release, even alone (faithful throttle_duration) ──
+// ── paceCount: corporeal occupants incl. me; a lone ghost counts only as avatar #2 ──
+{
+  assert(paceCount(world({ avatars: [{ noid: 1 }], meNoid: 1 })) === 1, "alone → 1")
+  assert(paceCount(world({ avatars: [{ noid: 1 }, { noid: 7 }], meNoid: 1 })) === 2, "two avatars → 2")
+  assert(paceCount(world({ avatars: [{ noid: 1 }, { noid: 7 }, { noid: 9 }], meNoid: 1 })) === 3, "three avatars → 3")
+  assert(paceCount(world({ avatars: [{ noid: 1 }], ghost: { noid: 255 }, meNoid: 1 })) === 2, "me + a lone ghost → 2 (ghost is avatar #2)")
+  assert(paceCount(world({ avatars: [{ noid: 1 }, { noid: 7 }], ghost: { noid: 255 }, meNoid: 1 })) === 2, "ghost adds nothing once ≥2 real avatars")
+  assert(paceCount(world({ avatars: [], ghost: { noid: 255 }, meNoid: 255 })) === 1, "I AM the ghost, empty room → 1 (no self-pace)")
+  assert(paceCount(null) === 1, "no world → 1")
+}
+
+// ── minWaitMs: 2s base, +1s per additional avatar (the agreed progression table) ──
+{
+  assert(minWaitMs(1) === BASE_WAIT_MS, "1 avatar → 2s base")
+  assert(minWaitMs(2) === BASE_WAIT_MS + PER_AVATAR_MS, "2 avatars → 3s")
+  assert(minWaitMs(3) === BASE_WAIT_MS + 2 * PER_AVATAR_MS, "3 avatars → 4s")
+  assert(minWaitMs(6) === BASE_WAIT_MS + 5 * PER_AVATAR_MS, "6 avatars → 7s")
+}
+
+// ── base per-command floor: minimum wait measured from ARM (BASE_WAIT_MS solo) ──
 {
   const b = new BusyState()
-  b.armCommand()
+  b.armCommand(1000)
   assert(b.isBusy(1000) === true, "command-active → busy immediately")
-  b.releaseCommand(1000)
+  b.releaseCommand(1000) // solo default = BASE_WAIT_MS, anchored at the arm time (1000)
   assert(b.commandActive === false, "release clears command-active")
-  assert(b.isBusy(1000) === true, "throttle tail keeps it busy at release")
-  assert(b.isBusy(1000 + THROTTLE_MS - 1) === true, "still busy just before throttle expires")
-  assert(b.isBusy(1000 + THROTTLE_MS) === false, "idle once throttle expires")
-  assert(b.msUntilIdle(1000) === THROTTLE_MS, "msUntilIdle = THROTTLE_MS right after release")
+  assert(b.isBusy(1000 + BASE_WAIT_MS - 1) === true, "held until the base floor (from arm)")
+  assert(b.isBusy(1000 + BASE_WAIT_MS) === false, "idle once the base floor passes")
+}
+{
+  // A command whose natural work already outran the floor gets NO extra hold.
+  const b = new BusyState()
+  b.armCommand(1000)
+  b.releaseCommand(1000 + BASE_WAIT_MS + 500) // released well past the floor
+  assert(b.isBusy(1000 + BASE_WAIT_MS + 500) === false, "no added hold when natural work outran the floor")
+}
+{
+  // Population scaling: 3 avatars → base + 2×per-avatar minimum wait, from arm.
+  const b = new BusyState()
+  b.armCommand(1000)
+  const wait = minWaitMs(3)
+  b.releaseCommand(1000, wait)
+  assert(b.isBusy(1000 + wait - 1) === true, "held until the scaled (4s) floor")
+  assert(b.isBusy(1000 + wait) === false, "idle at the scaled floor")
 }
 
 // ── make-storm accrual: 1s per object, ONLY while a command is outstanding, ONLY when paced ──
 {
   // Paced (someone else present): each make adds OBJECT_LOAD_MS.
   const b = new BusyState()
-  b.armCommand()
+  b.armCommand(1000)
   b.noteMake(1000, true)
   b.noteMake(1000, true)
   b.noteMake(1000, true)
-  b.releaseCommand(1000)
-  // three objects → ~3s of catch-up, dominating the base throttle
+  b.releaseCommand(1000) // solo base floor (3000) < storm tail (4000) → storm dominates
+  // three objects → ~3s of catch-up from t=1000, dominating the 2s base floor
   assert(b.isBusy(1000 + 3 * OBJECT_LOAD_MS - 1) === true, "3 objects ≈ 3s of hold")
-  assert(b.isBusy(1000 + 3 * OBJECT_LOAD_MS + THROTTLE_MS) === false, "released after the storm drains")
+  assert(b.isBusy(1000 + 3 * OBJECT_LOAD_MS) === false, "released after the storm drains")
 }
 {
-  // Unpaced (alone): makes during a command do NOT accrue catch-up time; only base throttle.
+  // Unpaced (alone): makes during a command do NOT accrue catch-up time; only the base floor.
   const b = new BusyState()
-  b.armCommand()
+  b.armCommand(1000)
   b.noteMake(1000, false)
   b.noteMake(1000, false)
   b.releaseCommand(1000)
-  assert(b.isBusy(1000 + THROTTLE_MS) === false, "alone: no per-object hold, just throttle")
+  assert(b.isBusy(1000 + BASE_WAIT_MS - 1) === true, "alone: held to the base floor")
+  assert(b.isBusy(1000 + BASE_WAIT_MS) === false, "alone: no per-object hold, just the base floor")
 }
 {
   // Idle makes (no command outstanding) are inert — the ATM-coin case: another user's action
@@ -70,7 +104,7 @@ const world = ({ avatars = [], ghost = null, meNoid = 1 }) => ({
 // ── storm settle: quiet gap after the last make ──
 {
   const b = new BusyState()
-  b.armCommand()
+  b.armCommand(1000)
   assert(b.stormSettled(1000) === true, "no makes yet → settled")
   b.noteMake(1000, true)
   assert(b.stormSettled(1000) === false, "just saw a make → not settled")
@@ -94,9 +128,9 @@ const world = ({ avatars = [], ghost = null, meNoid = 1 }) => ({
 {
   const b = new BusyState()
   b.armArrival(1000, true) // until 1000 + ARRIVAL_MS
-  b.armCommand()
-  b.releaseCommand(1000) // throttle tail is far shorter than the arrival hold
-  assert(b.isBusy(1000 + ARRIVAL_MS - 1) === true, "the longer (arrival) hold wins, not the throttle")
+  b.armCommand(1000)
+  b.releaseCommand(1000) // base floor is far shorter than the arrival hold
+  assert(b.isBusy(1000 + ARRIVAL_MS - 1) === true, "the longer (arrival) hold wins, not the base floor")
 }
 
 console.log("test-busy: ok")


### PR DESCRIPTION
## What

The webclient's command-cadence pacing (`busy.mjs`) applied a **flat 250ms** base throttle regardless of room population, gated only by a binary `shouldPace` (any other avatar present → pace). A webclient stays instantly responsive no matter how crowded a region is, so with several avatars present it still issued commands faster than a co-present C64 could drain them.

An all-C64 room doesn't have this problem: each C64's frame rate (and thus command cadence) **degrades with `avatar_count`**, so the room self-throttles to a shared "turn rate." The webclient never matched that curve — which produced the **2026-07-23 Ivan HELP/F7 congestion drop**: a co-present C64 fell behind, its QLink send window grew unboundedly, and the session eventually died.

## Change

Replace the flat throttle with a per-command **minimum wait** that scales with room population:

```
min wait = BASE_WAIT_MS (2s) + PER_AVATAR_MS (1s) × (N − 1)
```

- `N` = command-generating occupants (`paceCount`). Progression: **2s solo, 3s / 4s / 5s… for 2 / 3 / 4 avatars.**
- The floor is measured **from when the command was armed**, so a command whose own reply/animation/make-storm already outran it adds nothing (a changomatic op is unchanged); only faster commands are held to the floor.
- **Ghost rule** (`paceCount`): a lone observing ghost counts as avatar #2 and no more — ghosting exists partly to shed a non-essential avatar's command/traffic load, so it's presence without command generation; once ≥2 corporeal avatars are present it adds nothing.

## Scope

Client-side only (`webclient/`). The make-storm catch-up (`OBJECT_LOAD_MS`) and arrival hold (`ARRIVAL_MS`) co-presence delays are **untouched**; `shouldPace` still gates those. All three waits combine via `max()` on `busyUntil`, not addition.

## Testing

- `node webclient/test-busy.mjs` → `test-busy: ok` (added coverage for `paceCount`, `minWaitMs`, the arm-relative base floor, and population scaling).
- Validated live on local dev — feels like classic C64 responsiveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)