### PR TITLE
fix(pushserver): pin brace-expansion to 1.1.16 (GHSA-3jxr)

### DIFF
--- a/pushserver/package-lock.json
+++ b/pushserver/package-lock.json
@@ -191,6 +191,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/bson": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
@@ -678,16 +688,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/glob/node_modules/minimatch": {

--- a/pushserver/package.json
+++ b/pushserver/package.json
@@ -27,6 +27,7 @@
   "overrides": {
     "@maximegris/node-websockify": {
       "ws": "^8.17.1"
-    }
+    },
+    "brace-expansion": "1.1.16"
   }
 }


### PR DESCRIPTION
Clears open Dependabot alert **#183** (high): the nested `brace-expansion` in `pushserver/` (`yamljs → glob → minimatch`) resolved to **1.1.14**, vulnerable to exponential-time expansion of consecutive non-expanding `{}` groups (GHSA-3jxr-9vmj-r5cp).

Adds an `overrides` entry pinning `brace-expansion` to **1.1.16** (the patched 1.x), which satisfies `minimatch`'s `^1.1.7`. Lockfile regenerated (`--package-lock-only`); 0 occurrences of 1.1.14 remain. pushserver has no 5.x brace-expansion, so a global pin here is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)