### PR TITLE
fix(bridge): align semconv with otel 1.45.0 so the bridge starts

### DIFF
--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -308,6 +308,55 @@
         - 1986
         - 2026
 
+    # The port checks above CANNOT detect a failed tableflip upgrade. When the
+    # new child dies during startup, the old process keeps its listeners, so
+    # 1337/1986/2026 all answer and the deploy goes green while prod quietly
+    # carries on running the previous binary.
+    #
+    # That is not hypothetical: the otel 1.45.0 bump shipped a binary that
+    # exited 1 in OpenTelemetry init ("conflicting Schema URL"). tableflip kept
+    # the old process alive — no outage, which is the design working — but the
+    # deploy reported success and the change was not live. It was only found by
+    # hand-checking /proc/<pid>/exe afterwards.
+    #
+    # After a successful re-exec the running process executes the file now on
+    # disk. After a failed one it is still executing the inode that `mv`
+    # replaced, which the kernel marks "(deleted)". That is the signal.
+    - name: Verify bridge_v2 re-exec actually took (running binary is the one we shipped)
+      shell: |
+        set -u
+        pid=$(systemctl show bridge_v2.service -p MainPID --value)
+        if [ -z "$pid" ] || [ "$pid" = "0" ]; then
+          echo "FAIL: bridge_v2 has no MainPID"
+          exit 1
+        fi
+        exe=$(readlink "/proc/$pid/exe" || echo "<unreadable>")
+        echo "MainPID=$pid exe=$exe"
+        case "$exe" in
+          *"(deleted)")
+            echo "FAIL: bridge_v2 is STILL RUNNING THE PREVIOUS BINARY."
+            echo "The tableflip re-exec did not take — the new binary most likely"
+            echo "crashed during startup. Prod is up on the old build; the change"
+            echo "you just deployed is NOT live. Recent journal:"
+            # Match the upgrade path specifically. A plain "error" grep drowns
+            # in routine per-client EOF noise and buries the real cause.
+            journalctl -u bridge_v2 --since "-10 min" --no-pager 2>/dev/null \
+              | grep -iE "graceful upgrade|Upgrade failed|level\":\"fatal|panic" \
+              | tail -15 || true
+            exit 1
+            ;;
+        esac
+        echo "OK: running binary matches the deployed file"
+      become: true
+      when: bv2_binary_changed
+      register: bv2_reexec_check
+      changed_when: false
+      # The tableflip handoff and its sd_notify(MAINPID=) are asynchronous, so
+      # give systemd a few seconds to start tracking the child before judging.
+      retries: 6
+      delay: 5
+      until: bv2_reexec_check.rc == 0
+
     # ── everyone else ────────────────────────────────────────────────
     - name: Bring up non-bridge services (recreate only on image change)
       # Explicit service list — bridge_v2 isn't in docker anymore (it's

--- a/bridge_v2/observability/otel.go
+++ b/bridge_v2/observability/otel.go
@@ -24,15 +24,25 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+	// MUST track the semconv version that sdk/resource itself imports —
+	// resource.Merge refuses to merge two resources with conflicting schema
+	// URLs, so a mismatch here is a FATAL error at startup, not a warning.
+	// otel sdk 1.45.0 moved resource.Default() from schema 1.41.0 to 1.43.0.
+	// See buildResource and TestBuildResource.
+	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
 )
 
-// Init wires up the global tracer and meter providers and starts the
-// Go runtime metrics collector. The returned shutdown function flushes
-// both providers and should be called from the SIGINT path before
-// process exit so in-flight spans and metric data points reach the
-// collector.
-func Init(ctx context.Context, serviceName, version string) (func(context.Context) error, error) {
+// semconvSchemaURL is the schema URL of the semconv package imported above.
+// Named here so the drift test checks the SAME import production code uses,
+// rather than importing semconv a second time and drifting independently.
+const semconvSchemaURL = semconv.SchemaURL
+
+// buildResource merges the SDK's default resource with our service identity.
+//
+// Split out of Init purely so it can be tested without a collector: this is the
+// one part of OTel setup that can fail on a plain dependency bump, and Init as a
+// whole needs a live OTLP endpoint to run.
+func buildResource(serviceName, version string) (*resource.Resource, error) {
 	res, err := resource.Merge(
 		resource.Default(),
 		resource.NewWithAttributes(
@@ -43,6 +53,19 @@ func Init(ctx context.Context, serviceName, version string) (func(context.Contex
 	)
 	if err != nil {
 		return nil, fmt.Errorf("build resource: %w", err)
+	}
+	return res, nil
+}
+
+// Init wires up the global tracer and meter providers and starts the
+// Go runtime metrics collector. The returned shutdown function flushes
+// both providers and should be called from the SIGINT path before
+// process exit so in-flight spans and metric data points reach the
+// collector.
+func Init(ctx context.Context, serviceName, version string) (func(context.Context) error, error) {
+	res, err := buildResource(serviceName, version)
+	if err != nil {
+		return nil, err
 	}
 
 	traceExp, err := otlptracehttp.New(ctx)

--- a/bridge_v2/observability/otel_test.go
+++ b/bridge_v2/observability/otel_test.go
@@ -1,0 +1,66 @@
+package observability
+
+import (
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+// An otel bump that moves resource.Default()'s schema URL away from the semconv
+// package this file imports makes resource.Merge fail, and Init() treats that as
+// fatal — the bridge exits 1 on startup.
+//
+// That is exactly what otel 1.45.0 did: sdk/resource moved from semconv v1.41.0
+// to v1.43.0 while this package still imported v1.41.0. Nothing caught it. The
+// build was clean, vet was clean, every existing test passed, and the image built
+// — because no test and no smoke path ever ran the --otel.enabled branch. It only
+// surfaced when the deployed binary refused to start in production.
+//
+// So: exercise the merge directly. It needs no collector and no network.
+func TestBuildResource(t *testing.T) {
+	res, err := buildResource("bridge_v2", "test")
+	if err != nil {
+		t.Fatalf("buildResource failed — this is the startup-fatal path.\n"+
+			"If this says \"conflicting Schema URL\", the semconv import in otel.go has\n"+
+			"drifted from the one sdk/resource uses; realign it with the SDK.\nerror: %v", err)
+	}
+
+	// A conflicting merge can also silently yield an empty schema URL rather than
+	// an error, which would ship a resource the collector can't attribute.
+	if res.SchemaURL() == "" {
+		t.Error("merged resource has an empty schema URL")
+	}
+	if want := resource.Default().SchemaURL(); res.SchemaURL() != want {
+		t.Errorf("merged schema URL = %q, want %q (the SDK default)", res.SchemaURL(), want)
+	}
+
+	attrs := res.Attributes()
+	found := map[string]string{}
+	for _, kv := range attrs {
+		found[string(kv.Key)] = kv.Value.Emit()
+	}
+	if found["service.name"] != "bridge_v2" {
+		t.Errorf("service.name = %q, want %q", found["service.name"], "bridge_v2")
+	}
+	if found["service.version"] != "test" {
+		t.Errorf("service.version = %q, want %q", found["service.version"], "test")
+	}
+}
+
+// The schema URL our semconv import declares must be the SDK's, stated as a
+// standalone check so a failure names the drift directly instead of surfacing as
+// a confusing merge error.
+func TestSemconvMatchesSDKResource(t *testing.T) {
+	sdkURL := resource.Default().SchemaURL()
+	ours := resource.NewWithAttributes(semconvSchemaURL)
+	if ours.SchemaURL() != sdkURL {
+		t.Fatalf("semconv drift: observability/otel.go imports schema %q but\n"+
+			"go.opentelemetry.io/otel/sdk/resource uses %q.\n"+
+			"Update the semconv import in otel.go to match the SDK.",
+			ours.SchemaURL(), sdkURL)
+	}
+	if !strings.HasPrefix(sdkURL, "https://opentelemetry.io/schemas/") {
+		t.Errorf("unexpected schema URL form: %q", sdkURL)
+	}
+}


### PR DESCRIPTION
Follow-up to #661. **That bump shipped a bridge binary that cannot start.**

```
{"level":"fatal","error":"build resource: conflicting Schema URL:
 https://opentelemetry.io/schemas/1.43.0 and https://opentelemetry.io/schemas/1.41.0",
 "message":"Could not initialize OpenTelemetry"}
{"level":"error","error":"child pid=3657759 exited: exit status 1","message":"Upgrade failed"}
```

otel sdk 1.45.0 moved `resource.Default()` from semconv `v1.41.0` to `v1.43.0`; `observability/otel.go` still imported `v1.41.0`. `resource.Merge` refuses conflicting schema URLs and `Init` treats that as fatal.

### Prod was never down

tableflip saw the child exit and kept the old process serving — the graceful-upgrade design working as intended. But `/proc/<pid>/exe` on the made shows `→ /opt/neohabitat/bin/bridge_v2 (deleted)`: it is still executing the **25 Jul** inode. The deploy reported success anyway, and the next hard restart would have failed.

### What's here

1. **`semconv/v1.43.0`** — match what `sdk/resource` uses.
2. **`buildResource()` + tests.** Nothing caught this: build, vet, every existing test and `compose-smoke` all passed, because none exercise the `--otel.enabled` branch. The resource merge is the one part of OTel setup a dependency bump can break, and it needs no collector to test. `TestSemconvMatchesSDKResource` names the drift explicitly next time.
3. **Deploy detects a failed re-exec.** The port checks can't — the old process keeps its listeners, so `1337/1986/2026` answer and the deploy goes green. After a successful re-exec the process executes the file on disk; after a failed one it's on the inode `mv` replaced, marked `(deleted)`. That's the assertion.

### Verification

- New test **reproduces the exact production error** against the `v1.41.0` import, passes on `v1.43.0`
- `go build` / `go vet` / `go test ./...` green on `golang:1.25`
- Built binary now logs `OpenTelemetry initialized` under `--otel.enabled` instead of exiting 1
- Deploy check run **read-only against prod**, where it correctly exits 1 and prints the `SIGHUP → fatal → Upgrade failed` sequence

After merge the deploy will re-exec the bridge onto a binary that actually starts — worth watching that the new step goes green rather than firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)