### PR TITLE
fix(presence): hidden avatars must not appear in or inflate #just-connected

### DIFF
--- a/bridge_v2/DISCORD_ALERTS.md
+++ b/bridge_v2/DISCORD_ALERTS.md
@@ -45,9 +45,12 @@ cannot ping the channel (`allowed_mentions: {parse: []}`).
   (binary `handleElkoMessage` and JSON `handleElkoMessageJson` — a you-make fires on
   every region entry; the `presenceAnnounced` latch keeps only the login).
 - Suppression order: another live session for the same user (takeover/second window)
-  → 5-minute debounce since the user's last disconnect → `*bot` names +
+  → 5-minute debounce since the user's last disconnect → hidden service avatars
+  (elko's `HIDDEN_AVATAR` nitty_bit, read off the arrival make) → `*bot` names +
   `DISCORD_ALERT_EXCLUDE` (comma list, for bots not ending in "bot").
-- Bots are also excluded from the "avatars in-world" count.
+- Bots and hidden avatars are also excluded from the "avatars in-world" count. The
+  Oracle is hidden: elko already keeps it out of `Region.NameToUser` (F3, `/online`,
+  ESP), and honouring the same bit here keeps Discord's count agreeing with the game's.
 - Variants: `at *their turf*` when the entry region is the user's turf; 🎉 hatched
   fanfare for brand-new users; 🕹️ = binary/C64 path, 🌐 = web/JSON path.
 - Disconnects are recorded (they arm the debounce) but **never posted**.
@@ -95,7 +98,10 @@ sessions (including TCP_REPAIR'd C64s); steady-state deploys with an unchanged
 alerts.env stay on the seamless tableflip path.
 
 `DISCORD_ALERT_EXCLUDE` (optional, comma-separated names/refs) extends the `*bot`
-exclusion for bots whose names don't end in "bot".
+exclusion for bots whose names don't end in "bot". Prefer the `HIDDEN_AVATAR`
+nitty_bit for a service avatar: it travels with the avatar's own state, so it needs
+no bridge env change (and therefore no hard restart) and cannot drift from what elko
+already hides.
 
 ## Adding a channel (the recipe)
 

--- a/bridge_v2/bridge/client_session.go
+++ b/bridge_v2/bridge/client_session.go
@@ -168,6 +168,11 @@ type ClientSession struct {
 	// (drives the birth-announcement message). Written where userRef/UserName are (same
 	// discipline), read under stateMu at announce time.
 	presenceNewUser bool
+	// presenceHidden latches elko's HIDDEN_AVATAR nitty_bit from this session's own arrival
+	// make, so the presence producer can exclude the avatar from the logins channel and from
+	// the in-world count — including when scanning OTHER sessions, which is why it lives here
+	// rather than only in presenceConnect. Guarded by stateMu with the rest of the identity.
+	presenceHidden bool
 	// presenceClosed makes the disconnect record idempotent: Close() can run more than once
 	// (multiple error paths call `go c.Close()`). Guarded by closeMutex.
 	presenceClosed bool
@@ -521,6 +526,7 @@ func (c *ClientSession) handleElkoMessage(msg *ElkoMessage) {
 		// now, under the lock, so the userRef read is race-free).
 		go c.bridge.closeOtherSessionsForUser(c, c.userRef)
 
+		c.presenceHidden = modIsHiddenAvatar(mod)
 		c.notePresenceArrivalLocked()
 
 		// Elko sends the session user's avatar with noid=256 (UNASSIGNED_NOID);
@@ -1171,6 +1177,7 @@ func (c *ClientSession) notePresenceArrivalLocked() {
 		newUser:   c.presenceNewUser,
 		json:      c.jsonPassthrough,
 		ip:        c.RealClientAddr(),
+		hidden:    c.presenceHidden,
 	}
 	if c.user != nil && len(c.user.Mods) > 0 && c.user.Mods[0].Turf != nil {
 		info.turfRef = *c.user.Mods[0].Turf
@@ -2222,6 +2229,7 @@ func (c *ClientSession) handleElkoMessageJson(raw []byte, msg *ElkoMessage) {
 			if modIsGhost(mod) {
 				c.bridge.transit.clear(c.userRef)
 			}
+			c.presenceHidden = modIsHiddenAvatar(mod)
 		}
 		c.notePresenceArrivalLocked()
 	}
@@ -2940,6 +2948,7 @@ func (c *ClientSession) Snapshot() *SessionSnapshot {
 		QLinkMode:         c.qlinkMode,
 		Online:            c.Online,
 		PresenceAnnounced: c.presenceAnnounced,
+		PresenceHidden:    c.presenceHidden,
 		QLinkInSeq:        c.qlinkInSeq,
 		QLinkOutSeq:       c.qlinkOutSeq,
 		ReplySeq:          c.replySeq,
@@ -3020,6 +3029,7 @@ func RestoreSession(b *Bridge, snap *SessionSnapshot, clientConn net.Conn, elkoC
 		jsonPassthrough:          snap.JsonPassthrough,
 		largeRequestCache:        snap.LargeRequestCache,
 		presenceAnnounced:        snap.PresenceAnnounced,
+		presenceHidden:           snap.PresenceHidden,
 		nextRegion:               snap.NextRegion,
 		nextRegionSet:            snap.NextRegionSet,
 		sessionID:                snap.SessionID,

--- a/bridge_v2/bridge/presence.go
+++ b/bridge_v2/bridge/presence.go
@@ -53,6 +53,9 @@ type presenceConnect struct {
 	newUser   bool
 	json      bool
 	ip        string
+	// hidden: the arriving avatar carries elko's HIDDEN_AVATAR nitty_bit — a service
+	// avatar (the Oracle) that elko already keeps out of Region.NameToUser.
+	hidden bool
 }
 
 type presenceRegistry struct {
@@ -87,8 +90,24 @@ func newPresenceRegistry(b *Bridge, notifier *DiscordNotifier) *presenceRegistry
 	}
 }
 
+// hiddenAvatarBit is elko's Constants.HIDDEN_AVATAR (nitty_bit 30). The bit constants are
+// 1-based (inherited from PL/1), and HabitatMod.packBits maps bit N to 1<<(N-1), so 30 is
+// 1<<29. Elko keeps such an avatar out of Region.NameToUser — the table behind the F3 list,
+// /online counts, ESP and tellEveryone — so presence honours the same bit: a hidden service
+// avatar neither announces itself in the logins channel nor counts toward "N in-world".
+const hiddenAvatarBit int32 = 1 << 29
+
+// modIsHiddenAvatar reads that bit off an own-avatar (you:true) make. Avatar.encode emits
+// nitty_bits whenever the packed value is non-zero, on the client control path as well as the
+// durable one, so the bridge sees it on arrival without consulting Mongo.
+func modIsHiddenAvatar(mod *HabitatMod) bool {
+	return mod != nil && mod.NittyBits != nil && *mod.NittyBits&hiddenAvatarBit != 0
+}
+
 // isBot: `*bot` names (welcomebot, elizabot, sagebot…) and DISCORD_ALERT_EXCLUDE entries are
-// excluded from channel posts AND from the in-world avatar count (humans only).
+// excluded from channel posts AND from the in-world avatar count (humans only). Hidden
+// service avatars get the same treatment via modIsHiddenAvatar, keyed on state rather than
+// on a name — see hiddenAvatarBit.
 func (p *presenceRegistry) isBot(userRef string, name string) bool {
 	for _, id := range []string{userRef, name} {
 		id = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(id)), "user-")
@@ -127,8 +146,13 @@ func (p *presenceRegistry) noteConnect(info presenceConnect) {
 		}
 		p.mu.Unlock()
 	}
-	if reason == "" && p.isBot(info.userRef, info.name) {
-		reason = "bot"
+	if reason == "" {
+		switch {
+		case info.hidden:
+			reason = "hidden"
+		case p.isBot(info.userRef, info.name):
+			reason = "bot"
+		}
 	}
 	if reason == "" && !p.notifier.Enabled(presenceLoginsChannel) {
 		reason = "disabled"
@@ -177,7 +201,7 @@ func (p *presenceRegistry) noteDisconnect(userRef string, name string, json bool
 // sessionsMutex, release, then read each userRef under its own stateMu (never nested).
 func (p *presenceRegistry) scanSessions(info presenceConnect) (concurrent bool, humans int) {
 	seen := map[string]struct{}{}
-	if !p.isBot(info.userRef, info.name) {
+	if !info.hidden && !p.isBot(info.userRef, info.name) {
 		seen[info.userRef] = struct{}{}
 	}
 	if p.bridge != nil {
@@ -191,7 +215,7 @@ func (p *presenceRegistry) scanSessions(info presenceConnect) (concurrent bool, 
 		p.bridge.sessionsMutex.Unlock()
 		for _, s := range others {
 			s.stateMu.Lock()
-			ref, name := s.userRef, s.UserName
+			ref, name, hidden := s.userRef, s.UserName, s.presenceHidden
 			s.stateMu.Unlock()
 			if ref == "" {
 				continue
@@ -199,7 +223,7 @@ func (p *presenceRegistry) scanSessions(info presenceConnect) (concurrent bool, 
 			if ref == info.userRef {
 				concurrent = true
 			}
-			if !p.isBot(ref, name) {
+			if !hidden && !p.isBot(ref, name) {
 				seen[ref] = struct{}{}
 			}
 		}

--- a/bridge_v2/bridge/presence_test.go
+++ b/bridge_v2/bridge/presence_test.go
@@ -273,3 +273,57 @@ func TestPrettifyContextRef(t *testing.T) {
 		}
 	}
 }
+
+// A hidden service avatar (the Oracle) carries elko's HIDDEN_AVATAR nitty_bit. It must be as
+// invisible to #just-connected as a *bot is: no login post, and no seat in the "N avatars
+// in-world" tally that every human's login line carries.
+func TestPresenceHiddenAvatarSuppressedAndUncounted(t *testing.T) {
+	p, hook, _ := newTestPresence(t)
+	oracle := &ClientSession{
+		bridge: p.bridge, userRef: "user-oracle", UserName: "oracle", presenceHidden: true,
+	}
+	p.bridge.Sessions["oracle"] = oracle
+
+	info := connectInfo("user-oracle", "oracle", "context-oraclehome")
+	info.session = oracle // this arrival IS that session, not a concurrent one
+	info.hidden = true
+	p.noteConnect(info)
+	if posts := hook.posts(); len(posts) != 0 {
+		t.Fatalf("hidden avatar login must be silent; got %v", posts)
+	}
+	p.mu.Lock()
+	reason := p.history[len(p.history)-1].Reason
+	p.mu.Unlock()
+	if reason != "hidden" {
+		t.Fatalf("reason = %q, want hidden", reason)
+	}
+
+	p.noteConnect(connectInfo("user-randy", "Randy", "context-Downtown_4f"))
+	posts := hook.posts()
+	if len(posts) != 1 {
+		t.Fatalf("human login must post; got %v", posts)
+	}
+	if !strings.Contains(posts[0], "1 avatar in-world") {
+		t.Fatalf("hidden avatar must not inflate the count: %q", posts[0])
+	}
+}
+
+// The bit is read off the arrival make, not off a name — 1<<29 is Constants.HIDDEN_AVATAR (30)
+// through packBits' 1-based mapping. An avatar with other nitty_bits set stays visible.
+func TestModIsHiddenAvatar(t *testing.T) {
+	if modIsHiddenAvatar(nil) {
+		t.Fatal("nil mod must not be hidden")
+	}
+	if modIsHiddenAvatar(&HabitatMod{}) {
+		t.Fatal("absent nitty_bits must not be hidden")
+	}
+	if modIsHiddenAvatar(&HabitatMod{NittyBits: Int32P(1 << 3)}) { // GOD_FLAG (4)
+		t.Fatal("an unrelated nitty_bit must not read as hidden")
+	}
+	if !modIsHiddenAvatar(&HabitatMod{NittyBits: Int32P(536870912)}) {
+		t.Fatal("HIDDEN_AVATAR (536870912) must read as hidden")
+	}
+	if !modIsHiddenAvatar(&HabitatMod{NittyBits: Int32P(536870912 | 1<<3)}) {
+		t.Fatal("HIDDEN_AVATAR alongside another bit must read as hidden")
+	}
+}

--- a/bridge_v2/bridge/snapshot.go
+++ b/bridge_v2/bridge/snapshot.go
@@ -32,6 +32,10 @@ type SessionSnapshot struct {
 	// PresenceAnnounced carries the login-alert latch so a restored session never
 	// re-announces its avatar to Discord after a graceful reload.
 	PresenceAnnounced bool `json:"presence_announced"`
+	// PresenceHidden carries the HIDDEN_AVATAR flag, which is only ever read off the
+	// arrival make — a restored session gets no second make, so without this a service
+	// avatar would start counting toward the in-world tally again after a reload.
+	PresenceHidden bool `json:"presence_hidden,omitempty"`
 
 	QLinkInSeq  byte  `json:"qlink_in_seq"`
 	QLinkOutSeq byte  `json:"qlink_out_seq"`

--- a/bridge_v2/bridge/snapshot_test.go
+++ b/bridge_v2/bridge/snapshot_test.go
@@ -38,6 +38,7 @@ func TestSessionSnapshot_RoundTrip(t *testing.T) {
 		},
 		DataRate:           1200,
 		BufferedClientData: []byte{0x5A, 0x81},
+		PresenceHidden:     true,
 	}
 
 	data, err := json.Marshal(snap)
@@ -70,6 +71,11 @@ func TestSessionSnapshot_RoundTrip(t *testing.T) {
 	}
 	if len(restored.BufferedClientData) != 2 || restored.BufferedClientData[0] != 0x5A {
 		t.Errorf("BufferedClientData = %v, want [5A 81]", restored.BufferedClientData)
+	}
+	// A hidden service avatar must stay hidden across a tableflip: the flag is read off the
+	// arrival make, and a restored session never gets a second one.
+	if !restored.PresenceHidden {
+		t.Error("PresenceHidden = false, want true")
 	}
 	contents := restored.NoidContents["0"]
 	if len(contents) != 3 || contents[2] != 42 {


### PR DESCRIPTION
## The bug

The Oracle is invisible in-world — elko keeps it out of `Region.NameToUser`, so it is absent from the F3 list, `/online`, ESP and `tellEveryone`. The Discord presence producer never got the message. On prod it posted its own arrival:

> ✨ **oracle** materializes at *their turf*… 🌐 · N avatars in-world  ← `2026-09-02 00:00:43`

and every human login since has counted it, so `#just-connected` has been reporting one more avatar than the game itself does.

Presence had exactly one exclusion rule — `*bot` names plus `DISCORD_ALERT_EXCLUDE` — and "Oracle" matches neither.

## The fix

Read elko's `HIDDEN_AVATAR` nitty_bit, the same bit `Region.addUser` gates on.

Two alternatives rejected: hard-coding the name (drifts, and the next service avatar repeats the bug), and setting `DISCORD_ALERT_EXCLUDE=oracle` (`alerts.env` is read once at process start, so changing it needs a **hard** bridge restart, dropping live TCP_REPAIR'd C64 sessions — a heavy price for a cosmetic count).

The bit costs nothing to obtain: `Avatar.encode` emits `nitty_bits` on the client control path whenever the packed value is non-zero, so the own-avatar `make you:true` that already drives the presence hook carries it. Confirmed on the wire in prod:

```
{"to":"context-oraclehome", "op":"make", "obj":{"ref":"user-oracle-…", "name":"Oracle",
 "mods":[{"type":"Avatar", …, "nitty_bits":536870912, …}]}, "you":true}
```

`536870912` is `1<<29` — `HIDDEN_AVATAR` (30) through `packBits`' 1-based PL/1 mapping.

A hidden avatar now gets the same treatment as a bot: no login post, and no seat in the "N avatars in-world" tally, including when a *later* login scans the session table.

## Details worth a second look

- **It rides the tableflip manifest.** The flag is only ever read off an arrival make, and a restored session never gets a second one — so without `PresenceHidden` in `SessionSnapshot` the Oracle would silently start counting again after the next seamless deploy. That is the kind of regression that looks fixed for a week.
- **Both protocol paths capture it** (binary `handleElkoMessage`, JSON `handleElkoMessageJson`), since the bots ride the JSON path and a C64-era service avatar would ride the other.
- **Suppressed connects are still recorded** in the `/presence` history ring and the `presence_event` log line, now with `reason: "hidden"` — consistent with how bot and debounce suppressions are already kept.

## Verification

`go vet` + `go test ./...` clean. Three new tests: the suppression and the count, the bit-reading helper (including an unrelated nitty_bit staying visible), and snapshot survival across a handoff.

Not deployed. This ships whenever you want a bridge deploy — worth noting it pairs naturally with #670 (the grpc security bump), which also touches only `bridge_v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01St52LGEnJ56ctEpePDYFqD