### PR TITLE
fix(oracle): free the hands, so a stranded page cannot mute the bot

### DIFF
--- a/habibots/README.md
+++ b/habibots/README.md
@@ -107,6 +107,34 @@ answer anyone, permanently. After reading, the sheet is blanked and put
 back in a pocket, which makes the server destroy it (`Paper.java:334`),
 leaving exactly one Paper in the slot.
 
+### Nothing may be left in the hands
+
+`Paper.GET` is gated on `empty_handed(avatar)`, so a single page stranded in
+HANDS disables the Oracle in **both** directions — it can neither collect a
+letter nor pick up a blank sheet to answer one — and every symptom downstream
+presents as "the letter read back empty" instead of "the hands are full".
+Production, 2026-09-02: an elko-side EOF interrupted a collection, a letter sat
+in the Oracle's hands for sixteen hours, and the bot looped every two minutes
+doing nothing and logging nothing.
+
+So every mail check starts by clearing the hands, along this ladder:
+
+1. **Blank sheet** — fine as it is, use it.
+2. **Readable page with a postmark, or anything that arrived as a `LETTER`** —
+   somebody else wrote it. Relay it to Discord *first*, then dispose of it.
+3. **Readable page with no postmark and `WRITTEN` state** — our own abandoned
+   draft. Blank it and put it away, which destroys it.
+4. **Unreadable** — retried across several checks first, because elko loads
+   letter bodies asynchronously and one empty read proves nothing. A page still
+   unreadable minutes later has a `text_path` pointing at a document that no
+   longer exists. It is moved **intact** into a free pocket slot (never blanked
+   first — `Paper.PUT` destroys only a sheet that is already blank), the hands
+   come free, and the channel is told once.
+
+Destroying an unread page is not on the ladder. A `WRITTEN` page in hand is
+genuinely ambiguous, because `Paper.GET` fiddles an incoming letter to `WRITTEN`
+as you pick it up, so "written must mean my own draft" would erase real mail.
+
 It is **not** a ghost, though that looks like the obvious answer. A ghost
 cannot mail: `HabitatMod.objectIsComplete` skips `Region.addToNoids` when
 the container is a ghost avatar, so a ghost's pocket Paper is never

--- a/habibots/bots/oracle.js
+++ b/habibots/bots/oracle.js
@@ -124,6 +124,12 @@ const MAIL_POLL_SECONDS = parseInt(process.env.HABIBOTS_ORACLE_MAIL_POLL_SECONDS
 const MAIL_DRAIN_PASSES = 5
 // Region entry -> check_mail -> the letter appears in the slot, all asynchronous.
 const MAIL_SETTLE_MS = 3000
+// How many consecutive checks may find the SAME unreadable page in hand before
+// it is set aside. elko loads a letter body asynchronously (Paper.retrieve-
+// PaperContents), so one empty read proves nothing and patience is right. A page
+// still unreadable minutes later has a text_path pointing at a document that no
+// longer exists and will never read - waiting forever just keeps the bot deaf.
+const UNREADABLE_STOW_AFTER = 3
 
 const outbox = new OracleOutbox()
 
@@ -165,6 +171,64 @@ OracleBot.on('enteredRegion', (bot) => {
 // {"op":"exit","why":"full"}, which would lock the Oracle out of its own house.
 let checking = false
 let lastLetterText = null
+// Blocked-hands bookkeeping: which page is stuck, for how many checks running,
+// and which ones we have already reported to Discord (once each, not per tick).
+let stuckRef = null
+let stuckStrikes = 0
+const stowedReported = new Set()
+
+// Full hands are the bot's most dangerous state: Paper.GET is gated on
+// empty_handed(avatar), so a single stranded page disables mail in BOTH
+// directions, and every failure downstream of it presents as "the letter read
+// back empty" rather than as "the hands are full". Recovery ladder, in order of
+// preference: deliver it (clearHands hands a readable letter back), discard it
+// if it is only our own blank draft, and failing both, set it aside intact in a
+// pocket. Destroying an unread page is never on the ladder.
+//
+// Returns true if the hands are now free and the caller should carry on.
+async function freeTheHands(hands) {
+  const ref = hands.ref || null
+  if (ref === stuckRef) stuckStrikes++
+  else {
+    stuckRef = ref
+    stuckStrikes = 1
+  }
+  // Give an unreadable page a few checks to become readable before giving up on
+  // it - a body still loading is indistinguishable from a body that is gone.
+  if (hands.unreadable && stuckStrikes < UNREADABLE_STOW_AFTER) {
+    log.warn(`hands blocked: ${hands.error} (attempt ${stuckStrikes}/${UNREADABLE_STOW_AFTER})`)
+    return false
+  }
+  log.error(`hands blocked: ${hands.error}; setting it aside so mail can flow again`)
+  const stowed = await serialize(() => mail.stowHeldItem(OracleBot))
+  if (!stowed.ok) {
+    log.error(`could not free the hands: ${stowed.error}`)
+    return false
+  }
+  stuckRef = null
+  stuckStrikes = 0
+  if (stowed.stowed && stowed.ref && !stowedReported.has(stowed.ref)) {
+    stowedReported.add(stowed.ref)
+    await noteStowed(stowed).catch((err) =>
+      log.error(`could not report the set-aside page: ${err.message}`))
+  }
+  return true
+}
+
+// Say so in the channel. A page nobody can read is a real loss - somebody may
+// have mailed the Oracle and got no answer - and the alternative is that it
+// happens silently, which is how this went unnoticed for sixteen hours.
+async function noteStowed(stowed) {
+  const channel = await discord.channels.fetch(CHANNEL_ID)
+  await channel.send({
+    embeds: [{
+      description: `⚠️ The Oracle was holding a ${stowed.type} it could not read, which blocks all mail. ` +
+        `It has been set aside intact in pocket slot ${stowed.slot} — nothing was destroyed — and mail is flowing again.`,
+    }],
+    allowedMentions: NO_PINGS,
+  })
+  log.info(`reported a set-aside ${stowed.type} to Discord`)
+}
 
 async function checkForMail() {
   if (!inWorld || checking) return
@@ -174,6 +238,10 @@ async function checkForMail() {
       // A letter can be stranded in hand by an interrupted collection, which
       // blocks every pick-up until it is dealt with. Deliver it, then let go.
       const hands = await serialize(() => mail.clearHands(OracleBot))
+      if (hands.ok) {
+        stuckRef = null
+        stuckStrikes = 0
+      }
       if (hands.recovered) {
         if (hands.recovered.text !== lastLetterText) {
           lastLetterText = hands.recovered.text
@@ -182,6 +250,14 @@ async function checkForMail() {
             log.error(`could not relay a recovered letter: ${err.message}`))
         }
         await serialize(() => mail.discardHeldPaper(OracleBot, hands.ref))
+        stuckRef = null
+        stuckStrikes = 0
+        continue
+      }
+      // Anything else in the hands blocks every Paper.GET, so the bot can
+      // neither collect mail nor compose a reply. Never leave it there.
+      if (!hands.ok) {
+        if (!await freeTheHands(hands)) return
         continue
       }
 

--- a/habibots/lib/mail.js
+++ b/habibots/lib/mail.js
@@ -39,6 +39,11 @@ const CLEAR_SENTINEL_LENGTH = 16
 // blank sheet wherever it lands.
 const DISCARD_SLOT = 0
 
+// The numbered pockets, in the order stowHeldItem will fill them. MAIL_SLOT (4)
+// is excluded on purpose: it is the mailbox, and a second Paper parked there is
+// its own bug (see db/patchOracleHome.js).
+const POCKET_SLOTS = [0, 1, 2, 3]
+
 // Paper.retrievePaperContents loads a letter body from mongo asynchronously, so
 // the first read after the slot is repointed can legitimately come back empty.
 const READ_ATTEMPTS = 4
@@ -263,18 +268,24 @@ async function clearHands(bot) {
   }
   const state = held.grState || 0
   if (state === awareness.PAPER_BLANK_STATE) return { ok: true } // usable as-is
-  if (state === awareness.PAPER_LETTER_STATE) {
-    // Unread mail we picked up and never finished with. Never destroy it.
-    return { ok: false, error: 'holding an unread letter', letter: held }
-  }
 
+  // Everything else gets READ, and the page decides what happens to it.
+  //
   // WRITTEN is ambiguous and dangerous to guess at: Paper.GET fiddles an
   // INCOMING letter to WRITTEN as you pick it up, so a written page in hands is
   // either our own abandoned draft or somebody's letter we collected and never
-  // finished reading. Read it and let the postmark decide. A page with a sender
-  // on it is never destroyed here - it is handed back for the caller to deliver
-  // first. (Production had exactly this: a player's letter stuck in hands,
-  // blocking every pick-up, where blind cleanup would have erased it.)
+  // finished reading. A page with a sender on it is never destroyed here - it is
+  // handed back for the caller to deliver first. (Production had exactly this: a
+  // player's letter stuck in hands, blocking every pick-up, where blind cleanup
+  // would have erased it.)
+  //
+  // LETTER used to be refused here without even looking, on the theory that
+  // unread mail must never be touched. That was the wrong end of the stick:
+  // reading it IS how it gets delivered, and refusing left the hands full
+  // forever. Since every Paper.GET is gated on empty_handed, the bot then went
+  // silently deaf - it could neither collect mail nor compose a reply, and
+  // logged nothing. Production, 2026-09-02: a letter sat in the Oracle's hands
+  // for sixteen hours while it looped every two minutes doing nothing.
   let text = ''
   for (let attempt = 0; attempt < READ_ATTEMPTS && !text; attempt++) {
     if (attempt) await new Promise((r) => setTimeout(r, READ_RETRY_MS))
@@ -285,13 +296,19 @@ async function clearHands(bot) {
     }
   }
   const info = parsePostmark(text)
-  if (info.sender) {
-    log.info(`recovered a letter from ${info.sender} that was stuck in hand`)
+  // A postmark means somebody else wrote it. So does arriving as a LETTER, even
+  // if the postmark is missing - anything handed to us through the mail system
+  // gets delivered before it is disposed of.
+  if (text && (info.sender || state === awareness.PAPER_LETTER_STATE)) {
+    log.info(`recovered a letter from ${info.sender || 'an unknown sender'} that was stuck in hand`)
     return { ok: false, recovered: { sender: info.sender, body: info.body, text: text }, ref: held.ref }
   }
   if (!text) {
     // Could not read it at all - refuse rather than destroy something unseen.
-    return { ok: false, error: 'holding a page that cannot be read' }
+    // `unreadable` tells the caller this is the recoverable kind of stuck: the
+    // page is intact and can be set aside (stowHeldItem) once patience runs
+    // out, which is not the same as being free to destroy it.
+    return { ok: false, unreadable: true, ref: held.ref, error: 'holding a page that cannot be read' }
   }
   await discardHeldPaper(bot, held.ref)
   log.info('discarded an abandoned draft that was blocking the hands')
@@ -299,6 +316,33 @@ async function clearHands(bot) {
 }
 
 // Blank a held sheet and put it away; Paper.PUT destroys a blank one.
+// The escape hatch for a page the bot cannot read: move it out of HANDS into a
+// free numbered pocket slot, WITHOUT blanking it first. Nothing is destroyed -
+// Paper.PUT only destroys a sheet that is already blank - so an unreadable page
+// survives for a human to look at, while the hands come free and mail flows
+// again. Slots 0-3 are the pockets; MAIL_SLOT (4) is the mailbox and must stay
+// available for incoming letters, so it is never a target.
+//
+// Preferred over destroying an unreadable page (which risks erasing a player's
+// letter) and over leaving it in hands (which silently disables the whole bot).
+async function stowHeldItem(bot) {
+  const inv = awareness.getInventory(bot)
+  const held = inv.find((it) => it.slot === awareness.HANDS_SLOT)
+  if (!held) return { ok: true, stowed: false }
+  const me = bot.world && bot.world.me
+  if (!me) return { ok: false, error: 'no avatar in the world model' }
+  const taken = new Set(inv.map((it) => it.slot))
+  const slot = POCKET_SLOTS.find((n) => !taken.has(n))
+  if (slot === undefined) {
+    return { ok: false, error: 'every pocket slot is full' }
+  }
+  await withTimeout(
+    bot.send({ op: 'PUT', to: held.ref, containerNoid: me.noid, x: 0, y: slot, orientation: 0 }),
+    10000, 'stowHeldItem.put')
+  log.warn(`set aside ${held.type} ${held.ref} in pocket slot ${slot} to free the hands`)
+  return { ok: true, stowed: true, slot: slot, ref: held.ref, type: held.type }
+}
+
 async function discardHeldPaper(bot, ref) {
   await withTimeout(bot.writePaper(ref, ''), 10000, 'discardHeld.blank')
   await withTimeout(discardBlankPaper(bot, ref), 10000, 'discardHeld.discard')
@@ -353,6 +397,7 @@ module.exports = {
   drainMailSlot,
   clearHands,
   discardHeldPaper,
+  stowHeldItem,
   parsePostmark,
   buildMailPage,
   wrapForPaper,

--- a/habibots/test/mail.test.js
+++ b/habibots/test/mail.test.js
@@ -241,16 +241,84 @@ test('an unreadable page in hand is refused rather than destroyed', async () => 
   const bot = pageBot([{ ref: 'mystery', type: 'Paper', slot: 5, grState: 1 }], sent, '')
   const res = await mail.clearHands(bot)
   assert.strictEqual(res.ok, false)
+  assert.strictEqual(res.unreadable, true, 'the caller needs to know this one is recoverable')
+  assert.strictEqual(res.ref, 'mystery')
   assert.ok(!sent.some((s) => s.startsWith('WRITE')), 'must not blank what it cannot read')
   assert.ok(!sent.some((s) => s.startsWith('PUT')))
 })
 
-test('an unread letter in hands is never destroyed', async () => {
+// Refusing to even LOOK at an unread letter was the 2026-09-02 production jam:
+// the hands stayed full, and since Paper.GET is gated on empty_handed the bot
+// went silently deaf in both directions. Reading it is how it gets delivered.
+test('an unread letter in hands is read and handed back for delivery', async () => {
   const sent = []
-  const bot = fakeBot([{ ref: 'letter', type: 'Paper', slot: 5, grState: 2 }], sent)
+  const bot = pageBot([{ ref: 'letter', type: 'Paper', slot: 5, grState: 2 }], sent,
+    'From: Naibor         Postmark: 26-09-02 Works like a charm')
   const res = await mail.clearHands(bot)
   assert.strictEqual(res.ok, false)
-  assert.deepStrictEqual(sent, [], 'must not touch it')
+  assert.strictEqual(res.recovered.sender, 'Naibor')
+  assert.strictEqual(res.recovered.body, 'Works like a charm')
+  assert.ok(sent.some((s) => s.startsWith('READ:letter')), 'must actually read it')
+  assert.ok(!sent.some((s) => s.startsWith('WRITE')), 'must not blank a letter')
+  assert.ok(!sent.some((s) => s.startsWith('PUT')), 'delivery comes before disposal')
+})
+
+// A LETTER with no postmark still came through the mail system, so it goes up
+// to Discord unattributed rather than being treated as our own scrap paper.
+test('an unpostmarked LETTER is still delivered, not discarded', async () => {
+  const sent = []
+  const bot = pageBot([{ ref: 'odd', type: 'Paper', slot: 5, grState: 2 }], sent, 'no postmark here')
+  const res = await mail.clearHands(bot)
+  assert.strictEqual(res.recovered.sender, null)
+  assert.strictEqual(res.recovered.body, 'no postmark here')
+  assert.ok(!sent.some((s) => s.startsWith('WRITE')), 'must not blank it')
+})
+
+// The escape hatch. An unreadable page must not sit in the hands forever (that
+// disables the bot) and must not be destroyed (it may be someone's letter), so
+// it is moved intact into a free pocket.
+test('stowHeldItem moves the held page to a free pocket without blanking it', async () => {
+  const sent = []
+  const bot = fakeBot([
+    { ref: 'husk', type: 'Paper', slot: 5, grState: 2 },
+    { ref: 'mailbox', type: 'Paper', slot: 4, grState: 0 },
+  ], sent)
+  const res = await mail.stowHeldItem(bot)
+  assert.strictEqual(res.ok, true)
+  assert.strictEqual(res.slot, 0)
+  assert.strictEqual(res.ref, 'husk')
+  assert.ok(sent.includes('PUT:husk'), 'moves it out of the hands')
+  assert.ok(!sent.some((s) => s.startsWith('WRITE')), 'never blanks it — that would destroy it on PUT')
+})
+
+test('stowHeldItem skips occupied pockets and never targets the mail slot', async () => {
+  const sent = []
+  const bot = fakeBot([
+    { ref: 'husk', type: 'Paper', slot: 5, grState: 2 },
+    { ref: 'a', type: 'Paper', slot: 0, grState: 1 },
+    { ref: 'b', type: 'Paper', slot: 1, grState: 1 },
+    { ref: 'mailbox', type: 'Paper', slot: 4, grState: 0 },
+  ], sent)
+  assert.strictEqual((await mail.stowHeldItem(bot)).slot, 2)
+})
+
+test('stowHeldItem reports failure when every pocket is full', async () => {
+  const sent = []
+  const bot = fakeBot([
+    { ref: 'husk', type: 'Paper', slot: 5, grState: 2 },
+    ...[0, 1, 2, 3].map((n) => ({ ref: `p${n}`, type: 'Paper', slot: n, grState: 1 })),
+  ], sent)
+  const res = await mail.stowHeldItem(bot)
+  assert.strictEqual(res.ok, false)
+  assert.deepStrictEqual(sent, [], 'no half-move')
+})
+
+test('stowHeldItem is a no-op with empty hands', async () => {
+  const sent = []
+  const res = await mail.stowHeldItem(fakeBot([], sent))
+  assert.strictEqual(res.ok, true)
+  assert.strictEqual(res.stowed, false)
+  assert.deepStrictEqual(sent, [])
 })
 
 test('a blank sheet in hands is left alone - it is usable', async () => {


### PR DESCRIPTION
## What happened in production

```
06:02:47  Naibor → "To: Oracle / Works like a charm"
06:02:54  bridge: Elko-side disconnect (EOF); attempting silent reconnect  [oracle session]
```

The collection was interrupted mid-flight and the letter stayed in the Oracle's HANDS, where it still is. `Paper.GET` is gated on `empty_handed(avatar)`, so that single page disabled mail in **both** directions — no letters collected, no Discord answers composed. The bot kept polling every 120 seconds and logged **nothing**. Sixteen hours, and the only way to see it was to read mongo.

## Two bugs, one behaviour

**`mail.clearHands` refused to look at an unread letter.** The `PAPER_LETTER_STATE` branch returned `{ok:false, error:'holding an unread letter'}` without reading it, on the theory that unread mail must never be touched. But *reading it is how it gets delivered* — refusing just meant the hands stayed full forever. It now reads a held letter like any other page and hands it back for relay.

**`checkForMail` ignored every refusal it didn't recognise.** It acted only on `hands.recovered`; `{ok:false}` of any kind fell straight through to the queue peek and returned. That is why nothing was logged.

## The recovery ladder

1. **Blank** — usable as-is.
2. **Readable with a postmark, or anything that arrived as a `LETTER`** — somebody else wrote it: relay to Discord *first*, then dispose.
3. **Readable, unpostmarked, `WRITTEN`** — our own abandoned draft: blank and discard.
4. **Unreadable** — set aside intact.

Destroying an unread page is deliberately not on the ladder. `Paper.GET` fiddles an incoming letter to `WRITTEN` as you pick it up, so "written means my own draft" would erase real mail — the trap #672 was written to avoid.

**The escape hatch** (`mail.stowHeldItem`) moves the page into a free pocket slot **without blanking it first** — `Paper.PUT` destroys only a sheet that is already blank (`Paper.java:334`), so an unblanked page survives for a human to inspect. Never the mail slot, which must stay clear for incoming letters.

**Patience before the hatch:** an unreadable page gets `UNREADABLE_STOW_AFTER` (3) checks, ~6 minutes, because elko loads letter bodies asynchronously and one empty read proves nothing.

## It fixes the live jam by itself

The stuck page's `text_path` is `paper-i-2538248719087078849`, and **no such document exists in `odb`** — elko logs `Retrieving Paper contents … at: paper-i-2538248719087078849` and finds nothing. So it will never read, at any patience. Three checks after the bots come up, it goes into a pocket, the hands come free, and mail flows again. No manual mongo surgery, nothing destroyed.

Setting a page aside is reported once to `#oracle-requests`, so this can never again be silent.

## Tests

`npm test` — 56 pass. New coverage: a held letter is read and handed back; an unpostmarked LETTER is still delivered rather than discarded; `stowHeldItem` picks the first free pocket, skips occupied ones, never targets the mail slot, never blanks what it moves, reports failure when the pockets are full, and no-ops on empty hands. The existing "an unread letter in hands is never destroyed" test asserted the old refusal and is replaced by the delivery assertion.

Bots-image only — no elko or bridge changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FW2qxCACtN5zc39NWVCKYc