### PR TITLE
fix(pushserver): bump brace-expansion pin to 1.1.18 (GHSA)

### DIFF
--- a/pushserver/package-lock.json
+++ b/pushserver/package-lock.json
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/pushserver/package.json
+++ b/pushserver/package.json
@@ -28,6 +28,6 @@
     "@maximegris/node-websockify": {
       "ws": "^8.17.1"
     },
-    "brace-expansion": "1.1.16"
+    "brace-expansion": "1.1.18"
   }
 }


### PR DESCRIPTION
## What
Bumps the pushserver `brace-expansion` override from `1.1.16` → `1.1.18` and regenerates the lockfile.

## Why
The `1.1.16` pin from #645 is now flagged by a newer advisory (affected `< 1.1.18`). Dependabot's security updater for pushserver has been **erroring out** because the resolution path can't climb past the pinned `1.1.16` (`fix_available: false` — "the available update path still resolves it to 1.1.16"). This clears that failure and moves pushserver to the patched 1.x release.

- npm-only change; no Elko / prod behavior change.
- `npm install` reports 0 vulnerabilities after the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)