### PR TITLE
fix(pushserver): events page pointed at a dead Discord invite

### DIFF
--- a/pushserver/views/events.ejs
+++ b/pushserver/views/events.ejs
@@ -80,7 +80,7 @@
           </a>
         </div>
         <div class="col-2">
-          <a href="https://discord.gg/nk7HwAGF" target="_blank">
+          <a href="https://discord.gg/rspcX27Vt4" target="_blank">
             <h4>Neohabitat Discord</h4>
           </a>
         </div>


### PR DESCRIPTION
The **Neohabitat Discord** link on the events page used invite code `nk7HwAGF`, which Discord now answers with `Unknown Invite` (error 10006). Anyone clicking through from the public events page hit a dead end.

Every other invite in the repo — README, README-RealC64, PROTOCOL, `docs/`, and the webclient/emulator help pages — already uses `rspcX27Vt4`, which resolves to **The MADE** and lands in `#habitat-general`. This points the events page at the same one.

After the change all 14 `discord.gg/` links in the repo are identical:

```
$ grep -rho "discord\.gg/[A-Za-z0-9]*" --include="*" . | sort | uniq -c
     14 discord.gg/rspcX27Vt4
```

One-line view change in `pushserver`, found incidentally while researching Discord administration tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01St52LGEnJ56ctEpePDYFqD