### PR TITLE
fix(oracle): collect mail addressed to the Oracle

### DIFF
--- a/habibots/bots/oracle.js
+++ b/habibots/bots/oracle.js
@@ -57,6 +57,7 @@ log.configure({
 
 const HabiBot = require('../habibot')
 const mail = require('../lib/mail')
+const awareness = require('../lib/sage/awareness')
 const { OracleOutbox } = require('../lib/oracle-outbox')
 const { askerFromMessage } = require('../lib/oracle-footer')
 
@@ -114,6 +115,16 @@ const NO_PINGS = { parse: [] }
 const LETTER_ICON = '✉️'
 const LETTER_TEXT_MAX = 300 // matches oracleTextMax on the bridge side
 
+// How often to look for mail addressed to the Oracle. See pollForMail for why
+// this has to be a poll rather than an event.
+const MAIL_POLL_SECONDS = parseInt(process.env.HABIBOTS_ORACLE_MAIL_POLL_SECONDS || '120', 10)
+// Worst-case latency before a letter to the Oracle is noticed.
+// Each region entry hands over exactly one letter, so a backlog needs a pass
+// each; bounded so one tick cannot run away.
+const MAIL_DRAIN_PASSES = 5
+// Region entry -> check_mail -> the letter appears in the slot, all asynchronous.
+const MAIL_SETTLE_MS = 3000
+
 const outbox = new OracleOutbox()
 
 // ── Habitat side ───────────────────────────────────────────────────────
@@ -134,6 +145,70 @@ OracleBot.on('enteredRegion', (bot) => {
       return drainOutbox()
     })
     .catch((err) => log.error(`OracleBot could not corporate: ${err.message}`))
+})
+
+// Collecting mail addressed to the Oracle. Two facts shape this, both measured
+// rather than assumed:
+//
+//   - Avatar.check_mail() — the only thing that moves a letter from the
+//     mail-<name> queue into the pocket — runs ONLY in Region.noteUserArrival.
+//     This bot enters its region once and then stands still, so without a nudge
+//     it checks for mail exactly once, at startup, and letters sit in mongo.
+//   - The game's own "* You have MAIL in your pocket. *" announcement did NOT
+//     reliably reach us on that path in testing, so it is treated as a bonus
+//     trigger below, never as the mechanism.
+//
+// So: peek at the queue (a read-only look at elko's own data), and only when
+// something is actually waiting, re-enter the region to make elko hand it over.
+// Re-entering on a bare timer instead would churn context entries for nothing
+// and can trip the region's capacity limit — elko answers a full context with
+// {"op":"exit","why":"full"}, which would lock the Oracle out of its own house.
+let checking = false
+let lastLetterText = null
+
+async function checkForMail() {
+  if (!inWorld || checking) return
+  checking = true
+  try {
+    for (let pass = 0; pass < MAIL_DRAIN_PASSES; pass++) {
+      const slotLetter = awareness.getInventory(OracleBot).some((it) =>
+        it.type === 'Paper' && it.slot === awareness.MAIL_SLOT &&
+        (it.grState || 0) === awareness.PAPER_LETTER_STATE)
+      const waiting = slotLetter ? 0 : await outbox.queuedMailFor(Argv.username)
+      if (!slotLetter && !waiting) return
+      if (!slotLetter) {
+        log.info(`${waiting} letter(s) waiting; re-entering ${Argv.context} to collect`)
+        await OracleBot.gotoContext(Argv.context)
+        await new Promise((r) => setTimeout(r, MAIL_SETTLE_MS))
+      }
+      const drained = await serialize(() => mail.drainMailSlot(OracleBot))
+      if (!drained || !drained.drained) return
+      // The world model can still show the old letter for a moment after the
+      // slot is cleared, and draining again would post the same letter to
+      // Discord twice. The page text is the only identity available here —
+      // text_path is server-side and never reaches the client — so an
+      // identical page back-to-back ends the sweep.
+      if (drained.text && drained.text === lastLetterText) {
+        log.debug('same letter read twice; the mail slot has not caught up yet')
+        return
+      }
+      lastLetterText = drained.text || null
+      log.info(`picked up a letter from ${drained.sender || 'an unknown sender'}`)
+      await relayLetter(drained).catch((err) =>
+        log.error(`could not relay a letter to Discord: ${err.message}`))
+      await new Promise((r) => setTimeout(r, MAIL_SETTLE_MS))
+    }
+  } catch (err) {
+    log.error(`mail check failed: ${err.message}`)
+  } finally {
+    checking = false
+  }
+}
+
+// Free extra trigger when the game does announce (habibot promotes the balloon
+// into this event). Never depended upon — see above.
+OracleBot.on('mailArrived', () => {
+  checkForMail().catch((err) => log.error(`mail check: ${err.message}`))
 })
 
 OracleBot.on('disconnected', () => {
@@ -341,6 +416,9 @@ async function onAnswerSubmitted(interaction) {
     log.warn(`could not mark ${targetId} answered: ${err.message}`)
   }
 }
+
+setInterval(() => { checkForMail().catch((err) => log.error(`mail check: ${err.message}`)) },
+  MAIL_POLL_SECONDS * 1000)
 
 OracleBot.connect()
 discord.login(TOKEN).catch((err) => {

--- a/habibots/lib/mail.js
+++ b/habibots/lib/mail.js
@@ -39,6 +39,11 @@ const CLEAR_SENTINEL_LENGTH = 16
 // blank sheet wherever it lands.
 const DISCARD_SLOT = 0
 
+// Paper.retrievePaperContents loads a letter body from mongo asynchronously, so
+// the first read after the slot is repointed can legitimately come back empty.
+const READ_ATTEMPTS = 4
+const READ_RETRY_MS = 1200
+
 // Mirrors bridge_v2's validAvatarName, lowercased: mail is addressed by
 // DISPLAY NAME (Region.addUser keys NameToUser on name().toLowerCase()),
 // and those legally contain spaces and apostrophes. Paper.findAddressee
@@ -155,11 +160,25 @@ async function drainMailSlot(bot) {
   // GET moves it to HANDS and pops the next queued letter into MAIL_SLOT
   // (Paper.GET's update_mail_slot call). READ requires it be held.
   await withTimeout(getObj(bot, letter.ref), 10000, 'drainMailSlot.pick_up')
+  // Retry an empty read. advance_mail_slot repoints text_path and then loads
+  // the body from mongo ASYNCHRONOUSLY (Paper.retrievePaperContents), so a read
+  // that wins the race gets an empty page — and clearing on the strength of
+  // that would destroy a player's letter without anyone ever seeing it.
   let text = ''
-  try {
-    text = decodePage(await withTimeout(readPaperPage(bot, letter.ref), 10000, 'drainMailSlot.read'))
-  } catch (err) {
-    log.warn(`could not read the letter in MAIL_SLOT before clearing it: ${err.message}`)
+  for (let attempt = 0; attempt < READ_ATTEMPTS && !text; attempt++) {
+    if (attempt) await new Promise((r) => setTimeout(r, READ_RETRY_MS))
+    try {
+      text = decodePage(await withTimeout(readPaperPage(bot, letter.ref), 10000, 'drainMailSlot.read'))
+    } catch (err) {
+      log.warn(`could not read the letter in MAIL_SLOT: ${err.message}`)
+    }
+  }
+  if (!text) {
+    // Leave it where it is rather than clear it away unread. The slot stays
+    // blocked, which is visible and recoverable; a silently destroyed letter
+    // is neither.
+    log.warn('a letter in MAIL_SLOT read back empty after retries; leaving it intact')
+    return { drained: false, text: '', unreadable: true }
   }
   // Blank it (an empty write is Paper.WRITE's clear sentinel, which also
   // resets text_path so is_blank() holds), then put it back in a pocket so
@@ -169,6 +188,9 @@ async function drainMailSlot(bot) {
   await withTimeout(discardBlankPaper(bot, letter.ref), 10000, 'drainMailSlot.discard')
   const letterInfo = parsePostmark(text)
   log.info(`read a letter from ${letterInfo.sender || 'an unknown sender'} out of MAIL_SLOT`)
+  // `text` is the whole page including the postmark, which is the only
+  // identity a caller can use to spot the same letter twice: text_path lives
+  // server-side and never reaches the client's world model.
   return { drained: true, ref: letter.ref, text: text, sender: letterInfo.sender, body: letterInfo.body }
 }
 

--- a/habibots/lib/oracle-outbox.js
+++ b/habibots/lib/oracle-outbox.js
@@ -23,6 +23,9 @@ const { MongoClient } = require('mongodb')
 const DEFAULT_URI = process.env.HABIBOTS_MONGO_URL || 'mongodb://neohabitatmongo:27017'
 const DB_NAME = 'habibots'
 const COLLECTION = 'oracle_outbox'
+// elko's own database, read only, purely to see whether mail is waiting.
+const ELKO_DB = 'elko'
+const ELKO_COLLECTION = 'odb'
 
 class OracleOutbox {
   constructor(uri) {
@@ -122,6 +125,24 @@ class OracleOutbox {
     await this.col.updateOne(
       { _id: id },
       { $set: { lastError: message, lastAttemptAt: new Date() }, $inc: { attempts: 1 } })
+  }
+
+  // Is there mail waiting for this avatar? A READ-ONLY peek at elko's own
+  // queue, used only to decide whether it is worth re-entering the region;
+  // every actual change still goes through the game. Returns 0 when mongo is
+  // unavailable, so an unreachable database means "do nothing", never a storm
+  // of region entries.
+  async queuedMailFor(avatarName) {
+    await this._ensureReady()
+    if (!this.client) return 0
+    try {
+      const doc = await this.client.db(ELKO_DB).collection(ELKO_COLLECTION)
+        .findOne({ ref: `mail-${String(avatarName).toLowerCase()}` })
+      return (doc && Array.isArray(doc.queue)) ? doc.queue.length : 0
+    } catch (err) {
+      log.warn(`could not peek at the mail queue: ${err.message}`)
+      return 0
+    }
   }
 
   async close() {

--- a/habibots/test/mail.test.js
+++ b/habibots/test/mail.test.js
@@ -165,3 +165,23 @@ test('an unpostmarked page yields no sender rather than a wrong one', () => {
   assert.strictEqual(mail.parsePostmark('').sender, null)
   assert.strictEqual(mail.parsePostmark(null).sender, null)
 })
+
+// elko loads a letter body from mongo asynchronously (Paper.retrievePaperContents),
+// so a read can win the race and come back empty. Clearing on the strength of
+// that would destroy a player's letter with nobody having seen it, so an
+// unreadable letter is left in the slot instead — blocked but recoverable.
+test('a letter that reads back empty is left intact, not cleared', async () => {
+  const inv = [{ ref: 'p1', type: 'Paper', slot: 4, grState: 2, name: 'Pad and mailbox' }]
+  const sent = []
+  const bot = {
+    world: { me: { noid: 1 }, getByRef: () => null, inventory: () => inv.map((i) => ({ ref: i.ref, type: i.type, name: i.name, noid: 1, mod: { y: i.slot, gr_state: i.grState } })) },
+    sendForReply: (msg) => { sent.push(msg.op); return Promise.resolve({ ascii: [] }) },  // always empty
+    writePaper: () => { sent.push('WRITE'); return Promise.resolve({ ok: true }) },
+    send: (msg) => { sent.push(msg.op); return Promise.resolve({ ok: true }) },
+  }
+  const res = await mail.drainMailSlot(bot)
+  assert.strictEqual(res.drained, false)
+  assert.strictEqual(res.unreadable, true)
+  assert.ok(!sent.includes('WRITE'), 'must not clear a letter it could not read')
+  assert.ok(!sent.includes('PUT'), 'must not discard a letter it could not read')
+})

--- a/habibots/test/oracle-outbox.test.js
+++ b/habibots/test/oracle-outbox.test.js
@@ -52,3 +52,12 @@ test('a failed delivery stays queued', async () => {
   assert.strictEqual(pending[0].lastError, 'the Oracle is not in-world yet')
   assert.strictEqual(pending[0].attempts, 1)
 })
+
+// The mail peek decides whether to re-enter the region. If mongo is
+// unreachable it must read as "no mail" — an error must never turn into a
+// storm of region entries, which is what trips the region's capacity limit.
+test('the mail peek reads as empty when mongo is unreachable', async () => {
+  const box = offline()
+  assert.strictEqual(await box.queuedMailFor('oracle'), 0)
+  assert.strictEqual(await box.queuedMailFor('anybody'), 0)
+})


### PR DESCRIPTION
The Discord → mail direction shipped working. The reverse never fired: a player mailing `to: oracle` got a success reply, the letter queued in mongo, and it sat there.

## Why

Three things were true at once:

- **`Avatar.check_mail()` runs only in `Region.noteUserArrival`.** It's the only thing that moves a letter from the `mail-<name>` queue into the pocket, and the bot enters its region once at startup and then stands still — so it checked for mail exactly once, before the letter existed.
- **No push to fall back on.** Because the Oracle carries `HIDDEN_AVATAR` it's absent from `NameToUser`, so `sendMailToUser` always takes the offline branch and never calls `send_mail_arrived`.
- **The relay was on the wrong hook** — `drainMailSlot`, which only runs when the bot is composing a reply and finds no blank paper. That exists to break the paper deadlock, not to receive mail.

## Fix

Peek at the queue (read-only against elko's own data; every actual change still goes through the game), and only when a letter is actually waiting, re-enter the region so elko hands it over.

Only knocking when there *is* mail matters. A bare timer churns context entries for nothing, and dev showed where that ends:

```
User 'user-oracle-…' forbidden entry to Context 'context-oraclehome' (capacity limit reached)
```

— which would lock the Oracle out of its own house.

`mailArrived` is wired up as a free extra trigger but nothing depends on it: measured on dev, the balloon doesn't reach us on the region-entry path.

## Two bugs caught in testing, both of which would have shipped

- **Double-post.** The same letter was read twice — the world model still shows it for a moment after the slot is cleared. Deduped on the page text; `text_path` is server-side and never reaches the client, so it can't be the key.
- **Destroying a letter unseen.** A letter that read back empty was cleared and discarded anyway. elko loads bodies asynchronously (`Paper.retrievePaperContents`), so a fast read legitimately gets an empty page. It now retries, and leaves an unreadable letter in the slot — blocked is visible and recoverable.

## Verification

Live dev stack, the exact production scenario — Oracle idle with a blank slot, letter arrives:

```
+3s  raw mongo queue=1  outbox says=1  slotLetter=false
pass 0: 1 waiting -> re-entering
  READ sender=Steve body="Did you notice me arrive?"
RESULT: PASS — read 1
```

45 habibots tests pass. Changes are confined to `habibots/` — no Java, no Go — so only the bots container recreates; the bridge and elko are untouched and live sessions won't drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01St52LGEnJ56ctEpePDYFqD