### PR TITLE
fix(dev): bridge_v2 survives a reboot, and dev.sh gets NET_ADMIN back

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,6 +22,14 @@ services:
       context: ./bridge_v2
       dockerfile: Dockerfile.dev
     command: ["air"]
+    # Without this the bridge is the ONLY dev service that does not come back after a
+    # reboot or a Docker restart: every other service inherits `restart: unless-stopped`
+    # from docker-compose.yml, but bridge_v2 is defined only in the dev overlays, so it
+    # defaulted to `restart: no`. Air exits 0 on SIGTERM ("see you again~"), and a 0 exit
+    # is indistinguishable from a deliberate stop to `on-failure` — `unless-stopped` is
+    # what actually restores it on daemon start, while still respecting an explicit
+    # `docker compose stop bridge_v2`.
+    restart: unless-stopped
     # Repo-local .env (see .env.example). Picks up any bridge-relevant
     # overrides (log levels, debug flags) without compose edits.
     env_file:
@@ -35,10 +43,22 @@ services:
     ports:
       - "2026:2026"
       - "2027:2027"
-    # cap_add: [NET_ADMIN] and security_opt: [seccomp:unconfined] come from
-    # docker-compose.override.yml's bridge_v2 (always merged into the dev project). Compose
-    # concatenates list fields across files, and duplicate security_opt items are now a hard
-    # validation error ("items at 0 and 1 are equal"), so they must NOT be repeated here.
+    # TCP_REPAIR (bridge/tcp_repair.go) needs CAP_NET_ADMIN, and the seccomp default
+    # profile blocks the socket options it sets. Without both, a SIGHUP graceful upgrade
+    # still "succeeds" but drops every live session — the exact tableflip path that broke
+    # silently in prod (#661/#663), so dev must be able to exercise it.
+    #
+    # These used to be omitted here with a comment claiming they were inherited from
+    # docker-compose.override.yml because it is "always merged into the dev project".
+    # That is not true: dev.sh runs `docker compose -f docker-compose.yml -f
+    # docker-compose.dev.yml`, and passing any -f DISABLES auto-loading of the override
+    # file. The dev.sh bridge was running with no added capabilities at all. Nothing
+    # merges this file and override.yml together (CI uses base only; ansible uses
+    # base+prod+monitoring), so there is no duplicate-list-item validation error to avoid.
+    cap_add:
+      - NET_ADMIN
+    security_opt:
+      - seccomp:unconfined
     networks:
       - neohabitat
     depends_on:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -57,6 +57,11 @@ services:
       context: ./bridge_v2
       dockerfile: Dockerfile.dev
     command: ["air"]
+    # See the matching note in docker-compose.dev.yml. bridge_v2 is absent from the base
+    # docker-compose.yml, so it inherits no restart policy and defaulted to `restart: no`
+    # — the one dev service that stayed down after a reboot. Kept in sync here because
+    # this file, not dev.yml, is what a bare `docker compose up` uses.
+    restart: unless-stopped
     env_file:
       - path: .env
         required: false


### PR DESCRIPTION
`bridge_v2` was the only dev service that stayed down after a reboot or a Docker daemon
restart. It is defined solely in the two dev overlays and is absent from
`docker-compose.yml`, so it never inherited the base file's `restart: unless-stopped` and
silently defaulted to `restart: no`.

Observed live while investigating something else: mongo, elko and bots all showed
`Up 31 minutes` from a daemon restart while the bridge sat at `Exited (0) 20 hours ago`.
The exit was code 0 with air's `cleaning... see you again~` — a clean SIGTERM, not a crash.
Every bot had been unable to reach `:2026` for those 20 hours.

## Resolved config for `bridge_v2`, by invocation path

Both columns come from running `docker compose config` against the real files —
`origin/master` for before, this branch for after — not from reading YAML.

| Path | Command | `restart` | `cap_add` | `security_opt` |
|---|---|---|---|---|
| **dev.sh** | `-f compose.yml -f compose.dev.yml` | *(absent)* → **`unless-stopped`** | *(none)* → **`NET_ADMIN`** | *(none)* → **`seccomp:unconfined`** |
| **bare** | `docker compose up` | *(absent)* → **`unless-stopped`** | `NET_ADMIN` → unchanged | `seccomp:unconfined` → unchanged |
| **CI** | `-f compose.yml` | service absent → absent | — | — |
| **prod** | `-f compose.yml -f prod -f monitoring` | service absent → absent | — | — |

*(absent)* means the key is not in the resolved config, so Docker applies its default of
`restart: no`.

## Observable behavior

| Behavior | Before | After |
|---|---|---|
| Survives host reboot / daemon restart | ❌ stays down | ✅ comes back |
| Survives a process crash | ❌ stays down | ✅ ~2s, `restartCount=1` |
| Respects deliberate `compose stop` | ✅ | ✅ unchanged |
| Bots reach `:2026` after a reboot | ❌ blocked until noticed | ✅ reconnect automatically |
| **dev.sh** can exercise TCP_REPAIR graceful upgrade | ❌ no `CAP_NET_ADMIN` | ✅ |
| **bare** can exercise TCP_REPAIR | ✅ | ✅ unchanged |
| CI `compose-smoke` | no bridge | no bridge, unchanged |
| Production | host systemd unit | host systemd unit, unchanged |

## Why `unless-stopped`

Air exits **0** on SIGTERM, and a 0 exit is indistinguishable from a deliberate stop to
`on-failure`. `on-failure` containers are also not restarted on daemon start at all, so it
would not have fixed the reported problem. `always` would fix it but would resurrect a
container after an intentional `docker compose stop bridge_v2`. `unless-stopped` restores it
on daemon start while still respecting an explicit stop — and it matches what every other
service in `docker-compose.yml` already uses.

Added to **both** overlays: `dev.sh` uses `docker-compose.dev.yml`, a bare `docker compose up`
uses `docker-compose.override.yml`, and either can be the live one.

## Second, separate bug fixed here

Working out which overlay actually applies turned up something worse. A comment in `dev.yml`
claimed `cap_add`/`security_opt` were inherited from `docker-compose.override.yml` because it
is "always merged into the dev project". That is not true — `dev.sh` passes
`-f docker-compose.yml -f docker-compose.dev.yml`, and **passing any `-f` disables
auto-loading of the override file**. The `dev.sh` bridge was running with no added
capabilities at all.

TCP_REPAIR (`bridge/tcp_repair.go`) needs `CAP_NET_ADMIN` and trips the default seccomp
profile, so that path could not exercise a graceful upgrade with session preservation —
the tableflip mechanism whose *silent* failure caused #661/#663 was untestable in dev on the
path `dev.sh` uses. The caps are now declared there, and the false comment is replaced with
what is actually true.

Nothing merges the two overlays together (CI uses base only; ansible uses
base+prod+monitoring), so the duplicate list-item validation error the old comment guarded
against cannot occur.

## Verification

- All four resolution paths (dev.sh / bare / CI / prod) produce the intended config
- SIGKILL of the container's host PID → auto-recovered in ~2s, `restartCount=1`
  (note: `docker kill` does **not** test this — it marks the container manually stopped,
  which disables the restart policy)
- Full `service docker restart` → all four services came back, bridge included,
  re-initializing OTel and binding `:2027`; bots reconnected
- Production untouched by construction: the diff touches only `docker-compose.dev.yml` and
  `docker-compose.override.yml`, and ansible loads neither

Caveat: the reboot row was verified with `service docker restart`, which is the daemon-start
code path a real reboot takes. The machine itself was not rebooted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01St52LGEnJ56ctEpePDYFqD
