### PR TITLE
fix(oracle): recover a letter stranded in hand, and stop erasing it

### DIFF
--- a/db/Backroom/context-oraclehome.json
+++ b/db/Backroom/context-oraclehome.json
@@ -1,7 +1,8 @@
 [{
 	"type": "context",
 	"ref": "context-oraclehome",
-	"capacity": 4,
+	"_comment": "capacity is deliberately generous, not tight. Nothing can reach this region anyway (no exits, no neighbours, no teleport address, and its occupant is hidden), so a low cap protects nothing - while a session that does not exit cleanly consumes a slot, and the Oracle re-enters here to collect mail. Twice in testing a tight cap locked it out of its own house with {\"op\":\"exit\",\"why\":\"full\"}.",
+	"capacity": 32,
 	"name": "Oracle's Home",
 	"mods": [
 		{

--- a/habibots/bots/oracle.js
+++ b/habibots/bots/oracle.js
@@ -171,6 +171,20 @@ async function checkForMail() {
   checking = true
   try {
     for (let pass = 0; pass < MAIL_DRAIN_PASSES; pass++) {
+      // A letter can be stranded in hand by an interrupted collection, which
+      // blocks every pick-up until it is dealt with. Deliver it, then let go.
+      const hands = await serialize(() => mail.clearHands(OracleBot))
+      if (hands.recovered) {
+        if (hands.recovered.text !== lastLetterText) {
+          lastLetterText = hands.recovered.text
+          log.info(`delivering a letter from ${hands.recovered.sender} that was stuck in hand`)
+          await relayLetter(hands.recovered).catch((err) =>
+            log.error(`could not relay a recovered letter: ${err.message}`))
+        }
+        await serialize(() => mail.discardHeldPaper(OracleBot, hands.ref))
+        continue
+      }
+
       const slotLetter = awareness.getInventory(OracleBot).some((it) =>
         it.type === 'Paper' && it.slot === awareness.MAIL_SLOT &&
         (it.grState || 0) === awareness.PAPER_LETTER_STATE)

--- a/habibots/lib/mail.js
+++ b/habibots/lib/mail.js
@@ -157,6 +157,11 @@ async function drainMailSlot(bot) {
     (it) => it.type === 'Paper' && it.slot === awareness.MAIL_SLOT &&
       (it.grState || 0) === awareness.PAPER_LETTER_STATE)
   if (!letter) return { drained: false, text: '' }
+  const hands = await clearHands(bot)
+  if (!hands.ok) {
+    log.warn(`cannot collect mail: ${hands.error}`)
+    return { drained: false, text: '' }
+  }
   // GET moves it to HANDS and pops the next queued letter into MAIL_SLOT
   // (Paper.GET's update_mail_slot call). READ requires it be held.
   await withTimeout(getObj(bot, letter.ref), 10000, 'drainMailSlot.pick_up')
@@ -244,6 +249,61 @@ function discardBlankPaper(bot, ref) {
   return bot.send({ op: 'PUT', to: ref, containerNoid: me.noid, x: 0, y: DISCARD_SLOT, orientation: 0 })
 }
 
+// Every Paper.GET is gated on empty_handed(avatar) — ANY object in HANDS makes
+// the pick-up fail. Worse, the failure is quiet: Paper.READ answers
+// showEmptyPaper when you are not holding the sheet, so a draft left in hands by
+// an interrupted compose breaks both sending and receiving and presents as "the
+// letter read back empty". Seen in production. So: empty the hands first.
+async function clearHands(bot) {
+  const held = awareness.getInventory(bot).find((it) => it.slot === awareness.HANDS_SLOT)
+  if (!held) return { ok: true }
+  if (held.type !== 'Paper') {
+    log.warn(`holding a ${held.type}, which blocks picking anything up`)
+    return { ok: false, error: `hands are full (holding a ${held.type})` }
+  }
+  const state = held.grState || 0
+  if (state === awareness.PAPER_BLANK_STATE) return { ok: true } // usable as-is
+  if (state === awareness.PAPER_LETTER_STATE) {
+    // Unread mail we picked up and never finished with. Never destroy it.
+    return { ok: false, error: 'holding an unread letter', letter: held }
+  }
+
+  // WRITTEN is ambiguous and dangerous to guess at: Paper.GET fiddles an
+  // INCOMING letter to WRITTEN as you pick it up, so a written page in hands is
+  // either our own abandoned draft or somebody's letter we collected and never
+  // finished reading. Read it and let the postmark decide. A page with a sender
+  // on it is never destroyed here - it is handed back for the caller to deliver
+  // first. (Production had exactly this: a player's letter stuck in hands,
+  // blocking every pick-up, where blind cleanup would have erased it.)
+  let text = ''
+  for (let attempt = 0; attempt < READ_ATTEMPTS && !text; attempt++) {
+    if (attempt) await new Promise((r) => setTimeout(r, READ_RETRY_MS))
+    try {
+      text = decodePage(await withTimeout(readPaperPage(bot, held.ref), 10000, 'clearHands.read'))
+    } catch (err) {
+      log.warn(`could not read the page in hand: ${err.message}`)
+    }
+  }
+  const info = parsePostmark(text)
+  if (info.sender) {
+    log.info(`recovered a letter from ${info.sender} that was stuck in hand`)
+    return { ok: false, recovered: { sender: info.sender, body: info.body, text: text }, ref: held.ref }
+  }
+  if (!text) {
+    // Could not read it at all - refuse rather than destroy something unseen.
+    return { ok: false, error: 'holding a page that cannot be read' }
+  }
+  await discardHeldPaper(bot, held.ref)
+  log.info('discarded an abandoned draft that was blocking the hands')
+  return { ok: true, cleared: true }
+}
+
+// Blank a held sheet and put it away; Paper.PUT destroys a blank one.
+async function discardHeldPaper(bot, ref) {
+  await withTimeout(bot.writePaper(ref, ''), 10000, 'discardHeld.blank')
+  await withTimeout(discardBlankPaper(bot, ref), 10000, 'discardHeld.discard')
+}
+
 // composeAndSendMail — pick up a blank Paper, write the addressed page,
 // and PSENDMAIL it. The bot must be logged in: mailing is an avatar
 // action, not a server call.
@@ -262,6 +322,8 @@ async function composeAndSendMail(bot, opts) {
     return { ok: false, error: 'body is empty after sanitizing' }
   }
 
+  const hands = await clearHands(bot)
+  if (!hands.ok && !hands.letter) return { ok: false, error: hands.error }
   let { paper, error } = chooseBlankPaper(bot)
   const readLetters = []
   if (error && opts && opts.drainMail) {
@@ -289,6 +351,8 @@ async function composeAndSendMail(bot, opts) {
 module.exports = {
   composeAndSendMail,
   drainMailSlot,
+  clearHands,
+  discardHeldPaper,
   parsePostmark,
   buildMailPage,
   wrapForPaper,

--- a/habibots/test/mail.test.js
+++ b/habibots/test/mail.test.js
@@ -185,3 +185,83 @@ test('a letter that reads back empty is left intact, not cleared', async () => {
   assert.ok(!sent.includes('WRITE'), 'must not clear a letter it could not read')
   assert.ok(!sent.includes('PUT'), 'must not discard a letter it could not read')
 })
+
+// Paper.GET is gated on empty_handed(avatar), and the failure is silent —
+// Paper.READ answers showEmptyPaper when you aren't holding the sheet. So a
+// draft abandoned in HANDS breaks both sending and receiving, and looks like an
+// unreadable letter. This bit production.
+function fakeBot(items, sent) {
+  return {
+    world: { me: { noid: 1 }, getByRef: () => null,
+      inventory: () => items.map((i) => ({ ref: i.ref, type: i.type, name: i.name, noid: 1, mod: { y: i.slot, gr_state: i.grState } })) },
+    writePaper: (ref, text) => { sent.push(`WRITE:${ref}:${text === '' ? 'clear' : 'text'}`); return Promise.resolve({ ok: true }) },
+    send: (msg) => { sent.push(`${msg.op}:${msg.to}`); return Promise.resolve({ ok: true }) },
+    sendForReply: (msg) => { sent.push(`${msg.op}:${msg.to}`); return Promise.resolve({ ascii: [] }) },
+  }
+}
+
+// A WRITTEN page in hand is ambiguous — Paper.GET fiddles an INCOMING letter to
+// WRITTEN as you pick it up — so the postmark decides. This is the case that
+// bit production: a player's letter stranded in hand, where treating "WRITTEN"
+// as "my draft" would have erased it.
+function pageBot(items, sent, pageText) {
+  const bot = fakeBot(items, sent)
+  bot.sendForReply = (msg) => {
+    sent.push(`${msg.op}:${msg.to}`)
+    return Promise.resolve({ ascii: [...String(pageText)].map((c) => c.charCodeAt(0)) })
+  }
+  return bot
+}
+
+test('a postmarked page in hand is handed back, never destroyed', async () => {
+  const sent = []
+  const bot = pageBot([{ ref: 'stuck', type: 'Paper', slot: 5, grState: 1 }], sent,
+    'From: Randy          Postmark: 26-09-02 Does mail work too?')
+  const res = await mail.clearHands(bot)
+  assert.strictEqual(res.ok, false)
+  assert.strictEqual(res.recovered.sender, 'Randy')
+  assert.strictEqual(res.recovered.body, 'Does mail work too?')
+  assert.strictEqual(res.ref, 'stuck')
+  assert.ok(!sent.some((s) => s.startsWith('WRITE')), 'must not blank a letter')
+  assert.ok(!sent.some((s) => s.startsWith('PUT')), 'must not discard a letter')
+})
+
+test('an unpostmarked draft in hand is blanked and discarded', async () => {
+  const sent = []
+  const bot = pageBot([{ ref: 'draft', type: 'Paper', slot: 5, grState: 1 }], sent, 'to: someone')
+  const res = await mail.clearHands(bot)
+  assert.strictEqual(res.ok, true)
+  assert.strictEqual(res.cleared, true)
+  assert.ok(sent.includes('WRITE:draft:clear'), 'blanks the draft')
+  assert.ok(sent.some((s) => s.startsWith('PUT:draft')), 'puts it away so the server destroys it')
+})
+
+test('an unreadable page in hand is refused rather than destroyed', async () => {
+  const sent = []
+  const bot = pageBot([{ ref: 'mystery', type: 'Paper', slot: 5, grState: 1 }], sent, '')
+  const res = await mail.clearHands(bot)
+  assert.strictEqual(res.ok, false)
+  assert.ok(!sent.some((s) => s.startsWith('WRITE')), 'must not blank what it cannot read')
+  assert.ok(!sent.some((s) => s.startsWith('PUT')))
+})
+
+test('an unread letter in hands is never destroyed', async () => {
+  const sent = []
+  const bot = fakeBot([{ ref: 'letter', type: 'Paper', slot: 5, grState: 2 }], sent)
+  const res = await mail.clearHands(bot)
+  assert.strictEqual(res.ok, false)
+  assert.deepStrictEqual(sent, [], 'must not touch it')
+})
+
+test('a blank sheet in hands is left alone - it is usable', async () => {
+  const sent = []
+  const bot = fakeBot([{ ref: 'blank', type: 'Paper', slot: 5, grState: 0 }], sent)
+  assert.strictEqual((await mail.clearHands(bot)).ok, true)
+  assert.deepStrictEqual(sent, [])
+})
+
+test('empty hands need no clearing', async () => {
+  const sent = []
+  assert.strictEqual((await mail.clearHands(fakeBot([], sent))).ok, true)
+  assert.deepStrictEqual(sent, [])
+})


### PR DESCRIPTION
The previous fix made the Oracle look for mail. Prod immediately surfaced the next failure underneath it:

```
warn: a letter in MAIL_SLOT read back empty after retries; leaving it intact
```

That's the do-not-destroy guard working. The cause was a sheet jammed in the Oracle's **HANDS**: `Paper.GET` is gated on `empty_handed(avatar)`, so every pick-up silently failed — and `Paper.READ` answers `showEmptyPaper` when you aren't holding the sheet. Full hands present as "unreadable letter", and the Oracle could neither send nor receive.

## The dangerous part

What was stranded turned out to be Randy's letter, already collected and half-processed:

```
item-oracle.paper slot=5 gr=1 text_path=paper-item-oracle.paper-3012086…
  -> "From: Randy   Postmark: 26-09-02  Does mail work too?"
```

`Paper.GET` fiddles an **incoming** letter to WRITTEN as you pick it up, so "WRITTEN in hand" is ambiguous — our own abandoned draft, or somebody's mail mid-collection. My first cut of `clearHands` assumed draft and blanked it, which would have **erased a player's letter**. Caught in testing, not in production.

The postmark decides, since `text_path` is server-side and never reaches the client:

- postmarked → handed back to be delivered first, then let go
- unreadable → refused, never destroyed
- unpostmarked draft → discarded

## Also: region capacity 4 → 32

The Oracle re-enters its region to collect mail, and a session that doesn't exit cleanly holds a slot. Twice in testing a tight cap locked it out of its own house with `{"op":"exit","why":"full"}`. A low cap protects nothing here — no exits, no neighbours, no teleport address, hidden occupant — so it was pure downside.

## Verification

Prod's exact state reproduced on dev:

```
papers at login: ["slot5/WRITTEN","slot4/BLANK"]
recovered a letter from Randy that was stuck in hand
  RELAY: "Randy" said "Does mail work too?"
  papers after letting go: ["slot4/BLANK"]
RESULT: PASS - letter recovered, not erased
```

51 habibots tests pass. Deploying this recovers Randy's actual letter and frees the Oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01St52LGEnJ56ctEpePDYFqD