### PR TITLE
fix(oracle): re-enter the region after setting a page aside

### DIFF
--- a/habibots/README.md
+++ b/habibots/README.md
@@ -131,6 +131,14 @@ So every mail check starts by clearing the hands, along this ladder:
    first — `Paper.PUT` destroys only a sheet that is already blank), the hands
    come free, and the channel is told once.
 
+Step 4 ends with a **region re-entry**, and that part is not optional.
+`generic_PUT` announces the move with `send_neighbor_msg`, which excludes the
+actor, so the bot cannot see its own `PUT` any more than it can see its own
+`GET`: elko has the page in a pocket while the world model still shows it in
+hand. Without the refresh the next check finds the same "blocked" hands and sets
+the page aside again on every pass, never reaching the mail — which is exactly
+what the first deployment of this fix did.
+
 Destroying an unread page is not on the ladder. A `WRITTEN` page in hand is
 genuinely ambiguous, because `Paper.GET` fiddles an incoming letter to `WRITTEN`
 as you pick it up, so "written must mean my own draft" would erase real mail.

--- a/habibots/bots/oracle.js
+++ b/habibots/bots/oracle.js
@@ -207,6 +207,15 @@ async function freeTheHands(hands) {
   }
   stuckRef = null
   stuckStrikes = 0
+  // Our own PUT is announced with send_neighbor_msg, which EXCLUDES the actor —
+  // the same blindness that stops us seeing our own GET. So elko has moved the
+  // page into a pocket while our world model still shows it in HANDS, and
+  // without a refresh the next check finds the "same" blocked hands and sets it
+  // aside again, forever, never reaching the mail. Re-entering the region
+  // rebuilds contents from elko's own makes; it is the same nudge used below to
+  // make check_mail run.
+  await OracleBot.gotoContext(Argv.context)
+  await new Promise((r) => setTimeout(r, MAIL_SETTLE_MS))
   if (stowed.stowed && stowed.ref && !stowedReported.has(stowed.ref)) {
     stowedReported.add(stowed.ref)
     await noteStowed(stowed).catch((err) =>

--- a/habibots/lib/mail.js
+++ b/habibots/lib/mail.js
@@ -325,6 +325,14 @@ async function clearHands(bot) {
 //
 // Preferred over destroying an unreadable page (which risks erasing a player's
 // letter) and over leaving it in hands (which silently disables the whole bot).
+//
+// CALLER CONTRACT: the world model will still show the item in HANDS afterwards.
+// generic_PUT announces the move with send_neighbor_msg, which excludes the
+// actor — the same blindness that stops a bot seeing its own GET — so elko and
+// the model disagree until the region is re-entered. A caller that loops on
+// "are my hands clear?" must refresh, or it will set the same page aside on
+// every pass and never get any further. Seen in production the first time this
+// ran.
 async function stowHeldItem(bot) {
   const inv = awareness.getInventory(bot)
   const held = inv.find((it) => it.slot === awareness.HANDS_SLOT)


### PR DESCRIPTION
Follow-up to #676, which is live and half-working.

## What the deploy showed

```
00:15:26  set aside Paper i-2069…-1984… in pocket slot 0 to free the hands
00:15:26  reported a set-aside Paper to Discord
00:15:31  hands blocked: holding a page that cannot be read (attempt 1/3)
00:19:26  set aside Paper i-2069…-1984… in pocket slot 0 to free the hands
00:23:26  set aside Paper i-2069…-1984… in pocket slot 0 to free the hands
```

The escape hatch fired on schedule (3 checks, ~6 minutes) and mongo confirms the page moved to `y=0`. Then it set the *same* page aside every four minutes and never reached the mail check — `checkForMail` returns as soon as the hands look blocked, so the queue was never even peeked.

## Why

`generic_PUT` announces the move with `send_neighbor_msg`, which **excludes the actor** — the same blindness that stops a bot seeing its own `GET`, already documented for `Paper.GET` in `mail.js`. So elko had the page in a pocket while our world model still showed it in HANDS. `empty_handed(avatar)` was true server-side and the bot refused to believe it.

## Fix

Re-enter the region after a successful stow. That rebuilds contents from elko's own makes — the same nudge already used to make `check_mail` run — so the next pass sees genuinely empty hands and goes on to collect mail.

Recorded as a caller contract on `stowHeldItem`: anything that loops on "are my hands clear?" after a `PUT` has this bug.

`npm test` — 56 pass. Bots-image only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FW2qxCACtN5zc39NWVCKYc