### PR TITLE
feat(oracle): answer oracle requests from Discord as in-world mail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,9 +31,32 @@
 # external instance.
 # HABIBOTS_MONGO_URL=mongodb://neohabitatmongo:27017
 
-# Slack integration for greeter / hatchery / oracle bots. Leave unset
-# to disable Slack relays.
+# Slack integration for the greeter / hatchery bots. Leave unset to
+# disable Slack relays.
 # HABIBOTS_SLACK_TOKEN=
+
+# ── Oracle bot (Discord -> in-world mail) ─────────────────────────
+# Lets an Oracle answer a request from #oracle-requests: right-click the
+# message -> Apps -> "Answer as the Oracle", and the reply is mailed to
+# the asker in-world. Needs a real bot account (a webhook can only post),
+# with View Channel + Send Messages + Read Message History on that
+# channel. No privileged intents. All three of TOKEN / GUILD_ID /
+# CHANNEL_ID must be set or the oracle bot doesn't start.
+#
+# Prod-only in practice: pointing a dev stack at themade.org's Discord
+# would answer live players. Use a test server if you want to try it.
+# DISCORD_BOT_TOKEN=
+# DISCORD_ORACLE_GUILD_ID=
+# DISCORD_ORACLE_CHANNEL_ID=
+
+# Optional: restrict answering to holders of one role. Unset means any
+# member who can see the channel may answer.
+# DISCORD_ORACLE_ROLE_ID=
+
+# Where the Oracle avatar sits. Defaults to context-oraclehome, an
+# exitless region nothing links to; it is also the avatar's turf. Change
+# only if you know why — the Oracle is meant to be unreachable in-world.
+# HABIBOTS_ORACLE_REGION=context-oraclehome
 
 # Per-bot region / username overrides — see habibots/run for the full
 # list of HABIBOTS_*_REGION and HABIBOTS_*_USER vars each bot honors.

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -222,6 +222,16 @@ jobs:
           # oracular objects (fountain, crystal ball, genie) so operators can
           # play Oracle. Same alerts.env delivery as the logins webhook.
           DISCORD_WEBHOOK_ORACLE_REQUESTS: ${{ secrets.DISCORD_WEBHOOK_ORACLE_REQUESTS }}
+          # The Oracle bot answers those requests: an operator picks a request
+          # in Discord and its reply is mailed to the asker in-world. These go
+          # to bots.env, NOT alerts.env — a token in alerts.env would force a
+          # hard bridge restart (dropping live C64 sessions) on every change.
+          # ROLE_ID is optional; unset means any member of the channel may
+          # answer. When the token is unset the oracle bot simply doesn't start.
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_ORACLE_GUILD_ID: ${{ secrets.DISCORD_ORACLE_GUILD_ID }}
+          DISCORD_ORACLE_CHANNEL_ID: ${{ secrets.DISCORD_ORACLE_CHANNEL_ID }}
+          DISCORD_ORACLE_ROLE_ID: ${{ secrets.DISCORD_ORACLE_ROLE_ID }}
         run: |
           export ANSIBLE_SSH_KEY="$HOME/.ssh/deploy_key"
           # MONITORING_ENV is read by the playbook via lookup('env',...);

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -35,6 +35,13 @@
     discord_webhook_logins: "{{ lookup('env', 'DISCORD_WEBHOOK_LOGINS') | default('', true) }}"
     # Oracle-requests channel: ASK/WISH speech to the fountain/crystal ball/genie.
     discord_webhook_oracle_requests: "{{ lookup('env', 'DISCORD_WEBHOOK_ORACLE_REQUESTS') | default('', true) }}"
+    # Oracle bot credentials. Unlike the webhooks above these belong to the
+    # bots container, NOT the bridge: a token in alerts.env would force a hard
+    # bridge restart (dropping live C64 sessions) every time it changed.
+    discord_bot_token: "{{ lookup('env', 'DISCORD_BOT_TOKEN') | default('', true) }}"
+    discord_oracle_guild_id: "{{ lookup('env', 'DISCORD_ORACLE_GUILD_ID') | default('', true) }}"
+    discord_oracle_channel_id: "{{ lookup('env', 'DISCORD_ORACLE_CHANNEL_ID') | default('', true) }}"
+    discord_oracle_role_id: "{{ lookup('env', 'DISCORD_ORACLE_ROLE_ID') | default('', true) }}"
   tasks:
     # If somebody has been hand-editing files on the box (the made has
     # historically lived this way), `ansible.builtin.git` with force=false
@@ -133,11 +140,20 @@
         dest: /etc/neohabitat/bots.env
         content: |
           ANTHROPIC_API_KEY={{ anthropic_api_key }}
+          DISCORD_BOT_TOKEN={{ discord_bot_token }}
+          DISCORD_ORACLE_GUILD_ID={{ discord_oracle_guild_id }}
+          DISCORD_ORACLE_CHANNEL_ID={{ discord_oracle_channel_id }}
+          DISCORD_ORACLE_ROLE_ID={{ discord_oracle_role_id }}
         owner: "{{ neohabitat_owner }}"
         group: "{{ neohabitat_group }}"
         mode: "0600"
       become: true
-      when: anthropic_api_key is defined and anthropic_api_key | length > 0
+      # Any one secret is reason enough to write the file; each bot decides
+      # for itself whether it has what it needs (both sage and oracle skip
+      # their own launch when theirs is blank).
+      when: >-
+        (anthropic_api_key is defined and anthropic_api_key | length > 0) or
+        (discord_bot_token is defined and discord_bot_token | length > 0)
       register: bots_env_file
       no_log: true
 
@@ -392,7 +408,7 @@
       become: true
       changed_when: true
 
-    - name: Recreate bots if bots.env changed (so sage picks up the new key)
+    - name: Recreate bots if bots.env changed (so sage and oracle pick up new keys)
       shell: |
         set -euo pipefail
         docker compose {{ neohabitat_compose_files | map('regex_replace', '^', '-f ') | join(' ') }} \

--- a/bridge_v2/DISCORD_ALERTS.md
+++ b/bridge_v2/DISCORD_ALERTS.md
@@ -15,7 +15,7 @@ next one is a one-file change. This document is the map for future hookups.
    paths: binary + JSON) │  oracle.go    → "oracle-     │
                          │                  requests"   │
                          └──────────────┬───────────────┘
-                                        │ notifier.Post(channel, content)
+                                        │ notifier.Post / PostEmbed
                          ┌──────────────▼───────────────┐
                          │ discord.go — DiscordNotifier │
                          │  channels from env:          │
@@ -106,6 +106,10 @@ exclusion for bots whose names don't end in "bot".
 4. Write a producer that calls `notifier.Post("<name>", content)` — see `oracle.go`
    for the shape (a small struct captured under the session's `stateMu`, the decision
    + Mongo lookups + post on their own goroutine, a structured log line always).
+   Use `PostEmbed` instead when something downstream has to *act* on the message
+   rather than just read it: an embed footer carries a routing key out of the prose,
+   which is what lets the oracle bot answer a request without the bridge remembering
+   anything. Plain `Post` stays right for alerts nobody replies to.
 
 The notifier itself never changes.
 
@@ -125,8 +129,14 @@ The notifier itself never changes.
   speech, so the bridge can't see them; catching them means implementing
   `message_to_god` in elko (needs sign-off) and probably a third ops/security
   channel.
-- **Oracle *answers*** — two-way flow (operator replies in Discord → in-game
-  `object_say`) would need an inbound bot/webhook listener, a bigger design.
+- ~~**Oracle *answers***~~ — shipped, but not in the bridge. An operator picks a
+  request in Discord and the reply is mailed to the asker in-world; see
+  `habibots/bots/oracle.js`. The bridge's only part is the embed footer
+  (`formatOracleFooter`), which carries `<user ref> · <display name>` so the
+  answering bot can route a reply with no correlation state on this side. The
+  inbound half deliberately lives in a bot, not here: mail is an avatar action
+  the bridge cannot perform, and a Discord bot token in `alerts.env` would force
+  a hard bridge restart — dropping live C64 sessions — on every rotation.
 - **"Where is everyone?" (issue #245)** — the `GET /presence` endpoint already
   exposes who's online + regions; an in-game or /status rendering can build on it.
 - Known gap: the webclient's genie flow is broken (issue #607), so `WISH` relay is

--- a/bridge_v2/bridge/discord.go
+++ b/bridge_v2/bridge/discord.go
@@ -32,6 +32,20 @@ type DiscordNotifier struct {
 type discordPost struct {
 	channel string
 	content string
+	embed   *discordEmbed
+}
+
+// discordEmbed is the slice of Discord's embed object we use. The description carries the
+// same prose a plain post would; the footer carries machine-readable context a reader can
+// act on later — the oracle relay stamps the asker's user ref there so an operator's reply
+// in Discord can be routed back in-world with no correlation state on our side.
+type discordEmbed struct {
+	Description string              `json:"description,omitempty"`
+	Footer      *discordEmbedFooter `json:"footer,omitempty"`
+}
+
+type discordEmbedFooter struct {
+	Text string `json:"text"`
 }
 
 const (
@@ -88,13 +102,23 @@ func (d *DiscordNotifier) Enabled(channel string) bool {
 // Post enqueues content for a named channel. No-op (never an error) when the notifier or
 // the channel is unconfigured; drops with a warning when the queue is full.
 func (d *DiscordNotifier) Post(channel string, content string) {
-	if d == nil || d.queue == nil || !d.Enabled(channel) {
+	d.enqueue(discordPost{channel: channel, content: content})
+}
+
+// PostEmbed enqueues a single embed for a named channel. Same no-op and drop semantics as
+// Post; used where a reader needs structured context alongside the prose.
+func (d *DiscordNotifier) PostEmbed(channel string, embed *discordEmbed) {
+	d.enqueue(discordPost{channel: channel, embed: embed})
+}
+
+func (d *DiscordNotifier) enqueue(p discordPost) {
+	if d == nil || d.queue == nil || !d.Enabled(p.channel) {
 		return
 	}
 	select {
-	case d.queue <- discordPost{channel: channel, content: content}:
+	case d.queue <- p:
 	default:
-		log.Warn().Str("channel", channel).Msg("Discord queue full; dropping message")
+		log.Warn().Str("channel", p.channel).Msg("Discord queue full; dropping message")
 	}
 }
 
@@ -107,10 +131,15 @@ func (d *DiscordNotifier) run() {
 func (d *DiscordNotifier) deliver(p discordPost) {
 	// allowed_mentions:[] so an avatar named "@everyone" (or containing any mention) can
 	// never ping the channel — names are player-controlled input.
-	body, err := json.Marshal(map[string]interface{}{
-		"content":          p.content,
+	payload := map[string]interface{}{
 		"allowed_mentions": map[string]interface{}{"parse": []string{}},
-	})
+	}
+	if p.embed != nil {
+		payload["embeds"] = []*discordEmbed{p.embed}
+	} else {
+		payload["content"] = p.content
+	}
+	body, err := json.Marshal(payload)
 	if err != nil {
 		log.Error().Err(err).Str("channel", p.channel).Msg("Could not marshal Discord message")
 		return

--- a/bridge_v2/bridge/oracle.go
+++ b/bridge_v2/bridge/oracle.go
@@ -87,7 +87,30 @@ func (o *oracleRelay) relay(ask oracleAsk) {
 	if !posted {
 		return
 	}
-	o.notifier.Post(oracleChannel, formatOracleRequest(ask.verb, ask.name, class, region, text))
+	o.notifier.PostEmbed(oracleChannel, &discordEmbed{
+		Description: formatOracleRequest(ask.verb, ask.name, class, region, text),
+		Footer:      &discordEmbedFooter{Text: formatOracleFooter(ask.userRef, ask.name)},
+	})
+}
+
+// formatOracleFooter stamps what an Oracle's reply needs to reach the asker in-world:
+//
+//	user-randy · Randy
+//
+// Posting an embed rather than plain content is what makes answering possible at all: it
+// keeps the routing key out of the prose, so a reader recovers it from the message itself
+// and the bridge keeps no correlation state.
+//
+// Both fields are needed. The ref identifies the account in logs, but Habitat mail is
+// addressed by DISPLAY NAME — Region.addUser keys NameToUser on name().toLowerCase(), and
+// Avatar.mailQueueRef() is "mail-" + that. The ref cannot recover it: ensureUserCreated
+// builds the ref by lowercasing the name and mapping spaces to underscores, and avatar names
+// may legally contain underscores of their own, so the inverse is ambiguous. The name is
+// free-form and therefore goes LAST — a reader takes field 0 as the ref and rejoins
+// everything after it as the name, which round-trips even if a name contains the separator.
+// Neither field is sensitive; both are already public in the description above.
+func formatOracleFooter(userRef string, name string) string {
+	return userRef + " · " + name
 }
 
 // formatOracleRequest renders the channel line, e.g.:

--- a/bridge_v2/bridge/oracle_test.go
+++ b/bridge_v2/bridge/oracle_test.go
@@ -119,3 +119,43 @@ func TestOracleUnconfiguredChannelIsNoop(t *testing.T) {
 		targetRef: "item-fountain1", verb: "ASK", text: "anyone there?",
 	})
 }
+
+// The footer is the whole point of posting an embed: it carries the routing key an operator's
+// reply needs to reach the asker in-world, without the bridge keeping any correlation state.
+func TestOracleEmbedFooterCarriesUserRef(t *testing.T) {
+	o, hook := newTestOracle(t)
+	o.classCache["item-fountain1"] = "Fountain"
+	o.relay(oracleAsk{
+		userRef: "user-randy", name: "Randy", regionRef: "context-Downtown_5f",
+		targetRef: "item-fountain1", verb: "ASK", text: "How do I remove a curse?",
+	})
+	if posts := hook.posts(); len(posts) != 1 {
+		t.Fatalf("expected 1 post, got %v", posts)
+	}
+	footers := hook.footers()
+	want := "user-randy · Randy"
+	if footers[0] != want {
+		t.Fatalf("footer = %q, want %q", footers[0], want)
+	}
+}
+
+// Habitat mail is addressed by display name, which is free-form, so it goes last and a
+// reader rejoins everything after the ref. Names containing the separator must round-trip.
+func TestOracleEmbedFooterSurvivesAwkwardNames(t *testing.T) {
+	o, hook := newTestOracle(t)
+	o.classCache["item-fountain1"] = "Fountain"
+	o.relay(oracleAsk{
+		userRef: "user-phil_collins", name: "Phil · Collins", regionRef: "context-Downtown_5f",
+		targetRef: "item-fountain1", verb: "ASK", text: "anyone there?",
+	})
+	if posts := hook.posts(); len(posts) != 1 {
+		t.Fatalf("expected 1 post, got %v", posts)
+	}
+	parts := strings.Split(hook.footers()[0], " · ")
+	if parts[0] != "user-phil_collins" {
+		t.Fatalf("user ref = %q", parts[0])
+	}
+	if name := strings.Join(parts[1:], " · "); name != "Phil · Collins" {
+		t.Fatalf("name = %q, want %q", name, "Phil · Collins")
+	}
+}

--- a/bridge_v2/bridge/presence_test.go
+++ b/bridge_v2/bridge/presence_test.go
@@ -10,11 +10,14 @@ import (
 	"time"
 )
 
-// capturingWebhook is an httptest Discord endpoint recording each posted `content`.
+// capturingWebhook is an httptest Discord endpoint recording each post. Producers use
+// either plain `content` (presence) or a single embed (oracle), so it records the prose of
+// both — an embed's description — under contents, plus the embed footers separately.
 type capturingWebhook struct {
-	mu       sync.Mutex
-	contents []string
-	srv      *httptest.Server
+	mu           sync.Mutex
+	contents     []string
+	embedFooters []string
+	srv          *httptest.Server
 }
 
 func newCapturingWebhook(t *testing.T) *capturingWebhook {
@@ -22,11 +25,22 @@ func newCapturingWebhook(t *testing.T) *capturingWebhook {
 	c := &capturingWebhook{}
 	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
-			Content string `json:"content"`
+			Content string         `json:"content"`
+			Embeds  []discordEmbed `json:"embeds"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		c.mu.Lock()
-		c.contents = append(c.contents, body.Content)
+		if len(body.Embeds) > 0 {
+			c.contents = append(c.contents, body.Embeds[0].Description)
+			footer := ""
+			if body.Embeds[0].Footer != nil {
+				footer = body.Embeds[0].Footer.Text
+			}
+			c.embedFooters = append(c.embedFooters, footer)
+		} else {
+			c.contents = append(c.contents, body.Content)
+			c.embedFooters = append(c.embedFooters, "")
+		}
 		c.mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -51,6 +65,14 @@ func (c *capturingWebhook) posts() []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]string(nil), c.contents...)
+}
+
+// footers returns the embed footer of each post ("" for plain-content posts). Call after
+// posts(), which is the call that waits for the worker to drain.
+func (c *capturingWebhook) footers() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.embedFooters...)
 }
 
 // newTestPresence builds a registry with a fake clock and a capturing webhook on the

--- a/db/Backroom/context-oraclehome.json
+++ b/db/Backroom/context-oraclehome.json
@@ -1,0 +1,65 @@
+[{
+	"type": "context",
+	"ref": "context-oraclehome",
+	"capacity": 4,
+	"name": "Oracle's Home",
+	"mods": [
+		{
+			"town_dir": "",
+			"port_dir": "",
+			"type": "Region",
+	        "realm": "Backroom",
+			"nitty_bits": 0,
+			"max_avatars": 2,
+			"neighbors": ["", "", "", ""]
+		}
+	]
+},
+{
+	"type": "item",
+	"ref": "item-oraclehome.ground",
+	"name": "Ground",
+	"in": "context-oraclehome",
+	"mods": [
+		{
+			"type": "Ground",
+			"style": 1,
+			"x": 0,
+			"y": 4,
+			"orientation": 228
+		}
+	]
+},
+{
+	"type": "item",
+	"ref": "item-oraclehome.wall",
+	"name": "Wall",
+	"in": "context-oraclehome",
+	"mods": [
+		{
+			"type": "Wall",
+			"style": 4,
+			"x": 0,
+			"y": 0,
+			"orientation": 196
+		}
+	]
+},
+{
+	"type": "item",
+	"ref": "item-oraclehome.sign",
+	"name": "A Large Sign",
+	"in": "context-oraclehome",
+	"mods": [
+		{
+			"type": "Sign",
+			"style": 0,
+			"x": 0,
+			"y": 76,
+			"orientation": 0,
+			"gr_state": 1,
+			"text": "Entry Forbidden",
+			"ascii": []
+		}
+	]
+}]

--- a/db/Users/user-oracle.json
+++ b/db/Users/user-oracle.json
@@ -1,0 +1,36 @@
+[ {
+	"type" : "user",
+	"ref" : "user-oracle",
+	"name" : "Oracle",
+	"mods" : [ {
+		"type" : "Avatar",
+		"x" : 80,
+		"y" : 130,
+		"turf" : "context-oraclehome",
+		"bodyType" : "female",
+		"bankBalance" : 0,
+		"custom" : [ 108, 136 ],
+		"nitty_bits" : 536870912
+	} ]
+}, {
+	"type" : "item",
+	"ref" : "item-oracle.paper",
+	"name" : "Pad and mailbox",
+	"in" : "user-oracle",
+	"mods" : [ {
+		"type" : "Paper",
+		"orientation" : 16,
+		"y" : 4
+	} ]
+}, {
+	"type" : "item",
+	"ref" : "item-oracle.head",
+	"name" : "Oracle's Head",
+	"in" : "user-oracle",
+	"mods" : [ {
+		"type" : "Head",
+		"style" : 121,
+		"orientation" : 8,
+		"y" : 6
+	} ]
+} ]

--- a/db/package.json
+++ b/db/package.json
@@ -18,6 +18,7 @@
     "dbUtils": "node dbUtils.js",
     "dumpTeleportEntries": "node dumpTeleportEntries.js",
     "generateBookOfRecords": "node generateBookOfRecords.js",
+    "patchOracleHome": "node patchOracleHome.js",
     "populateModels": "node populateModels.js",
     "translateBookToHTML": "node translateBookToHTML.js"
   },

--- a/db/patchOracleHome.js
+++ b/db/patchOracleHome.js
@@ -1,0 +1,175 @@
+/**
+ * patchOracleHome.js — one-time migration adding the Oracle avatar and its
+ * region to an EXISTING database.
+ *
+ * `make db` runs `nuke` first, so it is not an option against prod. This
+ * touches only the handful of records the Oracle feature introduces and
+ * never deletes anything.
+ *
+ * Usage (dry run — reports what it would do, writes nothing):
+ *   node patchOracleHome.js --url=//127.0.0.1:27017/elko
+ * Then, to actually write:
+ *   node patchOracleHome.js --url=//127.0.0.1:27017/elko --apply
+ *
+ * Records come from the repo's own JSON so there is one source of truth:
+ *   db/Users/user-oracle.json         user-oracle + its Paper and Head
+ *   db/Backroom/context-oraclehome.json   the region + ground, wall, sign
+ *
+ * Safe to re-run: an existing record is left alone unless --force. That
+ * matters most for item-oracle.paper. PSENDMAIL destroys the sheet you
+ * mail and Paper.GET's special_get mints the replacement under a generated
+ * `i-<id>` ref, so a live Oracle no longer owns the seeded ref. Blindly
+ * re-inserting it would leave TWO Papers in MAIL_SLOT, which is the state
+ * the drain logic exists to prevent — so the Paper is skipped whenever the
+ * Oracle already owns one under any ref.
+ *
+ * Once prod is patched this script has done its job and can be deleted.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const MongoClient = require('mongodb').MongoClient;
+
+// Args are parsed by hand rather than with yargs: yargs 18 is ESM-only and
+// cannot be require()d under node 18, and a one-shot migration should run
+// on whatever node the server happens to have. That leaves `mongodb` as
+// this script's only dependency.
+const USAGE = [
+  '',
+  'Adds user-oracle and context-oraclehome to an existing Habitat database.',
+  '',
+  '  --url=//HOST:PORT/DB   mongodb server url (default //127.0.0.1:27017/elko)',
+  '  --apply                actually write; without it this is a dry run',
+  '  --force                overwrite records that already exist',
+  '  --help                 this message',
+  '',
+].join('\n');
+
+function parseArgs(argv) {
+  const opts = { url: '//127.0.0.1:27017/elko', apply: false, force: false, help: false };
+  for (const arg of argv) {
+    const [key, value] = arg.replace(/^--/, '').split('=');
+    if (key === 'url' && value) opts.url = value;
+    else if (key === 'apply') opts.apply = true;
+    else if (key === 'force') opts.force = true;
+    else if (key === 'help' || key === 'h') opts.help = true;
+    else { console.error(`Unrecognised argument: ${arg}\n${USAGE}`); process.exit(1); }
+  }
+  return opts;
+}
+
+const Argv = parseArgs(process.argv.slice(2));
+if (Argv.help) { console.log(USAGE); process.exit(0); }
+
+const SOURCES = [
+  path.join(__dirname, 'Users', 'user-oracle.json'),
+  path.join(__dirname, 'Backroom', 'context-oraclehome.json'),
+];
+
+const ORACLE_USER_REF = 'user-oracle';
+const ORACLE_REGION_REF = 'context-oraclehome';
+
+function load(file) {
+  const records = JSON.parse(fs.readFileSync(file, 'utf8'));
+  if (!Array.isArray(records)) throw new Error(`${file} is not an array of records`);
+  for (const r of records) if (!r.ref) throw new Error(`${file} has a record with no ref`);
+  return records;
+}
+
+// The Oracle's MAIL_SLOT Paper must stay unique — see the header.
+async function oracleAlreadyHasPaper(odb) {
+  const existing = await odb.findOne({
+    in: new RegExp(`^${ORACLE_USER_REF}`),
+    'mods.0.type': 'Paper',
+  });
+  return existing ? existing.ref : null;
+}
+
+// The region is only isolated as long as nothing links to it.
+async function checkIsolation(odb) {
+  const warnings = [];
+  const linked = await odb
+    .find({ 'mods.0.neighbors': ORACLE_REGION_REF }, { projection: { ref: 1 } })
+    .toArray();
+  for (const r of linked) {
+    warnings.push(`${r.ref} lists ${ORACLE_REGION_REF} as a neighbour — it is reachable on foot`);
+  }
+  const teleports = await odb.findOne({ ref: 'teleports' });
+  if (teleports && teleports.map) {
+    for (const [addr, target] of Object.entries(teleports.map)) {
+      if (target === ORACLE_REGION_REF) {
+        warnings.push(`teleport address "${addr}" points at ${ORACLE_REGION_REF}`);
+      }
+    }
+  }
+  return warnings;
+}
+
+(async () => {
+  const url = 'mongodb:' + Argv.url;
+  const dbName = url.split('/').pop() || 'elko';
+  const client = await MongoClient.connect(url);
+  const odb = client.db(dbName).collection('odb');
+  console.log(`Connected to ${url} (collection: odb)\n`);
+
+  let records = [];
+  for (const file of SOURCES) records = records.concat(load(file));
+
+  const heldPaper = await oracleAlreadyHasPaper(odb);
+  const plan = [];
+  for (const record of records) {
+    const existing = await odb.findOne({ ref: record.ref }, { projection: { ref: 1 } });
+    const isSeedPaper = record.in === ORACLE_USER_REF && record.mods[0].type === 'Paper';
+    if (isSeedPaper && heldPaper && heldPaper !== record.ref) {
+      plan.push({ record, action: 'skip', why: `the Oracle already owns a Paper (${heldPaper}); adding this one would put two in MAIL_SLOT` });
+    } else if (!existing) {
+      plan.push({ record, action: 'insert', why: 'not present' });
+    } else if (Argv.force) {
+      plan.push({ record, action: 'replace', why: 'exists, --force given' });
+    } else {
+      plan.push({ record, action: 'skip', why: 'already present (use --force to overwrite)' });
+    }
+  }
+
+  for (const p of plan) {
+    console.log(`  ${p.action.toUpperCase().padEnd(7)} ${p.record.ref.padEnd(34)} ${p.why}`);
+  }
+
+  const writes = plan.filter((p) => p.action !== 'skip');
+  console.log(`\n${writes.length} record(s) to write, ${plan.length - writes.length} unchanged.`);
+
+  const warnings = await checkIsolation(odb);
+  if (warnings.length) {
+    console.log('\nWARNING — the Oracle region is meant to be unreachable:');
+    for (const w of warnings) console.log('  ! ' + w);
+  }
+
+  if (!Argv.apply) {
+    console.log('\nDry run — nothing written. Re-run with --apply to commit.');
+    await client.close();
+    return;
+  }
+
+  for (const p of writes) {
+    // replaceOne, never $set: a partial update against elko's odb leaves
+    // omitted fields behind on the old document.
+    await odb.replaceOne({ ref: p.record.ref }, p.record, { upsert: true });
+    console.log(`  wrote ${p.record.ref}`);
+  }
+
+  const user = await odb.findOne({ ref: ORACLE_USER_REF });
+  const region = await odb.findOne({ ref: ORACLE_REGION_REF });
+  const papers = await odb.countDocuments({ in: new RegExp(`^${ORACLE_USER_REF}`), 'mods.0.type': 'Paper' });
+  console.log('\nVerification:');
+  console.log(`  ${ORACLE_USER_REF}: ${user ? 'present' : 'MISSING'}` +
+    (user ? `, nitty_bits=${user.mods[0].nitty_bits} (HIDDEN_AVATAR=${1 << 29}), turf=${user.mods[0].turf}` : ''));
+  console.log(`  ${ORACLE_REGION_REF}: ${region ? 'present' : 'MISSING'}` +
+    (region ? `, neighbors=${JSON.stringify(region.mods[0].neighbors)}, is_turf=${region.mods[0].is_turf === true}` : ''));
+  console.log(`  Papers owned by the Oracle: ${papers} (must be exactly 1)`);
+  console.log('\nThe elko image must already carry HIDDEN_AVATAR, or the Oracle will show up in F3.');
+
+  await client.close();
+})().catch((err) => {
+  console.error('patchOracleHome failed:', err.message);
+  process.exit(1);
+});

--- a/db/patchOracleHome.js
+++ b/db/patchOracleHome.js
@@ -41,17 +41,20 @@ const USAGE = [
   '  --url=//HOST:PORT/DB   mongodb server url (default //127.0.0.1:27017/elko)',
   '  --apply                actually write; without it this is a dry run',
   '  --force                overwrite records that already exist',
+  '  --undo                 remove everything this script added, and any',
+  '                         state the Oracle accumulated while running',
   '  --help                 this message',
   '',
 ].join('\n');
 
 function parseArgs(argv) {
-  const opts = { url: '//127.0.0.1:27017/elko', apply: false, force: false, help: false };
+  const opts = { url: '//127.0.0.1:27017/elko', apply: false, force: false, undo: false, help: false };
   for (const arg of argv) {
     const [key, value] = arg.replace(/^--/, '').split('=');
     if (key === 'url' && value) opts.url = value;
     else if (key === 'apply') opts.apply = true;
     else if (key === 'force') opts.force = true;
+    else if (key === 'undo') opts.undo = true;
     else if (key === 'help' || key === 'h') opts.help = true;
     else { console.error(`Unrecognised argument: ${arg}\n${USAGE}`); process.exit(1); }
   }
@@ -68,6 +71,7 @@ const SOURCES = [
 
 const ORACLE_USER_REF = 'user-oracle';
 const ORACLE_REGION_REF = 'context-oraclehome';
+const ORACLE_NAME = 'oracle';   // lowercased display name: mail-<name>, paper-item-<name>.*
 
 function load(file) {
   const records = JSON.parse(fs.readFileSync(file, 'utf8'));
@@ -114,6 +118,55 @@ async function checkIsolation(odb) {
 
   let records = [];
   for (const file of SOURCES) records = records.concat(load(file));
+
+  if (Argv.undo) {
+    // The inverse of a patch run, scoped so it can only ever touch the
+    // Oracle. Beyond the seeded refs this also clears what the Oracle
+    // accumulates once it is live — mail it was sent, the letter bodies,
+    // and the `i-<id>` Paper that special_get mints to replace a mailed
+    // sheet — because those are exactly the records a re-patch would
+    // otherwise trip over.
+    const targets = [];
+    for (const record of records) targets.push({ filter: { ref: record.ref }, label: record.ref });
+    targets.push({ filter: { in: new RegExp(`^${ORACLE_USER_REF}`) }, label: "anything contained in user-oracle (its Paper/Head, incl. i-<id> replacements)" });
+
+    // Letter BODIES are stored as `paper-i-<id>` — a shape shared by every
+    // avatar's mail, with nothing in the ref tying one to its author. So
+    // they must never be matched by pattern: `^paper-` would delete other
+    // players' letters, including ones the Oracle has already delivered and
+    // which are now the recipient's property. Instead, resolve the exact
+    // refs still listed in the Oracle's own undelivered queue.
+    const queue = await odb.findOne({ ref: `mail-${ORACLE_NAME}` });
+    const orphanBodies = ((queue && queue.queue) || []).map((entry) => entry.paper_ref).filter(Boolean);
+    if (orphanBodies.length) {
+      targets.push({ filter: { ref: { $in: orphanBodies } }, label: `${orphanBodies.length} undelivered letter body/bodies addressed to the Oracle` });
+    }
+    targets.push({ filter: { ref: `mail-${ORACLE_NAME}` }, label: `mail-${ORACLE_NAME} (its mail queue)` });
+
+    let total = 0;
+    for (const t of targets) {
+      const n = await odb.countDocuments(t.filter);
+      total += n;
+      console.log(`  ${String(n).padStart(3)}  ${t.label}`);
+    }
+    console.log(`\n${total} record(s) would be removed.`);
+    console.log('\nNOT touched: any letter a player already received from the Oracle.');
+    console.log('Those are ordinary mail in that player\'s own pocket and queue, and their');
+    console.log('bodies are indistinguishable by ref from everyone else\'s.');
+    if (!Argv.apply) {
+      console.log('\nDry run — nothing removed. Re-run with --undo --apply to commit.');
+      await client.close();
+      return;
+    }
+    for (const t of targets) {
+      const res = await odb.deleteMany(t.filter);
+      if (res.deletedCount) console.log(`  removed ${res.deletedCount}: ${t.label}`);
+    }
+    const left = await odb.countDocuments({ $or: [{ ref: /oracle/ }, { in: new RegExp(`^${ORACLE_USER_REF}`) }] });
+    console.log(`\nOracle-related records remaining: ${left} (expect 0)`);
+    await client.close();
+    return;
+  }
 
   const heldPaper = await oracleAlreadyHasPaper(odb);
   const plan = [];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,4 +120,4 @@ services:
     networks:
       - neohabitat
     entrypoint: ['/habibots/run']
-    command: ['hatchery', 'eliza', 'sage']
+    command: ['hatchery', 'eliza', 'sage', 'oracle']

--- a/habibots/README.md
+++ b/habibots/README.md
@@ -67,6 +67,28 @@ a resident. Two things arrange that:
   address, and `is_turf` deliberately unset so it can never be handed to
   a new player as their turf.
 
+### Installing the Oracle on an existing server
+
+`make db` runs `nuke` first, so it must never be pointed at a live server.
+Use the one-shot migration instead, which touches only the seven records
+this feature introduces and deletes nothing:
+
+```sh
+cd db
+node patchOracleHome.js --url=//127.0.0.1:27017/elko            # dry run
+node patchOracleHome.js --url=//127.0.0.1:27017/elko --apply    # commit
+```
+
+It is safe to re-run: existing records are left alone unless `--force`. It
+will not re-add `item-oracle.paper` once the Oracle owns a sheet under
+another ref — mailing destroys the sheet you send and `special_get` mints
+the replacement as `i-<id>`, so re-seeding would leave two Papers in
+MAIL_SLOT. It also warns if any region has come to list `context-oraclehome`
+as a neighbour, or a teleport address points at it.
+
+The elko image must already carry `HIDDEN_AVATAR` when this runs; if the
+image lags, the Oracle shows up in everyone's F3 until it catches up.
+
 ### Letters addressed to the Oracle
 
 A player can write `to: oracle` on a Paper and mail it. Because the Oracle

--- a/habibots/README.md
+++ b/habibots/README.md
@@ -22,7 +22,77 @@ docker compose up -d bots
 ```
 
 This brings up the `bots` service defined in `docker-compose.yml`, which
-runs `hatchery` and `eliza` against the local elko/bridge.
+runs `hatchery`, `eliza`, `sage` and `oracle` against the local
+elko/bridge. `sage` and `oracle` each skip their own launch when their
+credentials are unset, so the rest of the lineup still comes up.
+
+The Oracle bot
+--------------
+
+`bots/oracle.js` closes the loop on `#oracle-requests`. When an avatar
+ASKs a fountain (or WISHes on a magic lamp), `bridge_v2` posts it to
+Discord; an Oracle right-clicks that message → Apps → **Answer as the
+Oracle**, types a reply, and this bot mails it to the asker in-world.
+
+Mail rather than speech because the asker is usually logged out by then,
+and mail is the one thing that waits for them.
+
+It needs a real bot account — a webhook can post but cannot read or
+reply — with **View Channel**, **Send Messages** and **Read Message
+History** on that channel. No privileged intents: the context-menu
+command hands us the message we need, so the bot never sees the text of
+anything nobody pointed it at.
+
+Set `DISCORD_BOT_TOKEN`, `DISCORD_ORACLE_GUILD_ID` and
+`DISCORD_ORACLE_CHANNEL_ID` (optionally `DISCORD_ORACLE_ROLE_ID` to
+restrict who may answer) — see `.env.example`. It also needs the
+`user-oracle` avatar from `db/Users/user-oracle.json`, whose Paper in
+`MAIL_SLOT` is load-bearing: without it, mail sent *to* the Oracle is
+destroyed after the sender is told it succeeded.
+
+### Why the Oracle is unreachable in-world
+
+Players should meet the Oracle only through an oracular object, never as
+a resident. Two things arrange that:
+
+- It carries the **`HIDDEN_AVATAR`** nitty_bit (`Constants.java`), which
+  keeps it out of `Region.NameToUser`. That one table backs the F3 user
+  list, `/online` counts, ESP targeting, `/join`, `/invite`, `/teleport`,
+  `/yank` and `tellEveryone`, so all of them skip it at once. ESP answers
+  `"Cannot contact oracle."` Mail sent *to* it takes the offline branch
+  and queues at `mail-oracle` in mongo, which is where a future version
+  will read player replies from.
+- It lives in **`context-oraclehome`** (`db/Backroom/`): floor, wall, and
+  a sign reading "Entry Forbidden". No exits, no neighbours, no teleport
+  address, and `is_turf` deliberately unset so it can never be handed to
+  a new player as their turf.
+
+### Letters addressed to the Oracle
+
+A player can write `to: oracle` on a Paper and mail it. Because the Oracle
+is hidden, `getUserByName` misses and `Paper.sendMailToUser` always takes
+the offline branch, so the letter queues at `mail-oracle` and lands in the
+bot's MAIL_SLOT on its next `check_mail`. The bot reads it out and posts it
+to `#oracle-requests` with a ✉️ — the same shape the bridge uses for a
+fountain ASK, footer included, so an Oracle answers a letter with exactly
+the same right-click command.
+
+Draining is not optional. `MAIL_SLOT` is the only self-replenishing paper
+source (`Paper.GET`'s `special_get` fires only for that slot; a numbered
+pocket slot is single-use), and a blank sheet is refused if the slot holds
+unread mail — so one letter would otherwise leave the Oracle unable to
+answer anyone, permanently. After reading, the sheet is blanked and put
+back in a pocket, which makes the server destroy it (`Paper.java:334`),
+leaving exactly one Paper in the slot.
+
+It is **not** a ghost, though that looks like the obvious answer. A ghost
+cannot mail: `HabitatMod.objectIsComplete` skips `Region.addToNoids` when
+the container is a ghost avatar, so a ghost's pocket Paper is never
+materialised — measured live, a ghost logs in with noid 255 and an empty
+inventory, and there is no Paper to pick up.
+
+Point a dev instance at a **test** Discord server. Aiming it at
+themade.org's would answer live players.
 
 Running standalone
 ------------------

--- a/habibots/bots/oracle.js
+++ b/habibots/bots/oracle.js
@@ -1,109 +1,349 @@
-/* jslint bitwise: true */
-/* jshint esversion: 6 */
+/* jshint esversion: 8 */
 
 'use strict'
 
-const Defaults = {
-  host:         '127.0.0.1',
-  loglevel:     'debug',
-  port:         1337,
-  reconnect:    true,
-  slackChannel: 'general',
-}
+// oracle.js — carries Oracle answers from Discord into Habitat mail.
+//
+// The loop this closes:
+//   1. An avatar ASKs a fountain / crystal ball / bureaucrat, or WISHes on
+//      a magic lamp. bridge_v2's relay (bridge/oracle.go) posts it to
+//      Discord's #oracle-requests as an embed whose footer names the
+//      asker: "user-randy · Randy".
+//   2. An Oracle right-clicks that message -> Apps -> "Answer as the Oracle".
+//   3. A modal opens; they write the answer.
+//   4. This bot mails it to the asker, as the Oracle avatar.
+//
+// Mail rather than speech because by the time a human reads the channel
+// the asker has almost certainly logged out, and mail is the one in-world
+// mechanism that survives that: Paper.sendMailToUser queues to mongo when
+// the recipient is offline, and Avatar.check_mail drains it on their next
+// region entry with "* You have MAIL in your pocket. *".
+//
+// Why a context-menu command rather than watching for replies: the
+// interaction payload resolves the target message for us, so the footer is
+// readable with NO Message Content intent — this bot never sees the text
+// of a message nobody pointed it at. Application commands also arrive over
+// the gateway, so there is no HTTPS interactions endpoint to expose.
+//
+// Required env:
+//   DISCORD_BOT_TOKEN          the Oracle bot's token
+//   DISCORD_ORACLE_GUILD_ID    server to register the command in (guild-scoped
+//                              registration is instant; global takes ~an hour)
+//   DISCORD_ORACLE_CHANNEL_ID  only messages in this channel may be answered
+// Optional env:
+//   DISCORD_ORACLE_ROLE_ID     if set, only members holding it may answer
+//   HABIBOTS_MONGO_URL         outbox storage (default mongodb://neohabitatmongo:27017)
+//
+// Discord permissions needed: View Channel, Send Messages (for the
+// "answered by" marker) and Read Message History in #oracle-requests.
+// No privileged intents.
+//
+// The in-world Oracle is deliberately unreachable. It is a normal
+// corporeal avatar — a ghost cannot mail, because HabitatMod
+// objectIsComplete skips Region.addToNoids for a ghost's contents, so a
+// ghost's pocket Paper never exists to pick up. Instead it carries the
+// HIDDEN_AVATAR nitty_bit, which keeps it out of Region.NameToUser and
+// so out of the F3 list, /online counts, ESP, /join, /invite and
+// /teleport; and it lives in context-oraclehome, a region with no exits
+// that nothing else links to. Players reach the Oracle only by asking an
+// oracular object, and it answers only through this bot.
 
-const fs = require('fs')
-var log = require('winston')
+const log = require('winston')
 log.configure({
   transports: [new log.transports.Console({
     format: log.format.combine(log.format.timestamp(), log.format.splat(), log.format.simple())
   })]
 })
 
-// @slack/client is loaded LAZILY inside the SlackEnabled block below.
-// It's not in habibots/package.json — same security removal as
-// hatchery.js / greeter.js (the v3.x line drags in critical-CVE-laden
-// request / hawk / hoek). Reinstall with `npm install @slack/client@3`
-// and pass --slackToken to make the bot do anything; oracle's whole
-// job IS the slack <-> in-world bridge, so without a token it just
-// connects and idles.
-const constants = require('../constants')
 const HabiBot = require('../habibot')
+const mail = require('../lib/mail')
+const { OracleOutbox } = require('../lib/oracle-outbox')
+const { askerFromMessage } = require('../lib/oracle-footer')
+
+const Defaults = {
+  host: '127.0.0.1',
+  port: 1337,
+  loglevel: 'info',
+  reconnect: true,
+}
 
 const { hideBin } = require('yargs/helpers')
 const Argv = require('yargs/yargs')(hideBin(process.argv))
   .usage('Usage: $0 [options]')
   .help('help')
-  .option('help', { alias: '?', describe: 'Get this usage/help information.' })
-  .option('host', { alias: 'h', default: Defaults.host, describe: 'Host name or address of the Elko server.' })
-  .option('loglevel',  { alias: ';', default: Defaults.loglevel, describe: 'Log level name. (see: npm winston)'})
-  .option('port', { alias: 'p', default: Defaults.port, describe: 'Port number for the Elko server.' })
-  .option('context', { alias: 'c', describe: 'Context to enter.' })
-  .option('reconnect', { alias: 'r', default: Defaults.reconnect, describe: 'Whether the bot should reconnect on disconnection.' })
-  .option('slackToken', { alias: 's', default: Defaults.slackToken, describe: 'Token for sending user notifications to Slack.' })
-  .option('slackChannel', { alias: 'l', default: Defaults.slackChannel, describe: 'Default Slack channel to use for notifications.' })
-  .option('username', { alias: 'u', describe: 'Username of this bot.' })
+  .option('host',      { alias: 'h', default: Defaults.host })
+  .option('port',      { alias: 'p', default: Defaults.port })
+  .option('loglevel',  { default: Defaults.loglevel })
+  .option('context',   { alias: 'c', describe: 'Context to enter on connect.', demandOption: true })
+  .option('username',  { alias: 'u', describe: 'Avatar username.', demandOption: true })
+  .option('reconnect', { alias: 'r', default: Defaults.reconnect })
   .argv
 
 log.level = Argv.loglevel
 
-const OracleBot = HabiBot.newWithConfig(Argv.host, Argv.port, Argv.username)
+const TOKEN = process.env.DISCORD_BOT_TOKEN
+const GUILD_ID = process.env.DISCORD_ORACLE_GUILD_ID
+const CHANNEL_ID = process.env.DISCORD_ORACLE_CHANNEL_ID
+const ROLE_ID = process.env.DISCORD_ORACLE_ROLE_ID || null
 
-const SlackEnabled = Argv.slackToken !== ''
-let SlackClient = null
-let SlackChannelId
+if (!TOKEN || !GUILD_ID || !CHANNEL_ID) {
+  // Exit 0 (success) so supervisor doesn't read a missing secret as a
+  // crash and put us in a restart loop. The bots container starts before
+  // the deploy has necessarily written /etc/neohabitat/bots.env; the
+  // oracle simply sits out that cycle, exactly as sage does.
+  log.info('oracle: DISCORD_BOT_TOKEN / GUILD_ID / CHANNEL_ID not all set; not starting.')
+  process.exit(0)
+}
+
+// Required after the env check so an unconfigured deploy never depends on
+// the module being installed (the same reason the old Slack build loaded
+// its client lazily).
+const {
+  Client, Events, GatewayIntentBits, MessageFlags, ApplicationCommandType,
+  ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder,
+} = require('discord.js')
+
+const ANSWER_COMMAND = 'Answer as the Oracle'
+const MODAL_PREFIX = 'oracle_reply:'
+const ANSWER_FIELD = 'answer'
+const NO_PINGS = { parse: [] }
+
+// The relay in bridge/oracle.go keys an icon off the object spoken to —
+// a fountain, a crystal ball, a genie. A letter has no object, so it gets
+// its own, in the same slot.
+const LETTER_ICON = '✉️'
+const LETTER_TEXT_MAX = 300 // matches oracleTextMax on the bridge side
+
+const outbox = new OracleOutbox()
+
+// ── Habitat side ───────────────────────────────────────────────────────
+
+const OracleBot = HabiBot.newWithConfig(Argv.host, Argv.port, Argv.username)
+let inWorld = false
 
 OracleBot.on('connected', (bot) => {
   log.debug('OracleBot connected.')
   bot.gotoContext(Argv.context)
 })
 
-if (SlackEnabled) {
-  const Slack = require('@slack/client')
-  SlackClient = new Slack.RtmClient(Argv.slackToken, {
-    logLevel: 'error',
-    dataStore: new Slack.MemoryDataStore(),
-    autoReconnect: true,
-    autoMark: true,
-  })
-  SlackClient.on(Slack.CLIENT_EVENTS.RTM.AUTHENTICATED, (rtmStartData) => {
-    for (const c of rtmStartData.channels) {
-      if (c.name === Argv.slackChannel) {
-        SlackChannelId = c.id
-      }
-    }
-  })
+OracleBot.on('enteredRegion', (bot) => {
+  bot.ensureCorporated()
+    .then(() => {
+      inWorld = true
+      log.info('OracleBot is in-world; draining any queued answers.')
+      return drainOutbox()
+    })
+    .catch((err) => log.error(`OracleBot could not corporate: ${err.message}`))
+})
 
-  OracleBot.on('enteredRegion', (bot, me) => {
-    bot.ensureCorporated()
-      .then(() => SlackClient.sendMessage("OracleBot engaged.", SlackChannelId))
-  })
+OracleBot.on('disconnected', () => {
+  inWorld = false
+  log.warn('OracleBot disconnected; answers will queue until it is back.')
+})
 
-  OracleBot.on('OBJECTSPEAK_$', (bot, msg) => {
-    if (msg.noid === bot.getAvatarNoid()) {
-      return
-    }
-    if (msg.text.includes("says:")) { //JSN: This is silly, but for now it's fine.
-      SlackClient.sendMessage(`${msg.text}`, SlackChannelId)
-    }
-  })
+// Mailing is a multi-step avatar action (pick up a Paper, WRITE it,
+// PSENDMAIL it). Two of those interleaved would write one answer onto the
+// other's sheet, so every delivery goes through this one chain.
+let deliveryChain = Promise.resolve()
+function serialize(work) {
+  const next = deliveryChain.then(work, work)
+  deliveryChain = next.catch(() => {})
+  return next
+}
 
-  SlackClient.on(Slack.RTM_EVENTS.MESSAGE, (message) => {
-    if (!message.text.includes(":")) {
-      SlackClient.sendMessage("Error! Input did not follow *'USERNAME: Message'* format.", SlackChannelId)
-      return
+function deliver(entry) {
+  return serialize(async () => {
+    if (!inWorld) return { ok: false, error: 'the Oracle is not in-world yet' }
+    const res = await mail.composeAndSendMail(OracleBot, {
+      recipient: entry.recipient,
+      body: entry.body,
+      // Players can mail "to: oracle". Those letters land in our MAIL_SLOT
+      // via check_mail and, once the spare pocket sheet is spent, would
+      // leave us with no blank paper and no way to answer anyone. Read
+      // them and reuse the sheet.
+      drainMail: true,
+    })
+    for (const letter of res.readLetters || []) {
+      relayLetter(letter).catch((err) =>
+        log.error(`could not relay a letter to Discord: ${err.message}`))
     }
-    var msg = message.text.split(":")
-    OracleBot.wait(10000)
-      .then(() => OracleBot.say("TO: " + msg[0]))
-      .then(() => OracleBot.wait(5000))
-      .then(() => OracleBot.ESPsay(msg[1]))
-      .then(() => OracleBot.wait(5000))
-      .then(() => OracleBot.ESPsay(""))
+    if (res.ok) {
+      await outbox.markSent(entry._id)
+      log.info(`delivered oracle answer ${entry._id} to ${entry.recipient}`)
+    } else {
+      await outbox.noteFailure(entry._id, res.error)
+      log.warn(`could not deliver oracle answer ${entry._id}: ${res.error}`)
+    }
+    return res
   })
+}
+
+async function drainOutbox() {
+  let pending
+  try {
+    pending = await outbox.pending()
+  } catch (err) {
+    log.error(`could not read the oracle outbox: ${err.message}`)
+    return
+  }
+  for (const entry of pending) {
+    const res = await deliver(entry)
+    // Stop on the first failure: they are almost always "not in-world" or
+    // "no blank paper", and both apply equally to everything behind it.
+    if (!res.ok) break
+  }
+}
+
+// ── Discord side ───────────────────────────────────────────────────────
+
+// Letters addressed "to: oracle" arrive as in-world mail, not as an ASK,
+// so the bridge never sees them. Post them into the same channel in the
+// same shape — including the footer — so an Oracle answers a letter with
+// exactly the command they use on a fountain request.
+async function relayLetter(letter) {
+  const sender = letter.sender
+  let body = String(letter.body || '').trim()
+  if (!body) return
+  if (body.length > LETTER_TEXT_MAX) body = body.slice(0, LETTER_TEXT_MAX) + '…'
+  const channel = await discord.channels.fetch(CHANNEL_ID)
+  const embed = sender
+    ? {
+      description: `${LETTER_ICON} **${sender}** mails the Oracle: “${body}”`,
+      // Same "<user ref> · <display name>" contract as formatOracleFooter.
+      // The ref is reconstructed the way ensureUserCreated builds it.
+      footer: { text: `user-${sender.toLowerCase().replace(/ /g, '_')} · ${sender}` },
+    }
+    // No postmark means no way to address a reply, so it goes up without a
+    // footer — the answer command will refuse it rather than mail nowhere.
+    : { description: `${LETTER_ICON} A letter reached the Oracle: “${body}”` }
+  await channel.send({ embeds: [embed], allowedMentions: NO_PINGS })
+  log.info(`relayed a letter from ${sender || 'an unknown sender'} to Discord`)
+}
+
+function mayAnswer(interaction) {
+  if (!ROLE_ID) return true
+  const roles = interaction.member && interaction.member.roles
+  if (!roles) return false
+  return typeof roles.cache?.has === 'function' ? roles.cache.has(ROLE_ID) : (roles || []).includes(ROLE_ID)
+}
+
+function ephemeral(interaction, content) {
+  const payload = { content: content, flags: MessageFlags.Ephemeral }
+  return interaction.deferred || interaction.replied
+    ? interaction.editReply({ content: content })
+    : interaction.reply(payload)
+}
+
+const discord = new Client({ intents: [GatewayIntentBits.Guilds] })
+
+discord.once(Events.ClientReady, async (c) => {
+  log.info(`oracle Discord client ready as ${c.user.tag}`)
+  try {
+    await c.application.commands.set(
+      [{ name: ANSWER_COMMAND, type: ApplicationCommandType.Message }], GUILD_ID)
+    log.info(`registered "${ANSWER_COMMAND}" in guild ${GUILD_ID}`)
+  } catch (err) {
+    log.error(`could not register the answer command: ${err.message}`)
+  }
+})
+
+discord.on(Events.InteractionCreate, async (interaction) => {
+  try {
+    if (interaction.isMessageContextMenuCommand() && interaction.commandName === ANSWER_COMMAND) {
+      return await onAnswerCommand(interaction)
+    }
+    if (interaction.isModalSubmit() && interaction.customId.startsWith(MODAL_PREFIX)) {
+      return await onAnswerSubmitted(interaction)
+    }
+  } catch (err) {
+    log.error(`interaction failed: ${err.stack || err.message}`)
+    try { await ephemeral(interaction, `Something went wrong: ${err.message}`) } catch (_) { /* the interaction may already be dead */ }
+  }
+})
+
+async function onAnswerCommand(interaction) {
+  if (interaction.channelId !== CHANNEL_ID) {
+    return ephemeral(interaction, 'Oracle answers can only be sent from the oracle-requests channel.')
+  }
+  if (!mayAnswer(interaction)) {
+    return ephemeral(interaction, 'You do not hold the Oracle role.')
+  }
+  const asker = askerFromMessage(interaction.targetMessage)
+  if (!asker) {
+    return ephemeral(interaction, 'That is not an oracle request — no asker recorded on it.')
+  }
+  const modal = new ModalBuilder()
+    .setCustomId(MODAL_PREFIX + interaction.targetMessage.id)
+    .setTitle(`Answer ${asker.name}`.slice(0, 45))
+    .addComponents(new ActionRowBuilder().addComponents(
+      new TextInputBuilder()
+        .setCustomId(ANSWER_FIELD)
+        .setLabel('Your answer (arrives as Habitat mail)')
+        .setStyle(TextInputStyle.Paragraph)
+        // A page is 40x16 and the first row becomes the postmark, so
+        // anything past this cannot be shown; cap it here rather than
+        // silently clipping after they hit send.
+        .setMaxLength(mail.MAIL_BODY_MAX)
+        .setRequired(true)))
+  return interaction.showModal(modal)
+}
+
+async function onAnswerSubmitted(interaction) {
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral })
+  const targetId = interaction.customId.slice(MODAL_PREFIX.length)
+  const body = interaction.fields.getTextInputValue(ANSWER_FIELD)
+
+  // Re-fetch rather than trusting the id alone: it re-checks the channel
+  // and footer at send time, and the marker below needs the message.
+  const channel = await discord.channels.fetch(CHANNEL_ID)
+  const target = await channel.messages.fetch(targetId)
+  const asker = askerFromMessage(target)
+  if (!asker) return ephemeral(interaction, 'That request no longer names an asker.')
+
+  if (!mayAnswer(interaction)) {
+    // Re-checked here as well as before the modal: a role can be revoked
+    // in between, and this is the call that actually writes to a player.
+    return ephemeral(interaction, 'You do not hold the Oracle role.')
+  }
+
+  // Claim the request before writing anything. Anything other than a fresh
+  // insert means another Oracle already answered it — including one still
+  // sitting in the queue undelivered, which would otherwise become a
+  // second letter for the same question.
+  const status = await outbox.enqueue({
+    id: targetId,
+    recipient: asker.name.toLowerCase(),
+    body: body,
+    askedBy: asker.userRef,
+    answeredBy: interaction.user.id,
+  })
+  if (status !== 'inserted') {
+    return ephemeral(interaction, status === 'sent'
+      ? `${asker.name} has already been answered.`
+      : `${asker.name} already has an answer waiting to be delivered.`)
+  }
+
+  const res = await deliver({ _id: targetId, recipient: asker.name.toLowerCase(), body: body })
+  if (!res.ok) {
+    // Written down before Discord was told anything, so it goes out on
+    // the next drain — the operator does not have to retype it.
+    return ephemeral(interaction,
+      `Queued for ${asker.name} — not delivered yet (${res.error}). It will be mailed when the Oracle is back in-world.`)
+  }
+  await ephemeral(interaction,
+    `Mailed to ${asker.name}.${res.truncated ? ' (Trimmed to fit one page.)' : ''}`)
+  try {
+    await target.reply({
+      content: `:envelope: answered by <@${interaction.user.id}>`,
+      allowedMentions: NO_PINGS,
+    })
+  } catch (err) {
+    log.warn(`could not mark ${targetId} answered: ${err.message}`)
+  }
 }
 
 OracleBot.connect()
-
-if (SlackEnabled) {
-  SlackClient.start()
-}
+discord.login(TOKEN).catch((err) => {
+  log.error(`oracle could not log in to Discord: ${err.message}`)
+  process.exit(1)
+})

--- a/habibots/habibot.js
+++ b/habibots/habibot.js
@@ -996,10 +996,24 @@ class HabiBot {
   // WRITE — overwrite a Paper's contents. text is a regular string; we
   // convert to a 7-bit ASCII int array per the wire format. Pass empty
   // string to clear the paper.
+  //
+  // Paper.WRITE (Paper.java:157) reads a request_ascii of exactly 16
+  // elements as "erase this sheet" — that length IS the sentinel, not the
+  // content. Two consequences, both handled here:
+  //   - an empty string has to be sent as a 16-element array, or the
+  //     server takes the write branch instead and leaves the sheet in
+  //     WRITTEN state holding nothing.
+  //   - a real 16-character page would erase the sheet by accident, so it
+  //     gets a trailing space. webclient/lib/text-view.js does the same.
   writePaper(paperRef, text) {
     var ascii = []
     if (text) {
       for (var i = 0; i < text.length; i++) ascii.push(text.charCodeAt(i) & 0x7F)
+    }
+    if (ascii.length === 0) {
+      ascii = new Array(16).fill(0)      // the clear sentinel
+    } else if (ascii.length === 16) {
+      ascii.push(32)                     // ' ' — never collide with it
     }
     return this.sendWithDelay({ op: 'WRITE', to: paperRef, request_ascii: ascii }, 500)
   }

--- a/habibots/lib/mail.js
+++ b/habibots/lib/mail.js
@@ -1,0 +1,278 @@
+/* jshint esversion: 8 */
+
+'use strict'
+
+// mail.js — compose and send in-world Habitat mail.
+//
+// Lives at lib/ rather than lib/sage/ because two bots need it: sage
+// (via its compose_and_send_mail tool) and oracle (which mails an
+// operator's Discord reply to the avatar who asked). It reaches into
+// lib/sage/ for awareness + petscii, which are bot-agnostic despite
+// where they sit.
+//
+// Habitat mail has no addressee field on the wire. The recipient is the
+// literal first line of the page ("to: name"), which Paper.PSENDMAIL
+// parses with ADDRESS_REGEX and then OVERWRITES with the postmark
+// ("From: <sender>  Postmark: yy-MM-dd"). So the shape of the page IS
+// the protocol, and the three landmines below are all shape problems.
+
+const log = require('winston')
+const awareness = require('./sage/awareness')
+const { sanitizeForC64 } = require('./sage/petscii')
+
+// A page is 40x16 (Document.MAX_LINE_WIDTH x LINES_PER_PAGE; see
+// webclient/lib/text-view.js). Row 0 is spent on the "to:" line, which
+// PSENDMAIL replaces with the postmark, so the body gets the other 15.
+const MAIL_COLS = 40
+const MAIL_ROWS = 16
+const MAIL_BODY_ROWS = MAIL_ROWS - 1
+const MAIL_BODY_MAX = MAIL_COLS * MAIL_BODY_ROWS // 600
+
+// Paper.java:157 — WRITE treats a request_ascii of exactly 16 elements as
+// "erase this sheet", the same sentinel an empty page sends. A 16-char
+// page therefore blanks the Paper and mails nothing, silently. Since
+// "to: oracle\n" is 11 chars, a five-character reply lands right on it.
+// webclient/lib/text-view.js:81 fixes this by padding a space; do the same.
+const CLEAR_SENTINEL_LENGTH = 16
+
+// Any numbered pocket slot (0-3) works for disposal; Paper.PUT destroys a
+// blank sheet wherever it lands.
+const DISCARD_SLOT = 0
+
+// Mirrors bridge_v2's validAvatarName, lowercased: mail is addressed by
+// DISPLAY NAME (Region.addUser keys NameToUser on name().toLowerCase()),
+// and those legally contain spaces and apostrophes. Paper.findAddressee
+// trims and lowercases whatever follows "to:", so both survive the page.
+const RECIPIENT_REGEX = /^[a-z0-9][a-z0-9 ._'-]{0,31}$/
+
+// Paper.addPostmark overwrites the "to:" line with
+//   String.format("From: %-14s Postmark: %s ", from.name(), yy-MM-dd)
+// so the sender's name is recoverable from the page itself — there is no
+// sender field on a Paper. The name is padded to 14 and may contain
+// spaces, hence the non-greedy match up to " Postmark:".
+const POSTMARK_REGEX = /^From:\s+(.*?)\s+Postmark:\s*(\S+)\s*/
+
+function parsePostmark(text) {
+  const page = String(text || '')
+  const m = POSTMARK_REGEX.exec(page)
+  if (!m) return { sender: null, date: null, body: page.trim() }
+  return { sender: m[1].trim(), date: m[2], body: page.slice(m[0].length).trim() }
+}
+
+// sanitizeForC64 is built for single-line speech: its final pass drops
+// everything outside printable ASCII, and \n (0x0A) is outside it — so
+// running a whole page through at once welds the lines together. Fold
+// line by line instead, which keeps the author's paragraph breaks. Not
+// fixed in petscii.js itself because sage's SPEAK and ESP paths want
+// exactly the collapsing behavior it has today.
+function sanitizeLines(text) {
+  return String(text).split('\n').map((line) => sanitizeForC64(line) || '')
+}
+
+// Word-wrap to the page grid. The client wraps at 40 columns on its own,
+// but only mid-word — wrapping here keeps breaks on word boundaries and
+// lets us tell the caller when the text did not fit.
+function wrapForPaper(text, cols = MAIL_COLS, rows = MAIL_BODY_ROWS) {
+  const lines = []
+  for (const paragraph of String(text).split('\n')) {
+    if (paragraph === '') { lines.push(''); continue }
+    let line = ''
+    for (const word of paragraph.split(/ +/)) {
+      // A single word longer than the column width has to be split.
+      if (word.length > cols) {
+        if (line) { lines.push(line); line = '' }
+        for (let i = 0; i < word.length; i += cols) lines.push(word.slice(i, i + cols))
+        line = lines.length && lines[lines.length - 1].length < cols ? lines.pop() : ''
+        continue
+      }
+      if (!line) { line = word }
+      else if (line.length + 1 + word.length <= cols) { line += ' ' + word }
+      else { lines.push(line); line = word }
+    }
+    if (line) lines.push(line)
+  }
+  const truncated = lines.length > rows
+  const kept = lines.slice(0, rows)
+  if (truncated && kept.length) {
+    // Mark the cut so the reader knows the letter was clipped.
+    const last = kept[kept.length - 1]
+    kept[kept.length - 1] = (last.length + 4 <= cols ? last : last.slice(0, cols - 4)).trimEnd() + ' ...'
+  }
+  return { lines: kept, truncated }
+}
+
+// Build the page a Paper should hold: "to: <recipient>" then the wrapped
+// body. Kept separate from the send so it can be unit-tested and so a
+// caller can preview exactly what the recipient will read.
+function buildMailPage(recipient, body) {
+  const { lines, truncated } = wrapForPaper(sanitizeLines(body).join('\n'))
+  let text = `to: ${recipient}\n${lines.join('\n')}`
+  if (text.length === CLEAR_SENTINEL_LENGTH) text += ' '
+  return { text, truncated }
+}
+
+// Pick the Paper to write on, in the order that loses the least.
+//   1. blank Paper already in HANDS — write + mail in place.
+//   2. blank Paper in a numbered pocket slot — pick_up first.
+//   3. blank Paper in MAIL_SLOT — pick_up; elko auto-spawns a fresh
+//      blank Paper there (the Paper.GET special-case).
+//   4. unread LETTER in MAIL_SLOT — refuse: picking it up dismisses
+//      mail the bot has not read.
+function chooseBlankPaper(bot) {
+  const papers = awareness.getInventory(bot).filter((it) => it.type === 'Paper')
+  if (!papers.length) return { error: 'you have no Paper in your pocket' }
+  const isBlank = (p) => (p.grState || 0) === awareness.PAPER_BLANK_STATE
+  const chosen =
+    papers.find((p) => p.slot === awareness.HANDS_SLOT && isBlank(p)) ||
+    papers.find((p) => p.slot !== awareness.MAIL_SLOT && p.slot !== awareness.HANDS_SLOT && isBlank(p)) ||
+    papers.find((p) => p.slot === awareness.MAIL_SLOT && isBlank(p))
+  if (!chosen) {
+    return {
+      error:
+        'all pocket Paper is in LETTER state (unread mail). READ it first, then a blank ' +
+        'paper will be available for composing.',
+    }
+  }
+  return { paper: chosen }
+}
+
+// A letter sitting unread in MAIL_SLOT blocks composing: chooseBlankPaper
+// refuses to consume it (dismissing unread mail is destructive), and it is
+// usually the ONLY paper source left, because Paper.GET only auto-respawns
+// a sheet for MAIL_SLOT — a numbered pocket slot is single-use. So one
+// player typing "to: <bot>" can otherwise stop the bot mailing anyone ever
+// again.
+//
+// Draining reads the letter out and blanks the sheet, which both unblocks
+// the slot and hands back what the player wrote. Opt-in, because for sage
+// dismissing someone's unread mail would be wrong; for the Oracle, reading
+// what was sent to it is the point.
+async function drainMailSlot(bot) {
+  const letter = awareness.getInventory(bot).find(
+    (it) => it.type === 'Paper' && it.slot === awareness.MAIL_SLOT &&
+      (it.grState || 0) === awareness.PAPER_LETTER_STATE)
+  if (!letter) return { drained: false, text: '' }
+  // GET moves it to HANDS and pops the next queued letter into MAIL_SLOT
+  // (Paper.GET's update_mail_slot call). READ requires it be held.
+  await withTimeout(getObj(bot, letter.ref), 10000, 'drainMailSlot.pick_up')
+  let text = ''
+  try {
+    text = decodePage(await withTimeout(readPaperPage(bot, letter.ref), 10000, 'drainMailSlot.read'))
+  } catch (err) {
+    log.warn(`could not read the letter in MAIL_SLOT before clearing it: ${err.message}`)
+  }
+  // Blank it (an empty write is Paper.WRITE's clear sentinel, which also
+  // resets text_path so is_blank() holds), then put it back in a pocket so
+  // the server destroys it. Reusing this sheet instead would leave the
+  // MAIL_SLOT replacement behind as a second Paper in the same slot.
+  await withTimeout(bot.writePaper(letter.ref, ''), 10000, 'drainMailSlot.clear')
+  await withTimeout(discardBlankPaper(bot, letter.ref), 10000, 'drainMailSlot.discard')
+  const letterInfo = parsePostmark(text)
+  log.info(`read a letter from ${letterInfo.sender || 'an unknown sender'} out of MAIL_SLOT`)
+  return { drained: true, ref: letter.ref, text: text, sender: letterInfo.sender, body: letterInfo.body }
+}
+
+function withTimeout(promise, ms, label) {
+  let timer
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+  })
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
+}
+
+// GET takes no parameters beyond `to`; the old containerNoid field drew
+// an "ignored unknown parameter" warning on every send.
+//
+// sendForReply, not send: plain send resolves as soon as the message is on
+// the wire, so the next op can race ahead of elko actually moving the
+// sheet. Everything after a pick-up (READ, WRITE, PSENDMAIL) is gated on
+// holding(avatar, this) server-side, so the reply is the only real signal
+// that it is safe to continue.
+function getObj(bot, ref) {
+  return bot.sendForReply({ op: 'GET', to: ref })
+}
+
+// Paper.READ replies with the raw PETSCII page. Sent as a raw op rather
+// than through bot.readObject, which routes via habiworld's paper_do and
+// gates on ctx.inHand — and our world model can never satisfy that gate,
+// because Paper.GET announces the pick-up with send_neighbor_msg, which
+// excludes the actor. The server's own holding() check is the authority.
+function readPaperPage(bot, ref) {
+  return bot.sendForReply({ op: 'READ', to: ref, page: 0 })
+}
+
+function decodePage(reply) {
+  const codes = (reply && reply.ascii) || []
+  let out = ''
+  for (const c of codes) {
+    if (c === 0) break
+    out += String.fromCharCode(c)
+  }
+  return out
+}
+
+// Paper.PUT destroys a sheet outright once it is blank (Paper.java:334) —
+// the same way a player gets rid of scrap by stuffing it back in a pocket.
+// This is what keeps MAIL_SLOT at exactly one Paper: GET spawns the
+// replacement, and the sheet we read gets disposed of instead of piling up
+// as a second occupant of the slot.
+function discardBlankPaper(bot, ref) {
+  const me = bot.world && bot.world.me
+  if (!me) return Promise.resolve({ ok: false })
+  return bot.send({ op: 'PUT', to: ref, containerNoid: me.noid, x: 0, y: DISCARD_SLOT, orientation: 0 })
+}
+
+// composeAndSendMail — pick up a blank Paper, write the addressed page,
+// and PSENDMAIL it. The bot must be logged in: mailing is an avatar
+// action, not a server call.
+//
+// Resolves { ok: true, recipient, truncated } or { ok: false, error }.
+// Never throws for an expected condition (bad name, no blank paper) —
+// callers surface `error` to a human.
+async function composeAndSendMail(bot, opts) {
+  const recipient = String((opts && opts.recipient) || '').trim().toLowerCase()
+  const body = String((opts && opts.body) || '')
+  if (!recipient) return { ok: false, error: 'recipient is required' }
+  if (!RECIPIENT_REGEX.test(recipient)) {
+    return { ok: false, error: `recipient "${recipient}" doesn't look like an avatar name` }
+  }
+  if (!sanitizeLines(body).join('').trim()) {
+    return { ok: false, error: 'body is empty after sanitizing' }
+  }
+
+  let { paper, error } = chooseBlankPaper(bot)
+  const readLetters = []
+  if (error && opts && opts.drainMail) {
+    // Out of blank paper because someone mailed us. Read their letter and
+    // reuse the sheet rather than going mute.
+    const drained = await drainMailSlot(bot)
+    if (drained.drained) {
+      if (drained.body) readLetters.push({ sender: drained.sender, body: drained.body })
+      await new Promise((r) => setTimeout(r, 500)) // let the FIDDLE_$ land
+      ;({ paper, error } = chooseBlankPaper(bot))
+    }
+  }
+  if (error) return { ok: false, error, readLetters: readLetters }
+
+  const { text, truncated } = buildMailPage(recipient, body)
+  if (paper.slot !== awareness.HANDS_SLOT) {
+    await withTimeout(getObj(bot, paper.ref), 10000, 'composeAndSendMail.pick_up')
+  }
+  await withTimeout(bot.writePaper(paper.ref, text), 10000, 'composeAndSendMail.write')
+  await withTimeout(bot.mailPaper(paper.ref), 10000, 'composeAndSendMail.send')
+  log.info(`mailed a letter to ${recipient} (${text.length} chars, truncated=${truncated})`)
+  return { ok: true, recipient, truncated, readLetters: readLetters }
+}
+
+module.exports = {
+  composeAndSendMail,
+  drainMailSlot,
+  parsePostmark,
+  buildMailPage,
+  wrapForPaper,
+  MAIL_COLS,
+  MAIL_ROWS,
+  MAIL_BODY_ROWS,
+  MAIL_BODY_MAX,
+  CLEAR_SENTINEL_LENGTH,
+}

--- a/habibots/lib/oracle-footer.js
+++ b/habibots/lib/oracle-footer.js
@@ -1,0 +1,42 @@
+/* jshint esversion: 8 */
+
+'use strict'
+
+// oracle-footer.js — reads the routing key bridge_v2 stamps on an oracle
+// request. This is one half of a cross-language contract; the other half
+// is formatOracleFooter in bridge_v2/bridge/oracle.go. Isolated here so
+// both ends can be tested against the same examples.
+//
+// Format: "<user ref> · <display name>", e.g. "user-randy · Randy".
+//
+// Both fields are carried because they are not interchangeable. The ref
+// identifies the account for logs; Habitat mail is addressed by DISPLAY
+// NAME, since Region.addUser keys NameToUser on name().toLowerCase() and
+// Avatar.mailQueueRef() is "mail-" + that. The ref cannot recover the
+// name: ensureUserCreated builds it by lowercasing the name and mapping
+// spaces to underscores, and names may contain underscores themselves.
+//
+// The name is free-form, so it goes LAST and everything after the ref is
+// rejoined — a name containing the separator still round-trips.
+
+const SEPARATOR = ' · '
+const REF_PREFIX = 'user-'
+
+// Returns { userRef, name } or null when this is not an oracle request.
+function askerFromFooter(text) {
+  if (!text) return null
+  const parts = String(text).split(SEPARATOR)
+  if (parts.length < 2) return null
+  const userRef = parts[0].trim()
+  const name = parts.slice(1).join(SEPARATOR).trim()
+  if (!userRef.startsWith(REF_PREFIX) || userRef.length <= REF_PREFIX.length || !name) return null
+  return { userRef: userRef, name: name }
+}
+
+// Convenience for a discord.js Message: the relay posts exactly one embed.
+function askerFromMessage(msg) {
+  const embed = msg && msg.embeds && msg.embeds[0]
+  return askerFromFooter(embed && embed.footer && embed.footer.text)
+}
+
+module.exports = { askerFromFooter, askerFromMessage, SEPARATOR }

--- a/habibots/lib/oracle-outbox.js
+++ b/habibots/lib/oracle-outbox.js
@@ -1,0 +1,136 @@
+/* jshint esversion: 8 */
+
+'use strict'
+
+// oracle-outbox.js — durable queue for Oracle answers awaiting delivery.
+//
+// Mailing is an avatar action: PSENDMAIL only works while the bot is
+// logged in and holding a Paper. An operator in Discord has no idea
+// whether that's true right now, and their answer is hand-written — it
+// is not the kind of message the DiscordNotifier's drop-on-full posture
+// is acceptable for. So every answer is written down BEFORE Discord is
+// told anything, and drained whenever the Habitat session comes up.
+//
+// Storage mirrors lib/sage/memory.js: the `habibots` mongo database (kept
+// apart from elko's `elko.odb`), lazy idempotent connect, and a fall back
+// to process memory if mongo is unreachable so the bot still runs in dev.
+// Keyed by Discord message id, so a double modal submit — or a retry
+// after a crash — cannot mail the same answer twice.
+
+const log = require('winston')
+const { MongoClient } = require('mongodb')
+
+const DEFAULT_URI = process.env.HABIBOTS_MONGO_URL || 'mongodb://neohabitatmongo:27017'
+const DB_NAME = 'habibots'
+const COLLECTION = 'oracle_outbox'
+
+class OracleOutbox {
+  constructor(uri) {
+    this.uri = uri || DEFAULT_URI
+    this.client = null
+    this.col = null
+    this.ready = false
+    this._initPromise = null
+    this.fallback = new Map() // used only when mongo is unreachable
+  }
+
+  async _ensureReady() {
+    if (this.ready) return true
+    if (this._initPromise) return this._initPromise
+    this._initPromise = (async () => {
+      try {
+        this.client = new MongoClient(this.uri, {
+          serverSelectionTimeoutMS: 3000,
+          connectTimeoutMS: 3000,
+        })
+        await this.client.connect()
+        this.col = this.client.db(DB_NAME).collection(COLLECTION)
+        await this.col.createIndex({ status: 1, queuedAt: 1 })
+        this.ready = true
+        log.info('oracle outbox connected to mongo')
+      } catch (err) {
+        log.warn(`oracle outbox: mongo unavailable (${err.message}); queueing in memory only`)
+        this.client = null
+        this.col = null
+      }
+      return this.ready
+    })()
+    return this._initPromise
+  }
+
+  // Record an answer. Returns 'inserted' when this is the first answer to
+  // the request, or the EXISTING status ('queued' | 'sent') when the
+  // request has already been answered — two Oracles can both open a modal
+  // on the same message, and only the first may mail. Distinguishing the
+  // two matters: "already queued but not yet delivered" still means don't
+  // send again.
+  async enqueue(entry) {
+    const doc = {
+      _id: entry.id,
+      recipient: entry.recipient,
+      body: entry.body,
+      askedBy: entry.askedBy || null,
+      answeredBy: entry.answeredBy || null,
+      status: 'queued',
+      queuedAt: new Date(),
+    }
+    await this._ensureReady()
+    if (!this.col) {
+      if (this.fallback.has(entry.id)) return this.fallback.get(entry.id).status
+      this.fallback.set(entry.id, doc)
+      return 'inserted'
+    }
+    try {
+      await this.col.insertOne(doc)
+      return 'inserted'
+    } catch (err) {
+      if (err && err.code === 11000) {
+        const existing = await this.col.findOne({ _id: entry.id })
+        return (existing && existing.status) || 'queued'
+      }
+      throw err
+    }
+  }
+
+  async pending() {
+    await this._ensureReady()
+    if (!this.col) {
+      return [...this.fallback.values()].filter((d) => d.status === 'queued')
+    }
+    return this.col.find({ status: 'queued' }).sort({ queuedAt: 1 }).toArray()
+  }
+
+  async markSent(id) {
+    await this._ensureReady()
+    if (!this.col) {
+      const doc = this.fallback.get(id)
+      if (doc) { doc.status = 'sent'; doc.sentAt = new Date() }
+      return
+    }
+    await this.col.updateOne({ _id: id }, { $set: { status: 'sent', sentAt: new Date() } })
+  }
+
+  // Delivery failures stay 'queued' so the next drain retries them; the
+  // error is recorded for the operator reading logs.
+  async noteFailure(id, message) {
+    await this._ensureReady()
+    if (!this.col) {
+      const doc = this.fallback.get(id)
+      if (doc) { doc.lastError = message; doc.attempts = (doc.attempts || 0) + 1 }
+      return
+    }
+    await this.col.updateOne(
+      { _id: id },
+      { $set: { lastError: message, lastAttemptAt: new Date() }, $inc: { attempts: 1 } })
+  }
+
+  async close() {
+    if (this.client) await this.client.close()
+    this.client = null
+    this.col = null
+    this.ready = false
+    this._initPromise = null
+  }
+}
+
+module.exports = { OracleOutbox }

--- a/habibots/lib/sage/tools.js
+++ b/habibots/lib/sage/tools.js
@@ -31,6 +31,7 @@
 const log = require('winston')
 const awareness = require('./awareness')
 const { sanitizeForC64 } = require('./petscii')
+const mail = require('../mail')
 const { ACTION_DO, ACTION_GET, ACTION_GO, ACTION_PUT, ACTION_TALK } = require('../../../habiworld').constants
 
 const TOOLS = [
@@ -938,14 +939,6 @@ function putDown(bot, ref, containerNoid, x, y, orientation) {
   return bot.putObj(ref, containerNoid || 0, x || 80, y || 144, orientation || 0)
 }
 
-// GET op (used by the compose_and_send_mail flow; pick_up goes through
-// bot.performAction('GET') which adds the goToAndGet choreography).
-// Elko's GET takes no parameters beyond `to` — the old containerNoid
-// field drew an "ignored unknown parameter" warning on every send.
-function getObj(bot, ref) {
-  return bot.send({ op: 'GET', to: ref })
-}
-
 // ESP whisper to a specific avatar. Elko's ESP model: SPEAK with
 // `text:"to:NAME"` (esp=0) sets ESPTargetName for this session
 // (Avatar.SPEAK at line 669-680 of Avatar.java). After that, op:ESP
@@ -1299,52 +1292,14 @@ async function executeAction(toolUse, bot, ctx) {
         await withTimeout(bot.mailPaper(args.ref), 10_000, 'mail_paper')
         return { ok: true }
       case 'compose_and_send_mail': {
-        // The "to: <name>" first line is mandatory and easy for Claude to
-        // forget — bundling pick_up + write + mail into a single tool
-        // eliminates the failure mode where sage writes a body but no
-        // address line, the PSENDMAIL gets rejected, and sage doesn't
-        // notice because the dispatch returned ok:true at TCP-write
-        // time.
-        //
-        // Source-of-blank-paper preference order:
-        //   1. blank Paper already in HANDS — write + mail in place.
-        //   2. blank Paper in a numbered pocket slot — pick_up first.
-        //   3. blank Paper in MAIL_SLOT — pick_up; elko auto-spawns a
-        //      fresh blank Paper in MAIL_SLOT (Paper.GET special-case).
-        //   4. unread LETTER in MAIL_SLOT — refuse with a clear error,
-        //      because picking it up would dismiss unread mail.
-        //   5. no blank paper anywhere — refuse.
-        const recipient = String(args.recipient || '').trim().toLowerCase()
-        const body = String(args.body || '')
-        if (!recipient) return { ok: false, error: 'recipient is required' }
-        if (!/^[a-z0-9._-]{1,20}$/.test(recipient)) {
-          return { ok: false, error: `recipient "${recipient}" doesn't look like an avatar name` }
-        }
-        const inv = awareness.getInventory(bot)
-        const papers = inv.filter((it) => it.type === 'Paper')
-        if (!papers.length) return { ok: false, error: 'you have no Paper in your pocket' }
-        // Categorize by current paper state. grState=0 BLANK, =2 LETTER.
-        const isBlank = (p) => (p.grState || 0) === awareness.PAPER_BLANK_STATE
-        let chosen =
-          papers.find((p) => p.slot === awareness.HANDS_SLOT && isBlank(p)) ||
-          papers.find((p) => p.slot !== awareness.MAIL_SLOT && p.slot !== awareness.HANDS_SLOT && isBlank(p)) ||
-          papers.find((p) => p.slot === awareness.MAIL_SLOT && isBlank(p))
-        if (!chosen) {
-          // The only remaining papers are LETTER state — would lose mail.
-          return {
-            ok: false,
-            error:
-              'all pocket Paper is in LETTER state (unread mail). READ it first, then a blank ' +
-              'paper will be available for composing.',
-          }
-        }
-        if (chosen.slot !== awareness.HANDS_SLOT) {
-          await withTimeout(getObj(bot, chosen.ref), 10_000, 'compose_and_send_mail.pick_up')
-        }
-        const text = `to: ${recipient}\n${body}`
-        await withTimeout(bot.writePaper(chosen.ref, text), 10_000, 'compose_and_send_mail.write')
-        await withTimeout(bot.mailPaper(chosen.ref), 10_000, 'compose_and_send_mail.send')
-        return { ok: true, recipient }
+        // Bundles pick_up + write + mail into one tool because the
+        // mandatory "to: <name>" first line is easy for Claude to
+        // forget, and the failure mode is invisible: PSENDMAIL gets
+        // rejected but dispatch already returned ok:true at TCP-write
+        // time. lib/mail.js owns the page shape (blank-paper source
+        // order, 40x16 wrapping, the length-16 clear sentinel) and is
+        // shared with the oracle bot.
+        return mail.composeAndSendMail(bot, { recipient: args.recipient, body: args.body })
       }
       case 'ask_object':
         await withTimeout(bot.askObject(args.ref, args.text || ''), 10_000, 'ask_object')

--- a/habibots/package-lock.json
+++ b/habibots/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.120.0",
+        "discord.js": "^14.27.0",
         "elizabot": "^0.0.3",
         "mongodb": "^7.5.0",
         "promise-queue": "^2.2.3",
@@ -67,6 +68,136 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.3.tgz",
+      "integrity": "sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.50",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "^6.27.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
@@ -74,6 +205,39 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@so-ric/colorspace": {
@@ -91,6 +255,15 @@
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -111,6 +284,25 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -221,6 +413,42 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/discord-api-types": {
+      "version": "0.38.54",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.54.tgz",
+      "integrity": "sha512-3704EKdPtVl0Mozoe6uBJQ8GNmUkH8c81nfXkdSBx+Um8GN3FI/003uTY0Pg0A4KjL8g2Q+4v5cHR247kv6vwA==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.27.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
+      "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.5",
+        "discord-api-types": "^0.38.49",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "^6.27.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
     "node_modules/elizabot": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/elizabot/-/elizabot-0.0.3.tgz",
@@ -245,6 +473,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
@@ -321,6 +555,18 @@
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "license": "MIT"
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
     "node_modules/logform": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
@@ -337,6 +583,12 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.1.tgz",
+      "integrity": "sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==",
+      "license": "MIT"
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",
@@ -601,6 +853,33 @@
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -658,6 +937,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/habibots/package.json
+++ b/habibots/package.json
@@ -4,6 +4,7 @@
   "description": "In-world bots for Neohabitat",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.120.0",
+    "discord.js": "^14.27.0",
     "elizabot": "^0.0.3",
     "mongodb": "^7.5.0",
     "promise-queue": "^2.2.3",

--- a/habibots/run
+++ b/habibots/run
@@ -88,13 +88,23 @@ if [[ "${@}" = *"protester"* ]]; then
 fi
 
 if [[ "${@}" = *"oracle"* ]]; then
-  echo 'Launching oracle...'
-  supervisor -w "${DIR}" -- bots/oracle.js \
-    -c "${GREETER1_REGION}" \
-    -h "${HABITAT_HOST}" \
-    -p "${HABITAT_PORT}" \
-    -s "${SLACK_TOKEN}" \
-    -u devil &
+  if [[ -z "${DISCORD_BOT_TOKEN}" || -z "${DISCORD_ORACLE_GUILD_ID}" || -z "${DISCORD_ORACLE_CHANNEL_ID}" ]]; then
+    # Same reasoning as sage: bots.env may not be deployed yet, and a bot
+    # that exits on every start just makes supervisor thrash. Re-deploy
+    # once the secrets are written to bring the oracle up.
+    echo 'Skipping oracle (Discord credentials not set).'
+  else
+    echo 'Launching oracle...'
+    # Lowercase, like every other bot: Elko user refs are case-sensitive
+    # and the seeded avatar is `user-oracle`.
+    : "${HABIBOTS_ORACLE_REGION:=context-oraclehome}"
+    : "${HABIBOTS_ORACLE_USER:=oracle}"
+    supervisor -w "${DIR}" -- bots/oracle.js \
+      -c "${HABIBOTS_ORACLE_REGION}" \
+      -h "${HABITAT_HOST}" \
+      -p "${HABITAT_PORT}" \
+      -u "${HABIBOTS_ORACLE_USER}" &
+  fi
 fi
 
 if [[ "${@}" = *"sage"* ]]; then

--- a/habibots/test/mail.test.js
+++ b/habibots/test/mail.test.js
@@ -1,0 +1,167 @@
+/* jshint esversion: 8 */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const mail = require('../lib/mail')
+
+// Paper.java:157 treats a 16-element request_ascii as "erase this sheet".
+// "to: oracle\n" is 11 chars, so a 5-character body lands exactly on the
+// sentinel and would blank the Paper instead of mailing it.
+test('a 16-character page is padded off the clear sentinel', () => {
+  const { text } = mail.buildMailPage('oracle', 'abcde')
+  assert.notStrictEqual(text.length, mail.CLEAR_SENTINEL_LENGTH)
+  assert.strictEqual(text, 'to: oracle\nabcde ')
+})
+
+test('pages that are not 16 chars are left alone', () => {
+  assert.strictEqual(mail.buildMailPage('randy', 'Hi').text, 'to: randy\nHi')
+})
+
+test('the address is the literal first line PSENDMAIL parses', () => {
+  const { text } = mail.buildMailPage('Randy', 'seek within')
+  assert.strictEqual(text.split('\n')[0], 'to: Randy')
+})
+
+test('no line exceeds the 40-column page width', () => {
+  const body = Array.from({ length: 40 }, (_, i) => `word${i}`).join(' ')
+  for (const line of mail.buildMailPage('randy', body).text.split('\n')) {
+    assert.ok(line.length <= mail.MAIL_COLS, `line too wide: ${line.length}`)
+  }
+})
+
+test('a word longer than the page width is split rather than lost', () => {
+  const { text } = mail.buildMailPage('randy', 'x'.repeat(95))
+  assert.strictEqual(text.split('\n').slice(1).join('').length, 95)
+})
+
+test('a body longer than the page is truncated and marked', () => {
+  const body = Array.from({ length: 200 }, (_, i) => `word${i}`).join(' ')
+  const { text, truncated } = mail.buildMailPage('randy', body)
+  assert.ok(truncated)
+  // Row 0 is the address line; the body gets the remaining 15.
+  assert.strictEqual(text.split('\n').length, mail.MAIL_ROWS)
+  assert.ok(text.endsWith(' ...'), `expected a truncation marker, got ${JSON.stringify(text)}`)
+})
+
+test('a body that fits is not marked truncated', () => {
+  const { truncated } = mail.buildMailPage('randy', 'short enough')
+  assert.strictEqual(truncated, false)
+})
+
+// habibot.writePaper does charCodeAt(i) & 0x7F, so anything above 7-bit
+// ASCII has to be folded before it reaches the wire or it renders as
+// garbage block glyphs on the C64.
+test('non-ASCII is folded before it can reach the wire', () => {
+  const { text } = mail.buildMailPage('randy', 'Seek — the “oracle” \u{1F52E}')
+  assert.strictEqual(text, 'to: randy\nSeek - the "oracle" :-)')
+  for (const ch of text) {
+    assert.ok(ch === '\n' || (ch.charCodeAt(0) >= 0x20 && ch.charCodeAt(0) <= 0x7e), `bad char ${ch}`)
+  }
+})
+
+test('author paragraph breaks survive wrapping', () => {
+  const { text } = mail.buildMailPage('randy', 'one\n\ntwo')
+  assert.deepStrictEqual(text.split('\n'), ['to: randy', 'one', '', 'two'])
+})
+
+test('composeAndSendMail rejects a bad recipient before touching the world', async () => {
+  const bot = { send: () => assert.fail('must not talk to elko') }
+  assert.strictEqual((await mail.composeAndSendMail(bot, { recipient: '', body: 'x' })).ok, false)
+  assert.strictEqual((await mail.composeAndSendMail(bot, { recipient: 'a b', body: 'x' })).ok, false)
+})
+
+test('composeAndSendMail rejects a body that sanitizes away to nothing', async () => {
+  const bot = { send: () => assert.fail('must not talk to elko') }
+  const res = await mail.composeAndSendMail(bot, { recipient: 'randy', body: '\u{1F52E}'.repeat(0) + '   ' })
+  assert.strictEqual(res.ok, false)
+})
+
+// Mail is addressed by display name, not by user ref, and Habitat names
+// may contain spaces ("Phil Collins" → mail-phil collins).
+test('a display name with a space is a valid recipient', async () => {
+  const { text } = mail.buildMailPage('Phil Collins', 'seek within')
+  assert.strictEqual(text.split('\n')[0], 'to: Phil Collins')
+  const bot = { send: () => assert.fail('must not talk to elko') }
+  // Rejection here would have to come from the world, not the name check;
+  // with no inventory it stops at "no Paper", proving the name passed.
+  const res = await mail.composeAndSendMail(bot, { recipient: 'Phil Collins', body: 'x' })
+  assert.strictEqual(res.ok, false)
+  assert.match(res.error, /Paper/)
+})
+
+// Paper.WRITE's clear sentinel is a request_ascii of exactly 16 elements.
+// habibot.writePaper documented "pass empty string to clear" but sent a
+// length-0 array, which takes the write branch instead and leaves the
+// sheet WRITTEN holding nothing — so a drained mail sheet never became
+// reusable. Both directions of that are now handled at the wire level.
+test('writePaper sends the clear sentinel for an empty page', () => {
+  const HabiBot = require('../habibot')
+  const bot = Object.create(HabiBot.prototype)
+  let sent = null
+  bot.sendWithDelay = (msg) => { sent = msg; return Promise.resolve({ ok: true }) }
+  bot.writePaper('item-x', '')
+  assert.strictEqual(sent.request_ascii.length, mail.CLEAR_SENTINEL_LENGTH)
+})
+
+test('writePaper never lets a real page collide with the clear sentinel', () => {
+  const HabiBot = require('../habibot')
+  const bot = Object.create(HabiBot.prototype)
+  let sent = null
+  bot.sendWithDelay = (msg) => { sent = msg; return Promise.resolve({ ok: true }) }
+  bot.writePaper('item-x', 'x'.repeat(mail.CLEAR_SENTINEL_LENGTH))
+  assert.notStrictEqual(sent.request_ascii.length, mail.CLEAR_SENTINEL_LENGTH)
+  assert.strictEqual(sent.request_ascii[mail.CLEAR_SENTINEL_LENGTH], 32) // padded with ' '
+})
+
+// A player mailing "to: oracle" parks a LETTER in the bot's MAIL_SLOT.
+// That slot is the only self-replenishing paper source (Paper.GET's
+// special_get is MAIL_SLOT-only), so without draining, one letter stops
+// the bot answering anyone.
+test('drainMailSlot is a no-op when the mail slot holds no letter', async () => {
+  const bot = { world: null, send: () => assert.fail('must not talk to elko') }
+  assert.deepStrictEqual(await mail.drainMailSlot(bot), { drained: false, text: '' })
+})
+
+test('composeAndSendMail only dismisses unread mail when asked to', async () => {
+  // No drainMail flag: an unread LETTER must be left alone, even though it
+  // means refusing to send. This is what keeps sage from eating someone's mail.
+  const inv = [{ ref: 'p1', type: 'Paper', slot: 4, grState: 2, name: 'Pad and mailbox' }]
+  const bot = {
+    world: { me: { noid: 1 }, inventory: () => inv.map((i) => ({ ref: i.ref, type: i.type, name: i.name, noid: 1, mod: { y: i.slot, gr_state: i.grState } })) },
+    send: () => assert.fail('must not touch the letter'),
+  }
+  const res = await mail.composeAndSendMail(bot, { recipient: 'randy', body: 'hello' })
+  assert.strictEqual(res.ok, false)
+  assert.match(res.error, /LETTER state/)
+})
+
+// A Paper carries no sender field. Paper.addPostmark overwrites the "to:"
+// line with "From: %-14s Postmark: %s ", so that line is the only record
+// of who wrote — and it is what the Oracle relays to Discord.
+test('the sender is recovered from the postmark line', () => {
+  const p = mail.parsePostmark('From: Steve          Postmark: 26-09-01 Oracle, why is the sky green?')
+  assert.deepStrictEqual(p, { sender: 'Steve', date: '26-09-01', body: 'Oracle, why is the sky green?' })
+})
+
+test('a display name with a space survives the %-14s padding', () => {
+  const p = mail.parsePostmark('From: Phil Collins   Postmark: 26-09-01 Two words.')
+  assert.strictEqual(p.sender, 'Phil Collins')
+  assert.strictEqual(p.body, 'Two words.')
+})
+
+test('a multi-line letter body keeps its lines', () => {
+  const p = mail.parsePostmark('From: Steve          Postmark: 26-09-01 line one\nline two')
+  assert.strictEqual(p.body, 'line one\nline two')
+})
+
+// No postmark means no addressable sender — the relay posts it without a
+// footer so the answer command refuses rather than mailing nowhere.
+test('an unpostmarked page yields no sender rather than a wrong one', () => {
+  const p = mail.parsePostmark('just some scribbles')
+  assert.strictEqual(p.sender, null)
+  assert.strictEqual(p.body, 'just some scribbles')
+  assert.strictEqual(mail.parsePostmark('').sender, null)
+  assert.strictEqual(mail.parsePostmark(null).sender, null)
+})

--- a/habibots/test/oracle-footer.test.js
+++ b/habibots/test/oracle-footer.test.js
@@ -1,0 +1,43 @@
+/* jshint esversion: 8 */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const { askerFromFooter, askerFromMessage } = require('../lib/oracle-footer')
+
+// These must stay in lockstep with formatOracleFooter in
+// bridge_v2/bridge/oracle.go and its tests in oracle_test.go.
+test('reads the ref and name the relay stamps', () => {
+  assert.deepStrictEqual(askerFromFooter('user-randy · Randy'), { userRef: 'user-randy', name: 'Randy' })
+})
+
+test('a display name with spaces survives', () => {
+  assert.deepStrictEqual(
+    askerFromFooter('user-phil_collins · Phil Collins'),
+    { userRef: 'user-phil_collins', name: 'Phil Collins' })
+})
+
+// The name is free-form, which is exactly why it is last.
+test('a display name containing the separator round-trips', () => {
+  assert.deepStrictEqual(
+    askerFromFooter('user-phil_collins · Phil · Collins'),
+    { userRef: 'user-phil_collins', name: 'Phil · Collins' })
+})
+
+test('non-oracle messages are rejected rather than half-parsed', () => {
+  assert.strictEqual(askerFromFooter(null), null)
+  assert.strictEqual(askerFromFooter(''), null)
+  assert.strictEqual(askerFromFooter('some other bot footer'), null)
+  assert.strictEqual(askerFromFooter('Randy · asked something'), null, 'must require the user- prefix')
+  assert.strictEqual(askerFromFooter('user- · Randy'), null, 'a bare prefix is not a ref')
+  assert.strictEqual(askerFromFooter('user-randy · '), null, 'a missing name is not answerable')
+})
+
+test('reads the first embed of a discord.js message', () => {
+  const msg = { embeds: [{ footer: { text: 'user-randy · Randy' } }] }
+  assert.deepStrictEqual(askerFromMessage(msg), { userRef: 'user-randy', name: 'Randy' })
+  assert.strictEqual(askerFromMessage({ embeds: [] }), null)
+  assert.strictEqual(askerFromMessage({}), null)
+  assert.strictEqual(askerFromMessage({ embeds: [{}] }), null, 'plain-content posts are not requests')
+})

--- a/habibots/test/oracle-outbox.test.js
+++ b/habibots/test/oracle-outbox.test.js
@@ -1,0 +1,54 @@
+/* jshint esversion: 8 */
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert')
+const { OracleOutbox } = require('../lib/oracle-outbox')
+
+// Port 1 refuses immediately, so these exercise the in-memory fallback
+// the outbox degrades to when mongo is unreachable — the same path a dev
+// box without the docker stack takes.
+const offline = () => new OracleOutbox('mongodb://127.0.0.1:1')
+
+test('the first answer to a request is inserted', async () => {
+  const box = offline()
+  assert.strictEqual(await box.enqueue({ id: 'm1', recipient: 'randy', body: 'seek within' }), 'inserted')
+})
+
+// Two Oracles can both open a modal on the same message. Only the first
+// may mail, even while the first is still queued and undelivered.
+test('a second answer to the same request is refused, not queued twice', async () => {
+  const box = offline()
+  await box.enqueue({ id: 'm1', recipient: 'randy', body: 'first' })
+  assert.strictEqual(await box.enqueue({ id: 'm1', recipient: 'randy', body: 'second' }), 'queued')
+  assert.strictEqual((await box.pending()).length, 1)
+  assert.strictEqual((await box.pending())[0].body, 'first')
+})
+
+test('an already-delivered request reports sent', async () => {
+  const box = offline()
+  await box.enqueue({ id: 'm1', recipient: 'randy', body: 'first' })
+  await box.markSent('m1')
+  assert.strictEqual(await box.enqueue({ id: 'm1', recipient: 'randy', body: 'second' }), 'sent')
+  assert.deepStrictEqual(await box.pending(), [])
+})
+
+test('answers awaiting delivery come back oldest first', async () => {
+  const box = offline()
+  await box.enqueue({ id: 'm1', recipient: 'randy', body: 'one' })
+  await box.enqueue({ id: 'm2', recipient: 'steve', body: 'two' })
+  assert.deepStrictEqual((await box.pending()).map((e) => e._id), ['m1', 'm2'])
+})
+
+// A delivery failure must leave the answer queued so the next drain
+// retries it — the operator should never have to retype a letter.
+test('a failed delivery stays queued', async () => {
+  const box = offline()
+  await box.enqueue({ id: 'm1', recipient: 'randy', body: 'one' })
+  await box.noteFailure('m1', 'the Oracle is not in-world yet')
+  const pending = await box.pending()
+  assert.strictEqual(pending.length, 1)
+  assert.strictEqual(pending[0].lastError, 'the Oracle is not in-world yet')
+  assert.strictEqual(pending[0].attempts, 1)
+})

--- a/src/main/java/org/made/neohabitat/Constants.java
+++ b/src/main/java/org/made/neohabitat/Constants.java
@@ -252,6 +252,17 @@ public interface Constants {
     public static final int      MISC_FLAG3                 = 7;
     /* avatar NEOHabitat nitty_bit flags start at the top and work down. */
     public static final int      INTENTIONAL_GHOST          = 31;
+    /**
+     * Keeps an avatar out of Region.NameToUser, which is the single table behind every
+     * "who else is here" feature: the F3 user list, /online population counts, ESP
+     * targeting by name, /join, /invite, /teleport, /yank and tellEveryone. Set it on a
+     * service avatar (the Oracle, and any bot we don't want players addressing) so it can
+     * hold a session and use the mail system without ever appearing as a resident.
+     *
+     * Mail sent TO a hidden avatar takes Paper.sendMailToUser's offline branch and queues
+     * at mail-&lt;name&gt; in mongo, which is where its bot reads replies from anyway.
+     */
+    public static final int      HIDDEN_AVATAR              = 30;
     
     /* object nitty-bits constants */
     public static final int      DOOR_AVATAR_RESTRICTED_BIT = 32;

--- a/src/main/java/org/made/neohabitat/mods/Region.java
+++ b/src/main/java/org/made/neohabitat/mods/Region.java
@@ -263,11 +263,21 @@ public class Region extends Container implements UserWatcher, ContextMod, Contex
                 if (avatar.amAGhost) {
                     object_say(who, UPGRADE_PREFIX + "You are a ghost. Press F1 to become an Avatar.");
                 }
-                tellEveryone(who.name() + " has arrived.");
+                if (!avatar.nitty_bits[HIDDEN_AVATAR]) {
+                    tellEveryone(who.name() + " has arrived.");
+                }
             }
         }
         avatar.check_mail();
-        Region.addUser(who);
+        // NameToUser is what every "who else is here" feature reads: the F3 list
+        // (sayUserList), /online counts (topPopulatedRealms), ESP targeting, /join,
+        // /invite, /teleport, /yank and tellEveryone. Keeping a hidden avatar out of it
+        // suppresses all of them at once. removeUser needs no matching guard — removing an
+        // absent key is a no-op, and its other work (region contents, obj list) still
+        // has to happen.
+        if (!avatar.nitty_bits[HIDDEN_AVATAR]) {
+            Region.addUser(who);
+        }
     }
 
     public void noteUserDeparture(User who) {

--- a/tools/discord-webhook-capture.js
+++ b/tools/discord-webhook-capture.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * discord-webhook-capture.js — a stand-in for a Discord webhook, so the
+ * bridge's alert and oracle-relay output can be seen on a dev box without
+ * touching a real server.
+ *
+ * bridge_v2/DISCORD_ALERTS.md says to point DISCORD_WEBHOOK_* at "a local
+ * capture server" and never post test traffic to the public channels.
+ * This is that server.
+ *
+ *   node tools/discord-webhook-capture.js            # listens on :9099
+ *   node tools/discord-webhook-capture.js --port=... # somewhere else
+ *
+ * Then, in the repo-local .env the dev bridge reads:
+ *   DISCORD_WEBHOOK_ORACLE_REQUESTS=http://host.docker.internal:9099/oracle
+ *   DISCORD_WEBHOOK_LOGINS=http://host.docker.internal:9099/logins
+ * and restart the bridge:  docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d bridge_v2
+ *
+ * Prints each post the way it matters for the oracle work: the prose, and
+ * the embed footer that carries the routing key the answering bot reads
+ * back (see formatOracleFooter in bridge_v2/bridge/oracle.go).
+ *
+ * Answers 204 like Discord does. --fail=CODE returns that status instead,
+ * to exercise the notifier's retry path.
+ */
+
+'use strict'
+
+const http = require('http')
+
+const opts = { port: 9099, fail: 0 }
+for (const arg of process.argv.slice(2)) {
+  const [key, value] = arg.replace(/^--/, '').split('=')
+  if (key === 'port' && value) opts.port = parseInt(value, 10)
+  else if (key === 'fail' && value) opts.fail = parseInt(value, 10)
+  else if (key === 'help' || key === 'h') {
+    console.log('usage: discord-webhook-capture.js [--port=9099] [--fail=STATUS]')
+    process.exit(0)
+  } else { console.error(`Unrecognised argument: ${arg}`); process.exit(1) }
+}
+
+let seq = 0
+
+const server = http.createServer((req, res) => {
+  let body = ''
+  req.on('data', (chunk) => { body += chunk })
+  req.on('end', () => {
+    seq += 1
+    const when = new Date().toISOString().slice(11, 19)
+    console.log(`\n[${when}] #${seq}  ${req.method} ${req.url}`)
+    let payload
+    try { payload = JSON.parse(body) } catch (err) {
+      console.log('  (unparseable body) ' + body.slice(0, 400))
+      res.writeHead(204).end()
+      return
+    }
+    if (payload.content) console.log('  content: ' + payload.content)
+    for (const embed of payload.embeds || []) {
+      if (embed.description) console.log('  embed:   ' + embed.description)
+      // The contract the answering bot depends on: "<user ref> · <name>",
+      // name last because it is the free-form field. Reported for every
+      // embed, since a missing footer is just as unanswerable as a malformed
+      // one and is the likelier mistake.
+      const footer = (embed.footer && embed.footer.text) || ''
+      if (footer) console.log('  footer:  ' + footer)
+      const parts = footer.split(' · ')
+      if (footer && parts.length >= 2 && parts[0].startsWith('user-')) {
+        console.log(`           -> ref=${parts[0]}  mails to "${parts.slice(1).join(' · ').toLowerCase()}"`)
+      } else {
+        console.log('           -> NOT answerable: no "user-<ref> · <name>" footer')
+      }
+    }
+    // allowed_mentions must stay locked: avatar names are player input.
+    const parse = payload.allowed_mentions && payload.allowed_mentions.parse
+    if (!Array.isArray(parse) || parse.length !== 0) {
+      console.log('  !! allowed_mentions is not locked: ' + JSON.stringify(payload.allowed_mentions))
+    }
+    if (opts.fail) {
+      res.writeHead(opts.fail, { 'Retry-After': '1' }).end()
+      console.log(`  (answered ${opts.fail} to exercise the retry path)`)
+      return
+    }
+    res.writeHead(204).end()
+  })
+})
+
+server.listen(opts.port, () => {
+  console.log(`Discord webhook capture listening on http://0.0.0.0:${opts.port}`)
+  console.log('From a container, reach it as http://host.docker.internal:' + opts.port + '/<channel>')
+  if (opts.fail) console.log(`Answering every post with HTTP ${opts.fail}.`)
+})


### PR DESCRIPTION
Closes the loop on `#oracle-requests`. bridge_v2 has been relaying every ASK on a fountain and WISH on a magic lamp to Discord, and nothing could answer — elko's `message_to_god` is a stub and `CLASS_ORACLE` was never ported, which is why the relay lives in the bridge at all.

Now an Oracle right-clicks a request in Discord, types a reply in a modal, and the asker finds a letter in their pocket postmarked `From: Oracle`. Mail rather than speech because by the time a human reads the channel the asker has almost certainly logged out, and mail is the one in-world mechanism that waits for them.

## Shape

- **Discord surface** is a MESSAGE context-menu command, not reply-watching. The interaction resolves the target message for us, so the footer is readable with **no Message Content intent** — the bot never sees the text of anything nobody pointed it at. Application commands arrive over the gateway, so **no HTTPS interactions endpoint and no new public surface on prod**.
- **Correlation is stateless.** `oracle.go` now posts an embed whose description is the same prose as before, plus a footer `"<user ref> · <display name>"`. Both fields are needed: mail is addressed by *display name* (`Region.addUser` keys `NameToUser` on `name().toLowerCase()`), and the ref can't recover it because `ensureUserCreated` maps spaces to underscores while names may contain underscores. The name is free-form, so it goes last.
- **Runs as a habibot**, not in the bridge: the bridge can't make mail, it holds the TCP_REPAIR'd C64 sessions, and a bot token in `alerts.env` would force a hard bridge restart on every rotation.

## Why the Oracle is unreachable in-world

`HIDDEN_AVATAR` (a free NeoHabitat nitty_bit) gates `Region.addUser`. `NameToUser` is the single table behind the F3 list, `/online` counts, ESP, `/join`, `/invite`, `/teleport`, `/yank` and `tellEveryone`, so one chokepoint covers all of them. It lives in `context-oraclehome` — floor, wall, a sign reading "Entry Forbidden", no exits, nothing linking to it, no teleport address, and `is_turf` unset so it can never be handed to a new player.

It is **not** a ghost, which looks like the obvious answer: `objectIsComplete` skips `addToNoids` for a ghost's contents, so a ghost's pocket Paper never materialises and there is nothing to pick up.

## Letters to the Oracle

Because it's hidden, mail to it always queues at `mail-oracle` and arrives via `check_mail`. Draining that is **not optional**: `MAIL_SLOT` is the only self-replenishing paper source (`special_get` fires only for that slot), and a blank sheet is refused while the slot holds unread mail — so one player typing `to: oracle` would otherwise leave the Oracle unable to answer anyone, permanently. Reproduced before the fix. Letters now relay to the channel with a ✉️ and a footer, so they're answerable the same way.

## Two bugs found along the way

- `habibot.writePaper` documented "pass empty string to clear" but sent a length-0 array; `Paper.WRITE`'s clear sentinel is a length of exactly **16**, so the empty write left the sheet WRITTEN holding nothing. Wrong for sage too.
- Reading a held letter via `bot.readObject` can never work: `Paper.GET` announces a pick-up with `send_neighbor_msg`, which **excludes the actor**, so our own world model never learns we're holding it and habiworld's `paper_do` gates on `ctx.inHand`. The drain reads with the raw `READ` op, where the server's `holding()` check is the authority.

## Deploying

Ships **dormant**: `habibots/run` skips the oracle bot when `DISCORD_BOT_TOKEN` is unset, so this deploy activates nothing new. The elko change is a no-op for every existing avatar (bit 30 is 0 for all of them).

`db/patchOracleHome.js` installs the two new records on a live server — `make db` runs `nuke` and must never be pointed at prod. Dry-run by default, idempotent, and `--undo` removes everything it added plus the state the Oracle accumulates. Undo is careful never to pattern-match letter bodies (`paper-i-<id>` is shared with every other player's mail).

## Verification

Unit tests plus a live dev stack: ghost vs corporeal inventory, the hidden-flag control pair, ESP refusal, region contents, mail landing with the right postmark, the deadlock and its fix, the one-Paper-per-slot invariant, and the patcher across fresh/apply/re-run/simulated-live-Oracle. 43 habibots tests, the Go suite, and `mvn package` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01St52LGEnJ56ctEpePDYFqD